### PR TITLE
Fix typo, sensative -> sensitive

### DIFF
--- a/roles/credential_input_sources/README.md
+++ b/roles/credential_input_sources/README.md
@@ -21,12 +21,12 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other.
 If Both variables are not set, secure logging defaults to false.
-The role defaults to False as normally the add credential input source task does not include sensative information.
+The role defaults to False as normally the add credential input source task does not include sensitive information.
 tower_configuration_credential_input_sources_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of tower configuration roles with a single variable, or for the user to selectively use it.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_credential_input_sources_secure_logging`|`False`|no|Whether or not to include the sensative credential_input_source role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_credential_input_sources_secure_logging`|`False`|no|Whether or not to include the sensitive credential_input_source role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/credential_types/README.md
+++ b/roles/credential_types/README.md
@@ -24,12 +24,12 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 ### Secure Logging Variables
 The following Variables compliment each other. 
 If Both variables are not set, secure logging defaults to false.  
-The role defaults to False as normally the add credential type task does not include sensative information.  
+The role defaults to False as normally the add credential type task does not include sensitive information.  
 tower_configuration_credential_types_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.  
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_credential_types_secure_logging`|`False`|no|Whether or not to include the sensative Credential Type role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_credential_types_secure_logging`|`False`|no|Whether or not to include the sensitive Credential Type role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/credentials/README.md
+++ b/roles/credentials/README.md
@@ -24,12 +24,12 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 ### Secure Logging Variables
 The following Variables compliment each other. 
 If Both variables are not set, secure logging defaults to false.  
-The role defaults to False as normally the add credentials task does not include sensative information.  
+The role defaults to False as normally the add credentials task does not include sensitive information.  
 tower_configuration_credentials_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.  
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_credentials_secure_logging`|`False`|no|Whether or not to include the sensative Credential role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_credentials_secure_logging`|`False`|no|Whether or not to include the sensitive Credential role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/groups/README.md
+++ b/roles/groups/README.md
@@ -24,12 +24,12 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 ### Secure Logging Variables
 The following Variables compliment each other. 
 If Both variables are not set, secure logging defaults to false.  
-The role defaults to False as normally the add groups task does not include sensative information.  
+The role defaults to False as normally the add groups task does not include sensitive information.  
 tower_configuration_groups_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.  
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_groups_secure_logging`|`False`|no|Whether or not to include the sensative Group role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_groups_secure_logging`|`False`|no|Whether or not to include the sensitive Group role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/hosts/README.md
+++ b/roles/hosts/README.md
@@ -21,7 +21,7 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other.
 If Both variables are not set, secure logging defaults to false.
-The role defaults to False as normally the add host task does not include sensative information.
+The role defaults to False as normally the add host task does not include sensitive information.
 `tower_configuration_host_secure_logging` defaults to the value of `tower_configuration_secure_logging` if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.
 
 |Variable Name|Default Value|Required|Description|

--- a/roles/inventories/README.md
+++ b/roles/inventories/README.md
@@ -20,12 +20,12 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other.
 If Both variables are not set, secure logging defaults to false.
-The role defaults to False as normally the add inventories task does not include sensative information.
+The role defaults to False as normally the add inventories task does not include sensitive information.
 tower_configuration_inventories_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_inventories_secure_logging`|`False`|no|Whether or not to include the sensative Inventory role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_inventories_secure_logging`|`False`|no|Whether or not to include the sensitive Inventory role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/inventory_sources/README.md
+++ b/roles/inventory_sources/README.md
@@ -20,12 +20,12 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other. 
 If Both variables are not set, secure logging defaults to false.  
-The role defaults to False as normally the add inventory_source task does not include sensative information.  
+The role defaults to False as normally the add inventory_source task does not include sensitive information.  
 tower_configuration_inventory_sources_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.  
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_inventory_sources_secure_logging`|`False`|no|Whether or not to include the sensative Inventory Sources role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_inventory_sources_secure_logging`|`False`|no|Whether or not to include the sensitive Inventory Sources role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/job_templates/README.md
+++ b/roles/job_templates/README.md
@@ -21,12 +21,12 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other. 
 If Both variables are not set, secure logging defaults to false.  
