### PR TITLE
Make sure all role variables are defined in defaults/main.yml

### DIFF
--- a/roles/license/defaults/main.yml
+++ b/roles/license/defaults/main.yml
@@ -1,10 +1,19 @@
 ---
-tower_hostname: ""
-tower_oauthtoken: ""
-tower_validate_certs: false
+
+# These are the default variables common to most tower_configuration and _utilities roles
+# You shouldn't need to define them again and again but they should be defined
+#tower_hostname: "{{ inventory_hostname }}"
+#tower_username: "admin"
+#tower_password: ""
+#tower_oauthtoken: ""
+#tower_config_file: ""
+#tower_validate_certs: false
+
+# These are the default variables specific to the license role
+
 tower_configuration_license_secure_logging: "{{tower_configuration_secure_logging | default(false)}}"
 
 # Example license datastructure but no sensible default.
-# tower_license:
-#   data: "{{ lookup('file', '/tmp/my_tower.license') }}"
-#   eula_accepted: true
+#tower_license:
+#  data: "{{ lookup('file', '/tmp/my_tower.license') }}"
+#  eula_accepted: true  # must be true or role will fail


### PR DESCRIPTION
### What does this PR do?

The idea (and IMHO recommended practice) is to have a `defaults/main.yml` file which you can drop into an inventory, edit following the comments and examples present in the file, and you have a configured role in your inventory.
At the extreme, something like the following should more or less work, giving you a valid Tower inventory, which you only need to adapt to your exact needs:

```
for role in ansible_collections/redhat_cop/tower_configuration/roles/*
do
    cp ${role}/defaults/main.yml ${MY_INVENTORY}/host_vars/tower.example.com/${role}.yml
done
```

This makes the usage of roles so much easier, as you don't need to check against the documentation, you just go through the file and follow the comments.

### How should this be tested?

It wouldn't change anything to the functionality, it's just an improvement of "ease-of-use", so any test already existing will continue to work.

### Is there a relevant Issue open for this?

n/a (GChat discussion last week)

### Other Relevant info, PRs, etc.

I started with the license role because it's a simple one. Once we're in agreement that this is the right approach, should I create one PR per role, or just extending the current PR for all defaults would be fine?
