### PR TITLE
Use organization.name when updating a project.

### DIFF
--- a/playbooks/configure_tower_export_model.yml
+++ b/playbooks/configure_tower_export_model.yml
@@ -26,6 +26,7 @@
     - {role: inventories, when: tower_inventories is defined, tags: inventories}
     - {role: inventory_sources, when: tower_inventory_sources is defined, tags: inventory_sources}
     - {role: projects, when: tower_projects is defined, tags: projects}
+    - {role: project_update, when: tower_projects is defined, tags: projects}
     - {role: job_templates, when: tower_templates is defined, tags: job_templates}
     - {role: workflow_job_templates, when: tower_workflows is defined}
     - {role: notification_templates, when: tower_notifications is defined, tags: notification_templates}

--- a/roles/project_update/tasks/main.yml
+++ b/roles/project_update/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Run Tower project update
   tower_project_update:
     name:               "{{ __project_update_update_item.name }}"
-    organization:       "{{ __project_update_update_item.organization | default(omit, true) }}"
+    organization:       "{{ __project_update_update_item.organization.name | default(__project_update_update_item.organization | default(omit, true)) }}"
     wait:               "{{ __project_update_update_item.wait | default('true') }}"
     interval:           "{{ __project_update_update_item.interval | default(1) }}"
     timeout:            "{{ __project_update_update_item.timeout | default(omit, true) }}"


### PR DESCRIPTION
### What does this PR do?
Allows to directly use exported project YAML for project update.

### How should this be tested?
Export an existing project from an existing Tower using awx export --projects <PROJECT NAME>.
Import the resulting YAML using the role projects from this collection and try to update it using the role project_updates.

### Is there a relevant Issue open for this?
resolves #148 

### Other Relevant info, PRs, etc.
Unlike for the [PR 145](https://github.com/redhat-cop/tower_configuration/pull/145) I did not have to change the file playbooks/tower_configs_export_model/projects_export.yml since `organization` is already a dict. 
