### PR TITLE
fix notification task name

### DIFF
--- a/roles/notifications/tasks/main.yml
+++ b/roles/notifications/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Add ansible tower notifications
-  awx.awx.tower_notification:
+  awx.awx.tower_notification_template:
     name:                           "{{ tower_notifications_item.name }}"
     new_name:                       "{{ tower_notifications_item.new_name | default(omit) }}"
     description:                    "{{ tower_notifications_item.description | default(omit) }}"


### PR DESCRIPTION
### What does this PR do?
I have changed the name of the notifications task so that it refers to the proper name. Without this change a fresh install of tower_configuration will fail to run because awx.awx.tower_notification does not exist but awx.awx.tower_notification_template does.

### How should this be tested?
Not completely sure if the automated tests will get this as I do not know what the automated tests do for this project.

This is the command I was using when I ran into this issue.
```
ansible-playbook configure_tower.yml --tags hosts
```

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)
