### PR TITLE
Bump ansible-lint version

### DIFF
--- a/.github/workflow-config/.pre-commit-config.yml
+++ b/.github/workflow-config/.pre-commit-config.yml
@@ -13,7 +13,7 @@ repos:
         types:
           - yaml
   - repo: 'https://github.com/ansible-community/ansible-lint.git'
-    rev: v5.3.1
+    rev: v5.3.2
     hooks:
       # see discussions here about what arguments are used, and behavior
       # https://github.com/ansible/ansible-lint/issues/649

--- a/examples/tasks/differential.yml
+++ b/examples/tasks/differential.yml
@@ -7,7 +7,8 @@
   set_fact:
     set_absent_diff: "{{ lookup('controller_object_diff', api_list=controller_api_results, compare_list=differential_item.differential_test_items, with_present=differential_item.with_present ) }}"
 
-- debug:
+- name: Display set_absent_diff
+  debug:
     var: set_absent_diff
 
 - name: "Assert that the expected {{ differential_item.name }} results match."


### PR DESCRIPTION
### What does this PR do?
Fixes ansible-lint failure by updating to newer version which has a fix for the issue we have seen. Also fixing an actual linting error

### How should this be tested?
CI will work again

### Is there a relevant Issue open for this?
resolves #252 

### Other Relevant info, PRs, etc.
[This PR](https://github.com/ansible-community/ansible-lint/pull/1800) in ansible-lint fixes an underlying broken package which is the same error we have seen.
