### PR TITLE
https and validate certs added to example

### DIFF
--- a/examples/configure_controller.yml
+++ b/examples/configure_controller.yml
@@ -15,8 +15,9 @@
 
     - name: Wait for Controller to come up
       uri:
-        url: "{{ controller_hostname }}/api/v2/ping"
+        url: "https://{{ controller_hostname }}/api/v2/ping"
         status_code: 200
+        validate_certs: false
       register: result
       until: result.status == 200
       retries: 80


### PR DESCRIPTION
### What does this PR do?
Makes small changes to "examples/configuration_controller.yml": 
  - adding https in the url option 
  - adding the verify_certificates option.

Before those changes were made the playbook would just timeout waiting for a 200 return code.

### How should this be tested?
ansible-lint and yamllint did not show any errors when run against the playbook
