### PR TITLE
Ansiblelint ignore changelogs dir

### DIFF
--- a/.github/workflow-config/.ansiblelint.yml
+++ b/.github/workflow-config/.ansiblelint.yml
@@ -7,6 +7,7 @@
 exclude_paths:
 - '.github/'
 - 'roles/master_role_example/'
+- 'changelogs/'
 parseable: true
 use_default_rules: true
 # https://github.com/ansible/ansible-lint/issues/808

--- a/.github/workflow-config/.pre-commit-config.yml
+++ b/.github/workflow-config/.pre-commit-config.yml
@@ -26,4 +26,5 @@ repos:
           ansible-lint -c .github/workflow-config/.ansiblelint.yml
           --exclude=roles/master_role_example
           --exclude=.github/workflows/
+          --exclude=changelogs/
 ...


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with ansible lint where it was trying to parse the changelogs dir

### How should this be tested?
CI should pass

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A