### PR TITLE
Parametrize playbook to run with CICD tools directly

### DIFF
--- a/playbooks/configure_controller.yml
+++ b/playbooks/configure_controller.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   vars:
-    controller_validate_certs: "{{ lookup('env', 'CONTROLLER_VERIFY_SSL') | default('true') }}"
+    controller_validate_certs: "{{ lookup('env', 'CONTROLLER_VALIDATE_CERTS') | default('true') }}"
     controller_hostname: "{{ lookup('env', 'CONTROLLER_HOSTNAME') | default(omit) }}"
     controller_username: "{{ lookup('env', 'CONTROLLER_USERNAME') | default(omit) }}"
     controller_password: "{{ lookup('env', 'CONTROLLER_PASSWORD') | default(omit) }}"

--- a/playbooks/configure_controller.yml
+++ b/playbooks/configure_controller.yml
@@ -3,49 +3,44 @@
 #
 # Set the following variables on host_vars/localhost or group_vars/all
 #
-# - awx_validate_certs:
+# - controller_validate_certs:
 #     description: |
 #                  Wether to trust self-signed or invalid certificates
-#                  Falls back to env AWX_VALIDATE_CERTS. If nothing
-#                  provided defaults to true.
+#                  Falls back to env CONTROLLER_VERIFY_SSL and then to awx-cli config.
 #
-# - awx_hostname:
+# - controller_hostname: |
 #     description: |
 #                  Hostname of AWX or Red Hat Ansible Automation Platform Controller.
-#                  Falls back to env AWX_HOSTNAME. Omitted otherwise.
+#                  Falls back to env CONTROLLER_HOST and then to awx-cli config.
 #
-# - awx_username:
+# - controller_username:
 #     description: |
 #                  Username for AWX or Red Hat Ansible Automation Platform Controller.
-#                  Falls back to env AWX_USERNAME. Omitted otherwise.
+#                  Falls back to env CONTROLLER_USERNAME and then to awx-cli config.
 #
-# - awx_password:
+# - controller_password:
 #     description: |
 #                  Password for AWX or Red Hat Ansible Automation Platform Controller.
-#                  Falls back to env AWX_PASSWORD. Omitted otherwise.
+#                  Falls back to env CONTROLLER_PASSWORD and then to awx-cli config.
 #
-# - awx_wait_for_availability:
+# - controller_wait_for_availability:
 #     description: |
 #                  Wether to check & wait for controller availability.
-#                  Falls back to env AWX_WAIT_FOR_AVAILABILITY.
+#                  Falls back to env CONTROLLER_WAIT_FOR_AVAILABILITY.
 #                  Will wait if one of: true (boolean), 'true', 'True', 'yes', 'Yes', '1'
-#                  Otherwise skip availability check.
+#                  Otherwise availability check is skipped.
 #
-# - awx_configs_dir:
+# - controller_configs_dir:
 #     description: |
 #                  Directory with Controller configs.
-#                  Falls back to env AWX_CONFIGS_DIR.
+#                  Falls back to env CONTROLLER_CONFIGS_DIR.
 #                  Defaults to $PWD/configs
 #     
+
 
 - name: Playbook to configure ansible Controller post installation
   hosts: localhost
   connection: local
-  vars:
-    controller_validate_certs: "{{ awx_validate_certs | default(lookup('env', 'AWX_VALIDATE_CERTS')) | default('true') }}"
-    controller_hostname: "{{ awx_hostname | default(lookup('env', 'AWX_HOSTNAME')) | default(omit) }}"
-    controller_username: "{{ awx_username | default(lookup('env', 'AWX_USERNAME')) | default(omit) }}"
-    controller_password: "{{ awx_password | default(lookup('env', 'AWX_PASSWORD')) | default(omit) }}"
   collections:
     - awx.awx
     - redhat_cop.controller_configuration
@@ -68,11 +63,11 @@
           timeout: 60
         delegate_to: localhost
       
-      when: awx_wait_for_availability | default(lookup('env', 'AWX_WAIT_FOR_AVAILABILITY')) in [true, 'true', 'True', 'yes', 'Yes', '1']
+      when: controller_wait_for_availability | default(lookup('env', 'CONTROLLER_WAIT_FOR_AVAILABILITY')) in [true, 'true', 'True', 'yes', 'Yes', '1']
 
     - name: Include vars from configs directory
       include_vars:
-        dir: "{{ awx_configs_dir | default(lookup('env','AWX_CONFIGS_DIR')) | default(lookup('env', 'PWD') + '/configs') }}"
+        dir: "{{ controller_configs_dir | default(lookup('env','CONTROLLER_CONFIGS_DIR')) | default(lookup('env', 'PWD') + '/configs') }}"
         ignore_files: [controller_config.yml.template]
         extensions: ["yml"]
       tags:

