### PR TITLE
[cherry-pick] Adapt Workflows docs to new schema and fix schedules

### DIFF
--- a/roles/schedules/defaults/main.yml
+++ b/roles/schedules/defaults/main.yml
@@ -11,7 +11,7 @@
 # These are the default variables specific to the license role
 
 # list of dict describing Tower schedules:
-tower_schedules:
+tower_schedules: []
 # possible fields:
 # - name: "schedule_name"  # mandatory
 #  new_name: "new_name"  # optional

--- a/roles/workflow_job_templates/README.md
+++ b/roles/workflow_job_templates/README.md
@@ -194,6 +194,9 @@ tower_workflows:
         identifier: node101
         unified_job_template:
           name: RHVM-01
+          type: job_template
+          organization:
+            name: Default
         related:
           success_nodes:
             - workflow_job_template:
@@ -203,6 +206,9 @@ tower_workflows:
         identifier: node201
         unified_job_template:
           name: test-template-1
+          type: job_template
+          organization:
+            name: Default
       notification_templates_started: []
       notification_templates_success: []
       notification_templates_error: []
@@ -243,7 +249,9 @@ tower_workflows:
             "all_parents_must_converge": false,
             "identifier": "node101",
             "unified_job_template": {
-              "name": "RHVM-01"
+              "name": "RHVM-01",
+              "type": "job_template",
+              "organization": { "name": "Default" }
             },
             "related": {
               "credentials": [
@@ -269,7 +277,9 @@ tower_workflows:
             "all_parents_must_converge": false,
             "identifier": "node201",
             "unified_job_template": {
-              "name": "test-template-1"
+              "name": "test-template-1",
+              "type": "job_template",
+              "organization": { "name": "Default" }
             },
             "related": {
               "credentials": [


### PR DESCRIPTION
### What does this PR do?
- adapt workflow_job_templates' readme examples to new schema
- schedules defaults was missing an empty list
(cherry pick)

### How should this be tested?
n/a

### Is there a relevant Issue open for this?
n/a

### Other Relevant info, PRs, etc.
See PR #197 - note that it's a cherry pick towards the legacy branch (not towards devel)
