### PR TITLE
Legacy Update Fix

### DIFF
--- a/changelogs/fragments/update_fix.yml
+++ b/changelogs/fragments/update_fix.yml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - added when to skip project update when item is absent
+  - added when to skip inventory source update when item is absent
+  - added default to organization as null on project as it is not required for the module, but it is highly recommended.
+minor_changes:
+  - added tests for the project and inventory source skips
+...

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,3 @@
 ---
 requires_ansible: '>=2.9.6'
+...

--- a/playbooks/tower_configs/tower_inventory_sources.yml
+++ b/playbooks/tower_configs/tower_inventory_sources.yml
@@ -11,5 +11,9 @@ tower_inventory_sources:
     update_on_launch: true
     update_cache_timeout: 0
     wait: true
+  - name: RHVM-02
+    inventory: RHVM-01
+    source: scm
+    state: absent
     # more options can be provided but for scm source we are using, we need only this much.
 ...

--- a/playbooks/tower_configs/tower_projects.yml
+++ b/playbooks/tower_configs/tower_projects.yml
@@ -19,4 +19,6 @@ tower_projects:
     scm_url: https://github.com/ansible/ansible-examples.git
     description: ansible-examples
     organization: Satellite
+  - name: Test Project 3
+    state: absent
 ...

--- a/roles/inventory_source_update/tasks/main.yml
+++ b/roles/inventory_source_update/tasks/main.yml
@@ -20,5 +20,7 @@
   loop_control:
     loop_var: "__inventory_source_update_item"
   no_log: "{{ tower_configuration_inventory_source_update_secure_logging }}"
-  when: tower_inventory_sources is defined
+  when:
+    - controller_inventory_sources is defined
+    - __inventory_source_update_item.state | default('present') != "absent"
 ...

--- a/roles/project_update/tasks/main.yml
+++ b/roles/project_update/tasks/main.yml
@@ -22,4 +22,5 @@
   when:
     - tower_projects is defined
     - __project_update_update_item.update
+    - __project_update_update_item.state | default('present') != "absent"
 ...

--- a/roles/projects/tasks/main.yml
+++ b/roles/projects/tasks/main.yml
@@ -18,7 +18,7 @@
     allow_override:                 "{{ tower_projects_item.allow_override | default(omit) }}"
     job_timeout:                    "{{ tower_projects_item.job_timeout | default(tower_projects_item.timeout | default(omit, true)) }}"
     custom_virtualenv:              "{{ tower_projects_item.custom_virtualenv | default(omit, true) }}"
-    organization:                   "{{ tower_projects_item.organization.name | default( tower_projects_item.organization ) }}"
+    organization:                   "{{ tower_projects_item.organization.name | default( tower_projects_item.organization | default(omit) ) }}"
     state:                          "{{ tower_projects_item.state | default(tower_state | default('present')) }}"
     wait:                           "{{ tower_projects_item.wait | default(omit) }}"
     update_project:                 "{{ tower_projects_item.update_project | default(omit) }}"


### PR DESCRIPTION
### What does this PR do?
- added when to skip project update when item is absent
- added when to skip inventory source update when item is absent
- added default to organization on project as it is not required for the module, but it is highly recommended.
- added tests for the above skips

### How should this be tested?
Automated tests have been updated to reflect this change and test for them.

### Is there a relevant Issue open for this?
#228 