--- a/playbooks/configure_controller.yml
+++ b/playbooks/configure_controller.yml
@@ -1,14 +1,53 @@
 ---
+### Variables
+#
+# Set the following variables on host_vars/localhost or group_vars/all
+#
+# - awx_validate_certs:
+#     description: |
+#                  Wether to trust self-signed or invalid certificates
+#                  Falls back to env AWX_VALIDATE_CERTS. If nothing
+#                  provided defaults to true.
+#
+# - awx_hostname:
+#     description: |
+#                  Hostname of AWX or Red Hat Ansible Automation Platform Controller.
+#                  Falls back to env AWX_HOSTNAME. Omitted otherwise.
+#
+# - awx_username:
+#     description: |
+#                  Username for AWX or Red Hat Ansible Automation Platform Controller.
+#                  Falls back to env AWX_USERNAME. Omitted otherwise.
+#
+# - awx_password:
+#     description: |
+#                  Password for AWX or Red Hat Ansible Automation Platform Controller.
+#                  Falls back to env AWX_PASSWORD. Omitted otherwise.
+#
+# - awx_wait_for_availability:
+#     description: |
+#                  Wether to check & wait for controller availability.
+#                  Falls back to env AWX_WAIT_FOR_AVAILABILITY.
+#                  Will wait if one of: true (boolean), 'true', 'True', 'yes', 'Yes', '1'
+#                  Otherwise skip availability check.
+#
+# - awx_configs_dir:
+#     description: |
+#                  Directory with Controller configs.
+#                  Falls back to env AWX_CONFIGS_DIR.
+#                  Defaults to $PWD/configs
+#     
+
 - name: Playbook to configure ansible Controller post installation
   hosts: localhost
   connection: local
   vars:
-    controller_validate_certs: "{{ lookup('env', 'CONTROLLER_VALIDATE_CERTS') | default('true') }}"
-    controller_hostname: "{{ lookup('env', 'CONTROLLER_HOSTNAME') | default(omit) }}"
-    controller_username: "{{ lookup('env', 'CONTROLLER_USERNAME') | default(omit) }}"
-    controller_password: "{{ lookup('env', 'CONTROLLER_PASSWORD') | default(omit) }}"
+    controller_validate_certs: "{{ awx_validate_certs | default(lookup('env', 'AWX_VALIDATE_CERTS')) | default('true') }}"
+    controller_hostname: "{{ awx_hostname | default(lookup('env', 'AWX_HOSTNAME')) | default(omit) }}"
+    controller_username: "{{ awx_username | default(lookup('env', 'AWX_USERNAME')) | default(omit) }}"
+    controller_password: "{{ awx_password | default(lookup('env', 'AWX_PASSWORD')) | default(omit) }}"
   collections:
-    - "{{ lookup('env', 'CONTROLLER_COLLECTION_VARIANT') | default('awx.awx') }}"
+    - awx.awx
     - redhat_cop.controller_configuration
   pre_tasks:
 
@@ -24,16 +63,16 @@
         delay: 30
         ignore_errors: true
 
-      - name: Sleep for 60 seconds and allow awx to come up.
+      - name: Sleep for 60 seconds and allow Controller to come up.
         wait_for:
           timeout: 60
         delegate_to: localhost
       
-      when: lookup('env', 'CONTROLLER_WAIT_FOR_AVAILABILITY') in ['true', 'True', 'yes', 'Yes', '1']
+      when: awx_wait_for_availability | default(lookup('env', 'AWX_WAIT_FOR_AVAILABILITY')) in [true, 'true', 'True', 'yes', 'Yes', '1']
 
     - name: Include vars from configs directory
       include_vars:
-        dir: "{{ lookup('env','PWD') }}/configs"
+        dir: "{{ awx_configs_dir | default(lookup('env','AWX_CONFIGS_DIR')) | default(lookup('env', 'PWD') + '/configs') }}"
         ignore_files: [controller_config.yml.template]
         extensions: ["yml"]
       tags:

--- a/playbooks/configure_controller.yml
+++ b/playbooks/configure_controller.yml
@@ -3,30 +3,33 @@
   hosts: localhost
   connection: local
   vars:
-    controller_validate_certs: false
+    controller_validate_certs: "{{ lookup('env', 'CONTROLLER_VERIFY_SSL') | default('true') }}"
+    controller_hostname: "{{ lookup('env', 'CONTROLLER_HOSTNAME') | default(omit) }}"
+    controller_username: "{{ lookup('env', 'CONTROLLER_USERNAME') | default(omit) }}"
+    controller_password: "{{ lookup('env', 'CONTROLLER_PASSWORD') | default(omit) }}"
   collections:
