### PR TITLE
Let diff organization object type

### DIFF
--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -116,17 +116,21 @@ class LookupModule(LookupBase):
                 raise AnsibleLookupError("Unable to find items in api_list")
             return [api_list]
 
-        # Set Keys to keep for each list.
-        keys_to_keep = ["name", "organization"]
-        api_keys_to_keep = ["name", "summary_fields"]
+        # Set Keys to keep for each list. Depending on type
+        if api_list[0]["type"] == "organization":
+            keys_to_keep = ["name"]
+            api_keys_to_keep = ["name"]
+        else:
+            keys_to_keep = ["name", "organization"]
+            api_keys_to_keep = ["name", "summary_fields"]
 
-        # Depending on type, keep additional keys
-        if api_list[0]["type"] == "credential":
-            keys_to_keep.append("credential_type")
-            api_keys_to_keep.append("credential_type")
-        if api_list[0]["type"] == "inventory_source":
-            keys_to_keep.append("inventory")
-            api_keys_to_keep.append("inventory")
+            # Depending on type, keep additional keys
+            if api_list[0]["type"] == "credential":
+                keys_to_keep.append("credential_type")
+                api_keys_to_keep.append("credential_type")
+            if api_list[0]["type"] == "inventory_source":
+                keys_to_keep.append("inventory")
+                api_keys_to_keep.append("inventory")
 
         for item in compare_list:
             for key in keys_to_keep:
@@ -142,10 +146,11 @@ class LookupModule(LookupBase):
         compare_list_reduced = [{key: item[key] for key in keys_to_keep} for item in compare_list]
         api_list_reduced = [{key: item[key] for key in api_keys_to_keep} for item in api_list]
 
-        # Convert summary field name into org name
-        for item in api_list_reduced:
-            item.update({"organization": item["summary_fields"]["organization"]["name"]})
-            item.pop("summary_fields")
+        # Convert summary field name into org name Only if not type organization
+        if api_list[0]["type"] != "organization":
+            for item in api_list_reduced:
+                item.update({"organization": item["summary_fields"]["organization"]["name"]})
+                item.pop("summary_fields")
 
         # Find difference between lists
         difference = [i for i in api_list_reduced if i not in compare_list_reduced]
@@ -163,3 +168,4 @@ class LookupModule(LookupBase):
             difference = compare_list
 
         return [difference]
+


### PR DESCRIPTION
### What does this PR do?

Just added logic to check if is a organization type will have only the key name, as for keys_to_keep variable as  api_keys_to_keep variables. This enhance has ability to difference organizations between what is on the Controller (api_list) versus curated (compare_list).

### How should this be tested?
---
- hosts: localhost
  connection: local
  vars:
    controller_hostname: "aap.lab.example.com"
    controller_username: "admin"
    controller_password: "password"
    controller_validate_certs: false
    controller_organizations:
      - name: "Organization1"
      - name: "Organization2"
      - name: "Organization3"
      - name: "rh_cop_1"
  tasks:
    - set_fact:
        controller_api_organizations: "{{ lookup('ansible.controller.controller_api', 'organizations',
          host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=false) }}"

    - name: "Find the difference of Organizations between what is on the Controller versus curated list."
      set_fact:
        org_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
          api_list=controller_api_organizations, compare_list=controller_organizations,
          with_present=true, set_absent=true ) }}"

    - debug:
        var: "{{ item }}"
      loop:
          - org_difference

    - set_fact:
        controller_organizations: "{{ org_difference }}"

    - name: Configure Controller Projects | Launch project creation
      import_role:
        name: redhat_cop.controller_configuration.organizations
...
### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #<number>

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)