-The role defaults to False as normally the add job_template task does not include sensative information.  
+The role defaults to False as normally the add job_template task does not include sensitive information.  
 tower_configuration_job_templates_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.  
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_job_templates_secure_logging`|`False`|no|Whether or not to include the sensative Job Template role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_job_templates_secure_logging`|`False`|no|Whether or not to include the sensitive Job Template role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/labels/README.md
+++ b/roles/labels/README.md
@@ -20,12 +20,12 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other. 
 If Both variables are not set, secure logging defaults to false.  
-The role defaults to False as normally the add labels task does not include sensative information.  
+The role defaults to False as normally the add labels task does not include sensitive information.  
 tower_configuration_labels_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.  
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_labels_secure_logging`|`False`|no|Whether or not to include the sensative Label role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_labels_secure_logging`|`False`|no|Whether or not to include the sensitive Label role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/license/README.md
+++ b/roles/license/README.md
@@ -20,12 +20,12 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other.
 If Both variables are not set, secure logging defaults to false.
-The role defaults to False as normally the add license task does not include sensative information.
+The role defaults to False as normally the add license task does not include sensitive information.
 tower_configuration_license_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of tower configuration roles with a single variable, or for the user to selectively use it.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_license_secure_logging`|`False`|no|Whether or not to include the sensative license role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_license_secure_logging`|`False`|no|Whether or not to include the sensitive license role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/master_role_example/README.md
+++ b/roles/master_role_example/README.md
@@ -21,12 +21,12 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other. 
 If Both variables are not set, secure logging defaults to false.  
-The role defaults to False as normally the add ******* task does not include sensative information.  
+The role defaults to False as normally the add ******* task does not include sensitive information.  
 tower_configuration_*******_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of tower configuration roles with a single variable, or for the user to selectively use it.  
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_*******_secure_logging`|`False`|no|Whether or not to include the sensative ******* role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_*******_secure_logging`|`False`|no|Whether or not to include the sensitive ******* role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/notifications/README.md
+++ b/roles/notifications/README.md
@@ -21,7 +21,7 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other.
 If Both variables are not set, secure logging defaults to false.
-The role defaults to False as normally the add notification task does not include sensative information.
+The role defaults to False as normally the add notification task does not include sensitive information.
 `tower_configuration_notification_secure_logging` defaults to the value of `tower_configuration_secure_logging` if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.
 
 |Variable Name|Default Value|Required|Description|

--- a/roles/organizations/README.md
+++ b/roles/organizations/README.md
@@ -10,27 +10,27 @@ Currently:
 ## Variables
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
-|`tower_state`|"present"|no|The state all objects will take unless overriden by object default|'absent'|
+|`tower_state`|"present"|no|The state all objects will take unless overridden by object default|'absent'|
 |`tower_hostname`|""|yes|URL to the Ansible Tower Server.|127.0.0.1|
 |`validate_certs`|`False`|no|Whether or not to validate the Ansible Tower Server's SSL certificate.||
 |`tower_username`|""|yes|Admin User on the Ansible Tower Server.||
 |`tower_password`|""|yes|Tower Admin User's password on the Ansible Tower Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
 |`tower_oauthtoken`|""|yes|Tower Admin User's token on the Ansible Tower Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||
-|`tower_organizations`|`see below`|yes|Data structure describing your orgainzation or orgainzations Described below.||
+|`tower_organizations`|`see below`|yes|Data structure describing your organzation or organizations Described below.||
 
 ### Secure Logging Variables
 The following Variables compliment each other. 
 If Both variables are not set, secure logging defaults to false.  
-The role defaults to False as normally the add organization task does not include sensative information.  
+The role defaults to False as normally the add organization task does not include sensitive information.  
 tower_configuration_organizations_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.  
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_organizations_secure_logging`|`False`|no|Whether or not to include the sensative Organization role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
-|`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
+|`tower_configuration_organizations_secure_logging`|`False`|no|Whether or not to include the sensitive Organization role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared across multiple roles, see above.|
 
 ## Organization Data Structure
-This role accepts two data models. A simple starightforward easy to maintain model, and another based on the tower api. The 2nd one is more complicated and includes more detail, and is compatiable with tower import/export.
+This role accepts two data models. A simple straightforward easy to maintain model, and another based on the tower api. The 2nd one is more complicated and includes more detail, and is compatiable with tower import/export.
 
 ### Variables
 |Variable Name|Default Value|Required|Description|

