### PR TITLE
Adding instance_groups variable definition to the default for The job_templates role

### DIFF
--- a/roles/job_templates/defaults/main.yml
+++ b/roles/job_templates/defaults/main.yml
@@ -56,7 +56,7 @@ controller_templates: []
 #  webhook_credential:   # optional, str
 #  labels:  # optional, str
 #  state: present  # optional, choices: present, absent
-#  instance_groups: # optional, str 
+#  instance_groups: # optional, str
 #  notification_templates_started: []  # optional, notification template names
 #  notification_templates_success: []  # optional, notification template names
 #  notification_templates_error: []  # optional, notification template names

--- a/roles/job_templates/defaults/main.yml
+++ b/roles/job_templates/defaults/main.yml
@@ -56,6 +56,7 @@ controller_templates: []
 #  webhook_credential:   # optional, str
 #  labels:  # optional, str
 #  state: present  # optional, choices: present, absent
+#  instance_groups: # optional, str 
 #  notification_templates_started: []  # optional, notification template names
 #  notification_templates_success: []  # optional, notification template names
 #  notification_templates_error: []  # optional, notification template names


### PR DESCRIPTION

### What does this PR do?
The variable "instance_groups" definition was missing from the default/main.yml for the job_template role for the rhel_cop controller_configuration collection. 

### How should this be tested?
There is no test needed as its a comment for the variable that is present inside the tasks for the job_template role but missing from the default section. 

### Is there a relevant Issue open for this?
No open issue

### Other Relevant info, PRs, etc.

