### PR TITLE
ignore changelog files

### DIFF
--- a/.github/workflow-config/.yamllint.yml
+++ b/.github/workflow-config/.yamllint.yml
@@ -1,6 +1,9 @@
 ---
 extends: default
 
+ignore: |
+  changelogs
+
 rules:
   # 80 chars should be enough, but don't fail if a line is longer
   line-length: disable


### PR DESCRIPTION
### What does this PR do?
The files in changelog are auto generated and don't contain `---` or `...` at the start and end so will be picked up by yamllint. This adds the changelog dir to be ignored by yamllint

### How should this be tested?
Yamllint will pass the CI tests

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
Discovered on retesting for #154 and found these fails.
