### PR TITLE
Extend license role to support pulling from a URL or b64 content

### DIFF
--- a/changelogs/fragments/license.yml
+++ b/changelogs/fragments/license.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Added new options for adding manifest to Ansible Controller inc. from a URL and from b64 encoded content
+...

--- a/roles/license/README.md
+++ b/roles/license/README.md
@@ -37,8 +37,13 @@ controller_configuration_license_secure_logging defaults to the value of control
 ### Variables
 |Variable Name|Default Value|Required|Type|Description|
 |:---:|:---:|:---:|:---:|:---:|
-|`manifest`|""|yes|obj|File path to a Red Hat subscription manifest (a .zip file)|
-|`eula_accepted`|""|yes|bool|Whether to accept the End User License Agreement for Ansible controller|
+|`manifest_file`|""|no|obj|File path to a Red Hat subscription manifest (a .zip file)|
+|`manifest_url`|""|no|obj|URL containing a Red Hat subscription manifest (a .zip file)|
+|`manifest_content`|""|no|obj|Base64 encoded content of Red Hat subscription manifest|
+|`manifest`|""|no|obj|DEPRECATED - changed to `manifest_file` (still works as an alias)|
+|`manifest_username`|""|no|obj|Optional username for access to `manifest_url`|
+|`manifest_password`|""|no|obj|Optional password for access to `manifest_url`|
+|`eula_accepted`|""|yes|bool|DEPRECATED since Tower 3.8 - Whether to accept the End User License Agreement for Ansible controller|
 |`force`|`False`|no|bool|By default, the license manifest will only be applied if controller is currentlyunlicensed or trial licensed.  When force=true, the license is always applied.|
 
 For further details on fields see https://docs.ansible.com/ansible-tower/latest/html/userguide/credential_plugins.html
@@ -49,7 +54,7 @@ For further details on fields see https://docs.ansible.com/ansible-tower/latest/
 ---
 {
     "controller_license": {
-        "data": "{{ lookup('file', '/tmp/my_controller.license') }}",
+        "manifest_file": "/tmp/my_controller.license",
         "force": true
       }
 }
@@ -58,7 +63,9 @@ For further details on fields see https://docs.ansible.com/ansible-tower/latest/
 ```yaml
 ---
 controller_license:
-  data: "{{ lookup('file', '/tmp/my_controller.license') }}"
+  manifest_url: "https://fileserver.internal/controller_license.zip"
+  manifest_username: admin
+  manifest_password: password
   force: false
 ```
 

--- a/roles/license/tasks/main.yml
+++ b/roles/license/tasks/main.yml
@@ -1,8 +1,45 @@
 ---
 # tasks file for license role
+
+- name: Ensure manifest is set
+  assert:
+    that: controller_license.manifest_file is defined or controller_license.manifest is defined or controller_license.manifest_url is defined or controller_license.manifest_content is defined
+    fail_msg: "Must set a source for the manifest. Please set 'manifest_file', 'manifest_url' or 'manifest_content'"
+
+- name: Move manifest file to temporary location
+  copy:
+    src: "{{ controller_license.manifest_file | default(controller_license.manifest) }}"
+    dest: "{{ __controller_manifest_path }}"
+    mode: 0600
+  when:
+    - controller_license.manifest_file is defined or controller_license.manifest is defined
+
+- name: Fetch manifest from URL
+  get_url:
+    url: "{{ controller_license.manifest_url }}"
+    dest: "{{ __controller_manifest_path }}"
+    username: "{{ controller_license.manifest_username | default(omit) }}"
+    password: "{{ controller_license.manifest_password | default(omit) }}"
+    mode: 0600
+  when:
+    - controller_license.manifest_url is defined
+    - not controller_license.manifest_file is defined
+    - not controller_license.manifest is defined
+
+- name: Create manifest file from base64 encoded content
+  copy:
+    content: "{{ controller_license.manifest_content | b64decode }}"
+    dest: "{{ __controller_manifest_path }}"
+    mode: 0600
+  when:
+    - controller_license.manifest_content is defined
+    - not controller_license.manifest_url is defined
+    - not controller_license.manifest_file is defined
+    - not controller_license.manifest is defined
+
 - name: Install the Controller license
   license:
-    manifest:                       "{{ controller_license.manifest | mandatory }}"
+    manifest:                       "{{ __controller_manifest_path }}"
     eula_accepted:                  "{{ controller_license.eula_accepted | default(omit) }}"  # Depreciated only for Tower 3.8.x or lower
     force:                          "{{ controller_license.force | default(omit) }}"
 

--- a/roles/license/tests/config/license.yml
+++ b/roles/license/tests/config/license.yml
@@ -1,5 +1,7 @@
 ---
 controller_license:
-  data: "{{ lookup('file', '/tmp/my_tower.license') }}"
+  manifest_file: "/tmp/my_tower.zip"
+  # manifest_url: https://www.ansible.com/hubfs/Logo-Red_Hat-Ansible-A-Reverse-SVG.svg
+  # manifest_content: "aGVsbG8gd29ybGQ="
   eula_accepted: true
 ...

--- a/roles/license/tests/test.yml
+++ b/roles/license/tests/test.yml
@@ -15,7 +15,7 @@
   pre_tasks:
     - name: Include vars from controller_configs directory
       include_vars:
-        dir: ./configs
+        dir: ./config
         extensions: ["yml"]
 
   roles:

--- a/roles/license/vars/main.yml
+++ b/roles/license/vars/main.yml
@@ -1,0 +1,3 @@
+---
+__controller_manifest_path: /tmp/controller_license_manifest.zip
+...


### PR DESCRIPTION
### What does this PR do?
Allows user to set one of `manifest_file`, `manifest_url` or `manifest_content` where this is the manifest file location, a URL of the manifest file, or the content of a manifest (encoded by base64)

### How should this be tested?
The only real changes here are that stuff happens to the file prior to being placed onto Tower

### Is there a relevant Issue open for this?
resolves #214 

