### PR TITLE
changing default no_log to true for user creation

### DIFF
--- a/roles/users/defaults/main.yml
+++ b/roles/users/defaults/main.yml
@@ -26,5 +26,5 @@ controller_user_accounts: []
 # set this variable to something false and there won't be a default password
 controller_user_default_password: "change_me"
 
-controller_configuration_users_secure_logging: "{{controller_configuration_secure_logging | default('false')}}"
+controller_configuration_users_secure_logging: "{{controller_configuration_secure_logging | default('true')}}"
 ...


### PR DESCRIPTION
### What does this PR do?
changes default no log to true in users role, this task deals with passwords

### How should this be tested?
Automated should be fine

### Is there a relevant Issue open for this?
no

### Other Relevant info, PRs, etc.
none
