### PR TITLE
Adding GH actions ansible-lint

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,73 @@
+name: Ansible Lint  # feel free to pick your own name
+
+on: [push, pull_request]
+
+jobs:
+  yaml_lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: yaml-lint
+      uses: ibiqlik/action-yamllint@master
+      with:
+        # File(s) or Directory, separate by space if multiple files or folder are specified
+        file_or_dir: roles/*
+        # Path to custom configuration
+        # config_file: # optional
+        # Custom configuration (as YAML source)
+        # config_data: # optional
+        # Format for parsing output [parsable,standard,colored,auto]
+        # format: # optional, default is colored
+        # Return non-zero exit code on warnings as well as errors
+        # strict: # optional, default is false
+
+  ansible_lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    # Important: This sets up your GITHUB_WORKSPACE environment variable
+    - uses: actions/checkout@v2
+
+    - name: Lint Ansible Playbook
+      # replace "master" with any valid ref
+      uses: ansible/ansible-lint-action@master
+      with:
+        # [required]
+        # Paths to ansible files (i.e., playbooks, tasks, handlers etc..)
+        # or valid Ansible directories according to the Ansible role
+        # directory structure.
+        # If you want to lint multiple ansible files, use the following syntax
+        # targets: |
+        #   playbook_1.yml
+        #   playbook_2.yml
+        targets: "roles/*"
+        # [optional]
+        # Arguments to override a package and its version to be set explicitly.
+        # Must follow the example syntax.
+        override-deps: |
+          ansible==2.9
+          ansible-lint==4.2.0
+        # [optional]
+        # Arguments to be passed to the ansible-lint
+
+        # Options:
+        #   -q                    quieter, although not silent output
+        #   -p                    parseable output in the format of pep8
+        #   --parseable-severity  parseable output including severity of rule
+        #   -r RULESDIR           specify one or more rules directories using one or
+        #                         more -r arguments. Any -r flags override the default
+        #                         rules in ansiblelint/rules, unless -R is also used.
+        #   -R                    Use default rules in ansiblelint/rules in addition to
+        #                         any extra
+        #                         rules directories specified with -r. There is no need
+        #                         to specify this if no -r flags are used
+        #   -t TAGS               only check rules whose id/tags match these values
+        #   -x SKIP_LIST          only check rules whose id/tags do not match these
+        #                         values
+        #   --nocolor             disable colored output
+        #   --exclude=EXCLUDE_PATHS
+        #                         path to directories or files to skip. This option is
+        #                         repeatable.
+        #   -c C                  Specify configuration file to use. Defaults to ".ansible-lint"
+        args: ""

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,7 @@
+extends: default
+
+rules:
+  # 80 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 80
+    level: warning

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ansible_tower_genie_collections
-
+![Ansible Lint](https://github.com/redhat-cop/automate_tower_genie_collections/workflows/Ansible%20Lint/badge.svg)
 
 # Foo Collection
 <!-- Add CI and code coverage badges here. Samples included below. -->


### PR DESCRIPTION
## Enable GH Actions

- Yaml-Lint
- Ansible-Lint

### Notes:
- Currently You can see the Actions are failing, that is because our Repo is non-compliant and we can address that in a following PR.
- These are basic checks, we can extend these if needed.

Ref: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions