### PR TITLE
Rename scm_credential to credential

### DIFF
--- a/roles/projects/defaults/main.yml
+++ b/roles/projects/defaults/main.yml
@@ -21,7 +21,7 @@ controller_projects: []
 #  local_path:  # optional, URI
 #  scm_branch:  # optional, str
 #  scm_refspec:  # optional, str
-#  scm_credential: "credential_name"  # optional
+#  credential: "credential_name"  # optional
 #  scm_clean: false  # optional, boolean
 #  scm_delete_on_update: false  # optional, boolean
 #  scm_update_on_launch: false  # optional, boolean

--- a/roles/projects/tasks/main.yml
+++ b/roles/projects/tasks/main.yml
@@ -10,7 +10,7 @@
     local_path:                           "{{ __controller_project_item.local_path | default(omit, true) }}"
     scm_branch:                           "{{ __controller_project_item.scm_branch | default(omit, true)  }}"
     scm_refspec:                          "{{ __controller_project_item.scm_refspec | default(omit, true) }}"
-    credential:                           "{{ __controller_project_item.scm_credential | default(__controller_project_item.credential.name | default(omit, true)) }}"
+    credential:                           "{{ __controller_project_item.credential | default(__controller_project_item.credential.name | default(omit, true)) }}"
     scm_clean:                            "{{ __controller_project_item.scm_clean | default(omit) }}"
     scm_delete_on_update:                 "{{ __controller_project_item.scm_delete_on_update | default(omit) }}"
     scm_track_submodules:                 "{{ __controller_project_item.scm_track_submodules | default(omit) }}"


### PR DESCRIPTION
In the awx.awx collection it's called "credential".
Calling it "scm_credential" here causes confusion and unexpected results
when users rightfully try to use "credential", and it gets silently ignored.