--- a/roles/projects/README.md
+++ b/roles/projects/README.md
@@ -20,12 +20,12 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other. 
 If Both variables are not set, secure logging defaults to false.  
-The role defaults to False as normally the add projects task does not include sensative information.  
+The role defaults to False as normally the add projects task does not include sensitive information.  
 tower_configuration_projects_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.  
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_projects_secure_logging`|`False`|no|Whether or not to include the sensative Project role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_projects_secure_logging`|`False`|no|Whether or not to include the sensitive Project role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/schedules/README.md
+++ b/roles/schedules/README.md
@@ -21,12 +21,12 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other.
 If Both variables are not set, secure logging defaults to false.
-The role defaults to False as normally the add schedules task does not include sensative information.
+The role defaults to False as normally the add schedules task does not include sensitive information.
 tower_configuration_schedules_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of tower configuration roles with a single variable, or for the user to selectively use it.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_schedules_secure_logging`|`False`|no|Whether or not to include the sensative Schedules role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_schedules_secure_logging`|`False`|no|Whether or not to include the sensitive Schedules role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/teams/README.md
+++ b/roles/teams/README.md
@@ -17,7 +17,7 @@ An Ansible Role to create Teams in Ansible Tower.
 ### Secure Logging Variables
 The following Variables compliment each other.
 If Both variables are not set, secure logging defaults to false.
-The role defaults to False as normally the add teams task does not include sensative information.
+The role defaults to False as normally the add teams task does not include sensitive information.
 `tower_configuration_teams_secure_logging` defaults to the value of `tower_configuration_secure_logging` if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.
 
 |Variable Name|Default Value|Required|Description|

--- a/roles/tower_role/README.md
+++ b/roles/tower_role/README.md
@@ -21,7 +21,7 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other.
 If Both variables are not set, secure logging defaults to false.
-The role defaults to False as normally the add rbac task does not include sensative information.
+The role defaults to False as normally the add rbac task does not include sensitive information.
 `tower_configuration_rbac_secure_logging` defaults to the value of `tower_configuration_secure_logging` if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.
 
 |Variable Name|Default Value|Required|Description|

--- a/roles/tower_settings/README.md
+++ b/roles/tower_settings/README.md
@@ -20,12 +20,12 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other.
 If Both variables are not set, secure logging defaults to false.
-The role defaults to False as normally the add settings task does not include sensative information.
+The role defaults to False as normally the add settings task does not include sensitive information.
 tower_configuration_settings_secure_logging defaults to the value of tower_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`tower_configuration_settings_secure_logging`|`False`|no|Whether or not to include the sensative Settings role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`tower_configuration_settings_secure_logging`|`False`|no|Whether or not to include the sensitive Settings role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure

--- a/roles/users/README.md
+++ b/roles/users/README.md
@@ -21,7 +21,7 @@ Currently:
 ### Secure Logging Variables
 The following Variables compliment each other.
 If Both variables are not set, secure logging defaults to false.
-The role defaults to False as normally the add user task does not include sensative information.
+The role defaults to False as normally the add user task does not include sensitive information.
 `tower_configuration_user_secure_logging` defaults to the value of `tower_configuration_secure_logging` if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.
 
 |Variable Name|Default Value|Required|Description|

--- a/roles/workflow_job_templates/README.md
+++ b/roles/workflow_job_templates/README.md
@@ -21,12 +21,12 @@ Required Collections:
 ### Secure Logging Variables
 The following Variables compliment each other. 
 If Both variables are not set, secure logging defaults to false.  
-The role defaults to False as normally the add Workflow Job Templates task does not include sensative information.  
+The role defaults to False as normally the add Workflow Job Templates task does not include sensitive information.  
 workflow_job_templates_secure_logging defaults to the value of tower_genie_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of genie roles with a single variable, or for the user to selectively use it.  
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`workflow_job_templates_secure_logging`|`False`|no|Whether or not to include the sensative Workflow Job Templates role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`workflow_job_templates_secure_logging`|`False`|no|Whether or not to include the sensitive Workflow Job Templates role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`tower_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
 
 ## Data Structure


### PR DESCRIPTION
Noticed this repeated typo throughout the README files for the roles.  It doesn't appear to be a location based spelling, like `color` vs `colour`, and if that is the case here I'm not concerned with changing it and this PR can be closed.