### PR TITLE
this should be true to prevent passwords leaking

### DIFF
--- a/roles/credentials/defaults/main.yml
+++ b/roles/credentials/defaults/main.yml
@@ -24,5 +24,5 @@ tower_credentials: []
 #  team: "owner_name"  # optional, team owning the credential (str or group dict with name field)
 #  state: present  # optional, choices: present, absent
 
-tower_configuration_credentials_secure_logging: "{{tower_configuration_secure_logging | default('false')}}"
+tower_configuration_credentials_secure_logging: "{{ tower_configuration_secure_logging | default(true) }}"
 ...


### PR DESCRIPTION
### What does this PR do?
changes default from false to true, this will prevent password leaks from happening on accident if the user does not realize they need to set the tower_configuration_credentials_secure_logging to true.

### How should this be tested?
Automated

### Is there a relevant Issue open for this?
no

### Other Relevant info, PRs, etc.
none