### PR TITLE
Adapt Workflows docs to new schema and fix schedules

### DIFF
--- a/roles/schedules/defaults/main.yml
+++ b/roles/schedules/defaults/main.yml
@@ -11,7 +11,7 @@
 # These are the default variables specific to the license role
 
 # list of dict describing Tower schedules:
-controller_schedules:
+controller_schedules: []
 # possible fields:
 # - name: "schedule_name"  # mandatory
 #  new_name: "new_name"  # optional

--- a/roles/workflow_job_templates/README.md
+++ b/roles/workflow_job_templates/README.md
@@ -202,6 +202,9 @@ controller_workflows:
         identifier: node101
         unified_job_template:
           name: RHVM-01
+          type: job_template
+          organization:
+            name: Default
         related:
           success_nodes:
             - workflow_job_template:
@@ -211,6 +214,9 @@ controller_workflows:
         identifier: node201
         unified_job_template:
           name: test-template-1
+          type: job_template
+          organization:
+            name: Default
       notification_templates_started: []
       notification_templates_success: []
       notification_templates_error: []
@@ -251,7 +257,9 @@ controller_workflows:
             "all_parents_must_converge": false,
             "identifier": "node101",
             "unified_job_template": {
-              "name": "RHVM-01"
+              "name": "RHVM-01",
+              "type": "job_template",
+              "organization": { "name": "Default" }
             },
             "related": {
               "credentials": [
@@ -277,7 +285,9 @@ controller_workflows:
             "all_parents_must_converge": false,
             "identifier": "node201",
             "unified_job_template": {
-              "name": "test-template-1"
+              "name": "test-template-1",
+              "type": "job_template",
+              "organization": { "name": "Default" }
             },
             "related": {
               "credentials": [


### PR DESCRIPTION
### What does this PR do?
- adapt workflow_job_templates' readme examples to new schema
- schedules defaults was missing an empty list

### How should this be tested?

Mostly docs...

### Is there a relevant Issue open for this?
n/a

### Other Relevant info, PRs, etc.
n/a
