### PR TITLE
Add error message for diff plugin

### DIFF
--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -100,6 +100,16 @@ class LookupModule(LookupBase):
         keys_to_keep = ["name", "organization"]
         api_keys_to_keep = ["name", "summary_fields"]
 
+        for item in compare_list:
+            for key in keys_to_keep:
+                if key not in item.keys():
+                    self.handle_error(msg="Key: '{0}' missing from item in compare_list".format(key))
+
+        for item in api_list:
+            for key in api_keys_to_keep:
+                if key not in item.keys():
+                    self.handle_error(msg="Key: '{0}' missing from item in api_list. Does this object come from the api?".format(key))
+
         # Reduce list to name and organization
         compare_list_reduced = [{key: item[key] for key in keys_to_keep} for item in compare_list]
         api_list_reduced = [{key: item[key] for key in api_keys_to_keep} for item in api_list]

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -103,12 +103,12 @@ class LookupModule(LookupBase):
         for item in compare_list:
             for key in keys_to_keep:
                 if key not in item.keys():
-                    self.handle_error(msg="Key: '{0}' missing from item in compare_list".format(key))
+                    self.handle_error(msg="Key: '{0}' missing from item in compare_list item: {1}".format(key, item))
 
         for item in api_list:
             for key in api_keys_to_keep:
                 if key not in item.keys():
-                    self.handle_error(msg="Key: '{0}' missing from item in api_list. Does this object come from the api?".format(key))
+                    self.handle_error(msg="Key: '{0}' missing from item in api_list. Does this object come from the api? item: {1}".format(key, item))
 
         # Reduce list to name and organization
         compare_list_reduced = [{key: item[key] for key in keys_to_keep} for item in compare_list]


### PR DESCRIPTION
### What does this PR do?
Slight addendum to #242 (which I spotted straight after merging) that if you don't give the organization on `compare_list` and you don't give `summary_field` on `api_list` then it fails (correctly) but doesn't give a helpful error message. This does a check on the field then errors stating that the field is missing from the input.

### How should this be tested?
CI should still pass
Manually running the below will fail, but with a useful error:

```
  - debug:
        msg: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff', api_list=current_proj, compare_list=exp_proj) }}"
      vars:
        current_proj:
          - name: proj1
        exp_proj:
          - name: proj1
            organization: org1
```

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
Addendum to #242 