-    - awx.awx
+    - "{{ lookup('env', 'CONTROLLER_COLLECTION_VARIANT') | default('awx.awx') }}"
     - redhat_cop.controller_configuration
-  # Define following vars here, or in configs/controller_auth.yml
-  # controller_hostname: controller.example.com
-  # controller_username: admin
-  # controller_password: changeme
   pre_tasks:
 
     - name: Wait for Controller to come up
-      uri:
-        url: "{{ controller_hostname }}/api/v2/ping"
-        status_code: 200
-      register: result
-      until: result.status == 200
-      retries: 80
-      delay: 30
-      ignore_errors: true
+      block:
+      - name: Ensure controller is responding
+        uri:
+          url: "{{ controller_hostname }}/api/v2/ping"
+          status_code: 200
+        register: result
+        until: result.status == 200
+        retries: 80
+        delay: 30
+        ignore_errors: true
 
-    - name: Sleep for 60 seconds and allow awx to come up.
-      wait_for:
-        timeout: 60
-      delegate_to: localhost
+      - name: Sleep for 60 seconds and allow awx to come up.
+        wait_for:
+          timeout: 60
+        delegate_to: localhost
+      
+      when: lookup('env', 'CONTROLLER_WAIT_FOR_AVAILABILITY') in ['true', 'True', 'yes', 'Yes', '1']
 
     - name: Include vars from configs directory
       include_vars:
@@ -68,6 +71,7 @@
         name: settings
       vars:
         controller_settings: "{{ controller_settings_individuale }}"
+      when: controller_settings_individuale is defined
 
     - name: Run ad hoc commands
       include_role:

--- a/playbooks/configure_controller.yml
+++ b/playbooks/configure_controller.yml
@@ -33,7 +33,7 @@
 
     - name: Include vars from configs directory
       include_vars:
-        dir: ./configs
+        dir: "{{ lookup('env','PWD') }}/configs"
         ignore_files: [controller_config.yml.template]
         extensions: ["yml"]
       tags:

--- a/playbooks/configure_controller.yml
+++ b/playbooks/configure_controller.yml
@@ -35,7 +35,7 @@
 #                  Directory with Controller configs.
 #                  Falls back to env CONTROLLER_CONFIGS_DIR.
 #                  Defaults to $PWD/configs
-#     
+#
 
 
 - name: Playbook to configure ansible Controller post installation
@@ -48,21 +48,20 @@
 
     - name: Wait for Controller to come up
       block:
-      - name: Ensure controller is responding
-        uri:
-          url: "{{ controller_hostname }}/api/v2/ping"
-          status_code: 200
-        register: result
-        until: result.status == 200
-        retries: 80
-        delay: 30
-        ignore_errors: true
+        - name: Ensure controller is responding
+          uri:
+            url: "{{ controller_hostname }}/api/v2/ping"
+            status_code: 200
+          register: result
+          until: result.status == 200
+          retries: 80
+          delay: 30
+          ignore_errors: true
 
-      - name: Sleep for 60 seconds and allow Controller to come up.
-        wait_for:
-          timeout: 60
-        delegate_to: localhost
-      
+        - name: Sleep for 60 seconds and allow Controller to come up.
+          wait_for:
+            timeout: 60
+          delegate_to: localhost
       when: controller_wait_for_availability | default(lookup('env', 'CONTROLLER_WAIT_FOR_AVAILABILITY')) in [true, 'true', 'True', 'yes', 'Yes', '1']
 
     - name: Include vars from configs directory

--- a/playbooks/configure_controller.yml
+++ b/playbooks/configure_controller.yml
@@ -8,7 +8,7 @@
 #                  Wether to trust self-signed or invalid certificates
 #                  Falls back to env CONTROLLER_VERIFY_SSL and then to awx-cli config.
 #
-# - controller_hostname: |
+# - controller_hostname:
 #     description: |
 #                  Hostname of AWX or Red Hat Ansible Automation Platform Controller.
 #                  Falls back to env CONTROLLER_HOST and then to awx-cli config.
@@ -66,7 +66,7 @@
 
     - name: Include vars from configs directory
       include_vars:
-        dir: "{{ controller_configs_dir | default(lookup('env','CONTROLLER_CONFIGS_DIR')) | default(lookup('env', 'PWD') + '/configs') }}"
+        dir: "{{ controller_configs_dir | default((lookup('env','CONTROLLER_CONFIGS_DIR') == '') | ternary('./configs', lookup('env','CONTROLLER_CONFIGS_DIR'))) }}"
         ignore_files: [controller_config.yml.template]
         extensions: ["yml"]
       tags:


### PR DESCRIPTION
### What does this PR do?
Enriches the supplied playbook with parameters (env lookups) to allow running it more dynamically, e.g. from CI/CD tools

### Is there a relevant Issue open for this?
Fixes #211 

