### PR TITLE
Added condition so that add_workflows_schema.yml would not execute wh…

### DIFF
--- a/roles/workflow_job_templates/tasks/main.yml
+++ b/roles/workflow_job_templates/tasks/main.yml
@@ -43,4 +43,5 @@
   loop: "{{ tower_workflows }}"
   loop_control:
     loop_var: workflow_loop_var
+  when: workflow_loop_var.state == "present"
 ...


### PR DESCRIPTION
…en state is absent

### What does this PR do?
Added condition to the workflow_job_templates role so that add_workflows_schema.yml only executed when workflow_loop_var.state was present. 

### How should this be tested?


### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #166

### Other Relevant info, PRs, etc.

