### PR TITLE
Removed update_secrets parameter from users role as it is no longer valid

### DIFF
--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -9,7 +9,7 @@
     first_name:          "{{ tower_user_accounts_item.firstname | default(tower_user_accounts_item.first_name | default(omit, true)) }}"
     last_name:           "{{ tower_user_accounts_item.lastname | default(tower_user_accounts_item.last_name | default(omit, true)) }}"
     is_superuser:        "{{ tower_user_accounts_item.is_superuser | default(tower_user_accounts_item.superuser | default('false')) }}"
-    update_secrets:      "{{ tower_user_accounts_item.update_secrets | default(omit) }}"
+    update_secrets:      "{{ tower_user_accounts_item.update_secrets | default(omit, 'false') }}"
     state:               "{{ tower_user_accounts_item.state | default(tower_state | default(omit, true)) }}"
     tower_host:          "{{ tower_hostname | default(omit, true) }}"
     tower_username:      "{{ tower_username | default(omit, true) }}"

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -9,7 +9,7 @@
     first_name:          "{{ tower_user_accounts_item.firstname | default(tower_user_accounts_item.first_name | default(omit, true)) }}"
     last_name:           "{{ tower_user_accounts_item.lastname | default(tower_user_accounts_item.last_name | default(omit, true)) }}"
     is_superuser:        "{{ tower_user_accounts_item.is_superuser | default(tower_user_accounts_item.superuser | default('false')) }}"
-    update_secrets:      "{{ tower_user_accounts_item.update_secrets | default(omit, 'false') }}"
+    update_secrets:      "{{ tower_user_accounts_item.update_secrets | default(omit) }}"
     state:               "{{ tower_user_accounts_item.state | default(tower_state | default(omit, true)) }}"
     tower_host:          "{{ tower_hostname | default(omit, true) }}"
     tower_username:      "{{ tower_username | default(omit, true) }}"

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -9,6 +9,7 @@
     first_name:          "{{ tower_user_accounts_item.firstname | default(tower_user_accounts_item.first_name | default(omit, true)) }}"
     last_name:           "{{ tower_user_accounts_item.lastname | default(tower_user_accounts_item.last_name | default(omit, true)) }}"
     is_superuser:        "{{ tower_user_accounts_item.is_superuser | default(tower_user_accounts_item.superuser | default('false')) }}"
+    update_secrets:      "{{ tower_user_accounts_item.update_secrets | default(omit) }}"
     state:               "{{ tower_user_accounts_item.state | default(tower_state | default(omit, true)) }}"
     tower_host:          "{{ tower_hostname | default(omit, true) }}"
     tower_username:      "{{ tower_username | default(omit, true) }}"

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -9,7 +9,6 @@
     first_name:          "{{ tower_user_accounts_item.firstname | default(tower_user_accounts_item.first_name | default(omit, true)) }}"
     last_name:           "{{ tower_user_accounts_item.lastname | default(tower_user_accounts_item.last_name | default(omit, true)) }}"
     is_superuser:        "{{ tower_user_accounts_item.is_superuser | default(tower_user_accounts_item.superuser | default('false')) }}"
-    update_secrets:      "{{ tower_user_accounts_item.update_secrets | default('false') }}"
     state:               "{{ tower_user_accounts_item.state | default(tower_state | default(omit, true)) }}"
     tower_host:          "{{ tower_hostname | default(omit, true) }}"
     tower_username:      "{{ tower_username | default(omit, true) }}"


### PR DESCRIPTION
### What does this PR do?
awx.tower_user  no longer contains the update_secrets parameter so the users role fails when run. This pull request removes that parameter from the task in the users role