### PR TITLE
Use credential name when importing a project.

### DIFF
--- a/playbooks/tower_configs_export_model/projects_export.yml
+++ b/playbooks/tower_configs_export_model/projects_export.yml
@@ -13,6 +13,16 @@ tower_projects:
   scm_update_on_launch: false
   scm_update_cache_timeout: 0
   allow_override: false
+  credential:
+    credential_type:
+      kind: scm
+      name: Source Control
+      type: credential_type
+    name: Example SCM credential
+    organization:
+      name: Default
+      type: organization
+    type: credential
   custom_virtualenv:
   organization:
     name: Satellite

--- a/playbooks/tower_configs_export_model/projects_export.yml
+++ b/playbooks/tower_configs_export_model/projects_export.yml
@@ -18,7 +18,7 @@ tower_projects:
       kind: scm
       name: Source Control
       type: credential_type
-    name: Example SCM credential
+    name: AWX-Collection-tests-tower_workflow_job_template-scm-cred
     organization:
       name: Default
       type: organization

--- a/roles/projects/tasks/main.yml
+++ b/roles/projects/tasks/main.yml
@@ -8,7 +8,7 @@
     local_path:                     "{{ tower_projects_item.local_path | default(omit) }}"
     scm_branch:                     "{{ tower_projects_item.scm_branch | default(omit)  }}"
     scm_refspec:                    "{{ tower_projects_item.scm_refspec | default(omit) }}"
-    scm_credential:                 "{{ tower_projects_item.scm_credential | default(tower_projects_item.credential | default(omit)) }}"
+    scm_credential:                 "{{ tower_projects_item.scm_credential | default(tower_projects_item.credential.name | default(omit)) }}"
     scm_clean:                      "{{ tower_projects_item.scm_clean | default(omit) }}"
     scm_delete_on_update:           "{{ tower_projects_item.scm_delete_on_update | default(omit) }}"
     scm_update_on_launch:           "{{ tower_projects_item.scm_update_on_launch | default(omit) }}"


### PR DESCRIPTION
### What does this PR do?
Allows to directly use exported project YAML for import.

### How should this be tested?
Export an existing project from an existing Tower using `awx export --projects <PROJECT NAME>`.
Import the resulting YAML using the role projects from this collection.

### Is there a relevant Issue open for this?
resolves #144
