### PR TITLE
Fixed standard Role Usage, role and orgs list pointed to license obje…

### DIFF
--- a/roles/organizations/README.md
+++ b/roles/organizations/README.md
@@ -132,7 +132,7 @@ controller_organizations:
         ignore_files: [controller_config.yml.template]
         extensions: ["yml"]
   roles:
-    - {role: redhat_cop.controller_configuration.license, when: controller_license is defined}
+    - {role: redhat_cop.controller_configuration.organizations, when: controller_organizations is defined}
 ```
 ## License
 [MIT](LICENSE)


### PR DESCRIPTION
Fixed standard Role Usage, role and orgs list pointed to license object instead organizations

### What does this PR do?
Just changed README.md. At the "Playbook Examples"  the role and the data structure organization pointed to another list (license) instead organizations.


### How should this be tested?
It's no needed, because it affects just the README.md file

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)
