### PR TITLE
#182 - Add example machine credential with become_method

### DIFF
--- a/roles/credentials/README.md
+++ b/roles/credentials/README.md
@@ -98,6 +98,13 @@ tower_credentials:
   inputs:
     username: person
     password: password
+- name: localuser
+  description: Machine Credential example with become_method input
+  credential_type: Machine
+  inputs:
+    username: localuser
+    password: password
+    become_method: sudo
 ```
 ## Playbook Examples
 ### Standard Role Usage


### PR DESCRIPTION
### What does this PR do?
Updates readme based on issue #182 where the addition of the `become_*` inputs isn't very intuitive. Adding an example should help.

### How should this be tested?
N/A - readme update

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #182

### Other Relevant info, PRs, etc.
N/A
