### PR TITLE
fix incorrect github link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,11 +28,11 @@ If you feel like getting your hands dirty, feel free to make the change yourself
 1. Fork the repo on Github, and then clone it locally.
 2. Create a branch named appropriately for the change you are going to make.
 3. Make your code change.
-4. If you are creating a new role, please add a test for it in our [testing playbook.](https://github.com/redhat-cop/controller_configuration/blob/devel/playbooks/example_with_yaml/configure_controller.yml) by adding a new role entry and adding the appropriate yaml file with test data in the controller_configs directory.
+4. If you are creating a new role, please add a test for it in our [testing playbook.](https://github.com/redhat-cop/tower_configuration/blob/devel/playbooks/example_with_yaml/configure_controller.yml) by adding a new role entry and adding the appropriate yaml file with test data in the controller_configs directory.
 5. Add a changelog fragment in `changelogs/fragments` as per https://docs.ansible.com/ansible/latest/community/development_process.html#changelogs
 6. Push your code change up to your forked repo.
 7. Open a Pull Request to merge your changes to this repo. The comment box will be filled in automatically via a template.
-8. All Pull Requests will be subject to Ansible and Yaml Linting checks. Please make sure that your code complies and fix any warnings that arise. These are Checks that apear at the bottom of your Pull Request.
+8. All Pull Requests will be subject to Ansible and Yaml Linting checks. Please make sure that your code complies and fix any warnings that arise. These are Checks that appear at the bottom of your Pull Request.
 9. All Pull requests are subject to Testing against being used in controller. As above there is a check at the bottom of your pull request for this named integration.
 
 See [Using Pull Requests](https://help.github.com/articles/using-pull-requests/) got more information on how to use GitHub PRs.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Red Hat Communties of Practice Controller Configuration Collection
 
-![Ansible Lint](https://github.com/redhat-cop/controller_configuration/workflows/Ansible%20Lint/badge.svg)
-![Galaxy Release](https://github.com/redhat-cop/controller_configuration/workflows/galaxy-release/badge.svg)
+![Ansible Lint](https://github.com/redhat-cop/tower_configuration/workflows/Ansible%20Lint/badge.svg)
+![Galaxy Release](https://github.com/redhat-cop/tower_configuration/workflows/galaxy-release/badge.svg)
 <!-- Further CI badges go here as above -->
 
 This Ansible collection allows for easy interaction with an AWX or Ansible Controller server via Ansible roles using the AWX/Controller collection modules.
@@ -124,8 +124,8 @@ Adding the ability to use direct output from the awx export command in the roles
 
 ## Contributing to this collection
 
-We welcome community contributions to this collection. If you find problems, please open an issue or create a PR against the [Controller Configuration collection repository](https://github.com/redhat-cop/controller_configuration).
-More information about contributing can be found in our [Contribution Guidelines.](https://github.com/redhat-cop/controller_configuration/blob/devel/.github/CONTRIBUTING.md)
+We welcome community contributions to this collection. If you find problems, please open an issue or create a PR against the [Controller Configuration collection repository](https://github.com/redhat-cop/tower_configuration).
+More information about contributing can be found in our [Contribution Guidelines.](https://github.com/redhat-cop/tower_configuration/blob/devel/.github/CONTRIBUTING.md)
 
 ## Licensing
 


### PR DESCRIPTION
### What does this PR do?
Small fix for the readme links which were pointing to the wrong github URL (controller_configuration.git)

e.g. note that the status icons on the readme are currently broken

### How should this be tested?
N/A

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A