### PR TITLE
Add Changelogs and release cycle for changelog

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,10 +29,11 @@ If you feel like getting your hands dirty, feel free to make the change yourself
 2. Create a branch named appropriately for the change you are going to make.
 3. Make your code change.
 4. If you are creating a new role, please add a test for it in our [testing playbook.](https://github.com/redhat-cop/tower_configuration/blob/devel/playbooks/example_with_yaml/configure_tower.yml) by adding a new role entry and adding the appropriate yaml file with test data in the tower_configs directory.
-5. Push your code change up to your forked repo.
-6. Open a Pull Request to merge your changes to this repo. The comment box will be filled in automatically via a template.
-7. All Pull Requests will be subject to Ansible and Yaml Linting checks. Please make sure that your code complies and fix any warnings that arise. These are Checks that apear at the bottom of your Pull Request.
-8. All Pull requests are subject to Testing against being used in tower. As above there is a check at the bottom of your pull request for this named integration.
+5. Add a changelog fragment in `changelogs/fragments` as per https://docs.ansible.com/ansible/latest/community/development_process.html#changelogs
+6. Push your code change up to your forked repo.
+7. Open a Pull Request to merge your changes to this repo. The comment box will be filled in automatically via a template.
+8. All Pull Requests will be subject to Ansible and Yaml Linting checks. Please make sure that your code complies and fix any warnings that arise. These are Checks that apear at the bottom of your Pull Request.
+9. All Pull requests are subject to Testing against being used in tower. As above there is a check at the bottom of your pull request for this named integration.
 
 See [Using Pull Requests](https://help.github.com/articles/using-pull-requests/) got more information on how to use GitHub PRs.
 

--- a/.github/workflow-config/release.yml
+++ b/.github/workflow-config/release.yml
@@ -17,6 +17,11 @@
         src: "{{ repo_base_dir }}/galaxy.yml.j2"
         dest: "{{ repo_base_dir }}/galaxy.yml"
 
+    - name: Update changelog
+      command:
+        cmd: antsibull-changelog release --version {{ collection_version }}
+        chdir: "{{ repo_base_dir }}"
+
     - name: build collection
       command:
         cmd: ansible-galaxy collection build
@@ -35,6 +40,16 @@
         cmd: "ansible-galaxy collection publish --api-key={{ api_key }} {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
         chdir: "{{ repo_base_dir }}"
       tags: publish
+
+    - name: Set git config
+      shell:
+        cmd: "git config user.name 'redhat-cop-ci-bot' && git config user.email 'action@github.com'"
+        chdir: "{{ repo_base_dir }}"
+
+    - name: push changelogs to devel
+      shell:
+        cmd: "git add changelogs CHANGELOG.rst && git commit -m 'add changelog {{ collection_version }}'"
+        chdir: "{{ repo_base_dir }}"
 
     - name: git cleanup
       command:

--- a/.github/workflows/galaxy-release.yml
+++ b/.github/workflows/galaxy-release.yml
@@ -13,14 +13,17 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
 
-      - name: Install ansible-base
-        run: pip install ansible
+      - name: Install ansible-base and changelog
+        run: pip install ansible antsibull-changelog
 
       - name: Publish to galaxy
         run: ansible-playbook .github/workflow-config/release.yml
@@ -29,3 +32,9 @@ jobs:
           -e api_key=${{ secrets.ANSIBLE_GALAXY_APIKEY }}
           -e collection_repo=https://github.com/${{ github.repository }}
           --skip-tags=install,cleanup
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: devel
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,32 @@
+=============================================================
+redhat_cop.tower_configuration Release Notes
+=============================================================
+
+.. contents:: Topics
+
+
+v0.1.0
+======
+
+Major Changes
+-------------
+
+- Groups role - Added groups role to the collection
+- Labels role - Added labels role to the collection
+- Notifications role - Added many options to notifications role
+- Workflow Job Templates role - Added many options to WJT role
+
+Minor Changes
+-------------
+
+- GitHub Workflows - Added workflows to run automated linting and integration tests against the codebase
+- Hosts role - Added new_name and enabled options to hosts role
+- Housekeeping - Added CONTRIBUTING guide and pull request template
+- Inventory Sources role - Added notification_templates_started, success, and error options. Also added verbosity and source_regions options.
+- Teams role - Added new_name option to teams role
+- Test Configs - Added full range of test objects for integration testing
+
+Bugfixes
+--------
+
+- Fixed an issue where tower_validate_certs and validate_certs were both used as vars. Now changed to tower_validate_certs

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -1,0 +1,15 @@
+plugins:
+  become: {}
+  cache: {}
+  callback: {}
+  cliconf: {}
+  connection: {}
+  httpapi: {}
+  inventory: {}
+  lookup: {}
+  module: {}
+  netconf: {}
+  shell: {}
+  strategy: {}
+  vars: {}
+version: 0.1.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,0 +1,26 @@
+ancestor: null
+releases:
+  0.1.0:
+    changes:
+      bugfixes:
+      - Fixed an issue where tower_validate_certs and validate_certs were both used
+        as vars. Now changed to tower_validate_certs
+      major_changes:
+      - Groups role - Added groups role to the collection
+      - Labels role - Added labels role to the collection
+      - Notifications role - Added many options to notifications role
+      - Workflow Job Templates role - Added many options to WJT role
+      minor_changes:
+      - GitHub Workflows - Added workflows to run automated linting and integration
+        tests against the codebase
+      - Hosts role - Added new_name and enabled options to hosts role
+      - Housekeeping - Added CONTRIBUTING guide and pull request template
+      - Inventory Sources role - Added notification_templates_started, success, and
+        error options. Also added verbosity and source_regions options.
+      - Teams role - Added new_name option to teams role
+      - Test Configs - Added full range of test objects for integration testing
+    fragments:
+    - housekeeping.yaml
+    - new_roles.yaml
+    - workflows.yaml
+    release_date: '2020-08-04'

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,0 +1,32 @@
+changelog_filename_template: ../CHANGELOG.rst
+changelog_filename_version_depth: 0
+changes_file: changelog.yaml
+changes_format: combined
+ignore_other_fragment_extensions: true
+keep_fragments: false
+mention_ancestor: true
+new_plugins_after_name: removed_features
+notesdir: fragments
+prelude_section_name: release_summary
+prelude_section_title: Release Summary
+sanitize_changelog: true
+sections:
+- - major_changes
+  - Major Changes
+- - minor_changes
+  - Minor Changes
+- - breaking_changes
+  - Breaking Changes / Porting Guide
+- - deprecated_features
+  - Deprecated Features
+- - removed_features
+  - Removed Features (previously deprecated)
+- - security_fixes
+  - Security Fixes
+- - bugfixes
+  - Bugfixes
+- - known_issues
+  - Known Issues
+title: redhat_cop.tower_configuration
+trivial_section_name: trivial
+use_fqcn: true

--- a/changelogs/fragments/72-defaults.yaml
+++ b/changelogs/fragments/72-defaults.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Removed defaulted objects for all roles so that they were not always run if using a conditional against the variable. (see https://github.com/redhat-cop/tower_configuration/issues/68)

--- a/changelogs/fragments/73-readmes.yaml
+++ b/changelogs/fragments/73-readmes.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Standardised and corrected all READMEs

--- a/changelogs/fragments/77-pre-commit.yaml
+++ b/changelogs/fragments/77-pre-commit.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added pre-commit hook for local development and automated testing purposes


### PR DESCRIPTION
### What does this PR do?
- Adds changelog for version v0.1.0
- Adds changelog fragments for intermin between v0.1.0 and present
- Edit the release workflow to update the changelog before it is packaged and sent to galaxy, then pushes the changelog to devel

### How should this be tested?
See the result of releasing on this branch https://github.com/Tompage1994/tower_configuration/tree/add-changelogs
See the diff of the commit the action pushes back here https://github.com/Tompage1994/tower_configuration/commit/af239570a546e4a76b66e7f54ec8b311ec1ef0f8

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #79 

### Other Relevant info, PRs, etc.
None
