### PR TITLE
Do not use 'kind' when importing credential.

### DIFF
--- a/changelogs/fragments/credential_kind_deprecated.yml
+++ b/changelogs/fragments/credential_kind_deprecated.yml
@@ -1,2 +1,4 @@
+---
 breaking_changes:
-  - Removed kind from to credentials role. This will be depreciated in a few months. Kind arguments are replaced by the credential_type and inputs fields. 
+  - Removed kind from to credentials role. This will be depreciated in a few months. Kind arguments are replaced by the credential_type and inputs fields.
+...

--- a/changelogs/fragments/credential_kind_deprecated.yml
+++ b/changelogs/fragments/credential_kind_deprecated.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Removed kind from to credentials role. This will be depreciated in a few months. Kind arguments are replaced by the credential_type and inputs fields. 

--- a/playbooks/tower_configs/tower_credentials.yml
+++ b/playbooks/tower_configs/tower_credentials.yml
@@ -1,12 +1,12 @@
 ---
 # Commented out content is serving as example for you to add new content.
 tower_credentials:
-  - kind: ssh
+  - credential_type: Machine
     name: Demo Credential
     inputs:
       username: username
     organization: Default
-  - kind: rhv
+  - credential_type: Red Hat Virtualization
     name: admin@internal-RHVM-01
     description: infra-rhvm-01 creds for inventory sources.
     inputs:
@@ -14,21 +14,21 @@ tower_credentials:
       username: "user"
       password: "password"
     organization: Satellite
-  - kind: ssh
+  - credential_type: Machine
     organization: Satellite
     name: machine-creds-with-jenkins-pvt-key
     description: This credential can be used with any vm that contains jenkins_public key in authorized keys
     inputs:
       username: root
       ssh_key_data: "{{ ssh_private_key }}"
-  - kind: scm
+  - credential_type: Source Control
     name: gitlab-personal-access-token for satqe_auto_droid
     description: General purpose token that can be used by anyone for satlab-admin(or other private) repo clone
     inputs:
       username: gitlab
       password: password
     organization: Satellite
-  - kind: vault
+  - credential_type: Vault
     name: satlab-admin-vault
     inputs:
       vault_password: s3cr3t
@@ -41,7 +41,7 @@ tower_credentials:
       url: "https://cyberark.example.com"
       app_id: "My-App-ID"
     organization: Default
-  - kind: scm
+  - credential_type: Source Control
     name: gitlab
     organization: Default
     inputs:

--- a/playbooks/tower_configs_export_model/credentials_export.yml
+++ b/playbooks/tower_configs_export_model/credentials_export.yml
@@ -40,4 +40,26 @@ tower_credentials:
         kind: ssh
         type: credential_type
       type: credential
+  - name: Demo Custom Credential
+    credential_type:
+      kind: cloud
+      name: 'REST API Credential'
+      type: credential_type
+    description: ''
+    inputs:
+      rest_username: admin
+      rest_password: ''
+    natural_key:
+      credential_type:
+        kind: cloud
+        name: 'REST API Credential'
+        type: credential_type
+      name: 'REST API Credential'
+      organization:
+        name: Default
+        type: organization
+      type: credential
+    organization:
+      name: Default
+      type: organization
 ...

--- a/roles/credentials/tasks/main.yml
+++ b/roles/credentials/tasks/main.yml
@@ -6,7 +6,6 @@
     description:                    "{{ tower_credentials_item.description | default(omit, true) }}"
     organization:                   "{{ tower_credentials_item.organization.name | default( tower_credentials_item.organization | default(omit, true)) }}"
     credential_type:                "{{ tower_credentials_item.credential_type.name | default( tower_credentials_item.credential_type | default(omit, true)) }}"
-    kind:                           "{{ tower_credentials_item.credential_type.kind | default( tower_credentials_item.kind | default(omit, true)) }}"
     inputs:                         "{{ tower_credentials_item.inputs | default(omit, true) }}"
     user:                           "{{ tower_credentials_item.user.username | default( tower_credentials_item.user | default(omit, true)) }}"
     team:                           "{{ tower_credentials_item.team.name | default( tower_credentials_item.team | default(omit, true)) }}"


### PR DESCRIPTION
### What does this PR do?
This PR allows to import credentials of custom credential types, exported with awxkit (17.0.0), having the `kind` field value to `cloud` or `external`.

### How should this be tested?
Create a custom credential type and a credential of that new custom type. Export the credential using awxkit and try to import it using this collection.

### Is there a relevant Issue open for this?
resolves #150 

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)
