### PR TITLE
Update the controller_object_diff to let diff more object types.

### DIFF
--- a/changelogs/fragments/playbook.yml
+++ b/changelogs/fragments/playbook.yml
@@ -4,4 +4,5 @@ breaking_changes:
 minor_changes:
   - Added asynchronous to {organizations,credentials,credential_types,inventories,job_templates} task to speed up creation.
   - Update to controller_object_diff lookup plugin to better handle organizations.
+  - Update to controller_object_diff lookup plugin to better handle group, host, inventory, credential, workflow_job_template_node and user objects.
 ...

--- a/examples/configs/differential_items.yml
+++ b/examples/configs/differential_items.yml
@@ -71,24 +71,24 @@ differential_items:
     with_present: false
     differential_test_items:
       - name: "cyberark"
-        credential_type: 19
+        credential_type: "CyberArk AIM Central Credential Provider Lookup"
         organization: Default
     expected_test_result:
       - name: gitlab
         organization: Default
-        credential_type: 2
+        credential_type: "Source Control"
         state: absent
   - name: inventory_sources
     with_present: false
     differential_test_items:
       - name:  RHVM-02
         organization: Default
-        inventory: 3
+        inventory: 12
         state: absent
     expected_test_result:
       - name: RHVM-01-Default
         organization: Default
-        inventory: 3
+        inventory: 12
         state: absent
   - name: inventories
     with_present: false

--- a/examples/configure_controller.yml
+++ b/examples/configure_controller.yml
@@ -16,8 +16,9 @@
 
     - name: Wait for Controller to come up
       uri:
-        url: "{{ controller_hostname }}/api/v2/ping"
+        url: "https://{{ controller_hostname }}/api/v2/ping"
         status_code: 200
+        validate_certs: "{{ controller_validate_certs }}"
       register: result
       until: result.status == 200
       retries: 80

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -168,3 +168,4 @@ class LookupModule(LookupBase):
             difference = compare_list
 
         return [difference]
+

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -120,6 +120,15 @@ class LookupModule(LookupBase):
         if api_list[0]["type"] == "organization":
             keys_to_keep = ["name"]
             api_keys_to_keep = ["name"]
+        elif api_list[0]["type"] == "user":
+            keys_to_keep = ["username"]
+            api_keys_to_keep = ["username"]
+        elif api_list[0]["type"] == "workflow_job_template_node":
+            keys_to_keep = ["workflow_job_template", "unified_job_template", "identifier"]
+            api_keys_to_keep = ["identifier", "summary_fields"]
+        elif api_list[0]["type"] == "group" or api_list[0]["type"] == "host":
+            keys_to_keep = ["name", "inventory"]
+            api_keys_to_keep = ["name", "summary_fields"]
         else:
             keys_to_keep = ["name", "organization"]
             api_keys_to_keep = ["name", "summary_fields"]
@@ -147,10 +156,27 @@ class LookupModule(LookupBase):
         api_list_reduced = [{key: item[key] for key in api_keys_to_keep} for item in api_list]
 
         # Convert summary field name into org name Only if not type organization
-        if api_list[0]["type"] != "organization":
+        if api_list[0]["type"] == "group" or api_list[0]["type"] == "host":
+            for item in api_list_reduced:
+                item.update({"inventory": item["summary_fields"]["inventory"]["name"]})
+                item.pop("summary_fields")
+        elif api_list[0]["type"] == "credential":
+            for item in api_list_reduced:
+                item.update({"organization": item["summary_fields"]["organization"]["name"]})
+                item.update({"credential_type": item["summary_fields"]["credential_type"]["name"]})
+                item.pop("summary_fields")
+        elif api_list[0]["type"] == "workflow_job_template_node":
+            for item in api_list_reduced:
+                item.update({"unified_job_template": item["summary_fields"]["unified_job_template"]["name"]})
+                item.update({"workflow_job_template": item["summary_fields"]["workflow_job_template"]["name"]})
+                item.pop("summary_fields")
+        elif api_list[0]["type"] != "organization" and api_list[0]["type"] != "user":
             for item in api_list_reduced:
                 item.update({"organization": item["summary_fields"]["organization"]["name"]})
                 item.pop("summary_fields")
+
+        self.display.warning("compare_list_reduced: {0}".format(compare_list_reduced))
+        self.display.warning("api_list_reduced: {0}".format(api_list_reduced))
 
         # Find difference between lists
         difference = [i for i in api_list_reduced if i not in compare_list_reduced]
@@ -168,4 +194,3 @@ class LookupModule(LookupBase):
             difference = compare_list
 
         return [difference]
-

--- a/roles/workflow_job_templates/tasks/add_workflows_schema.yml
+++ b/roles/workflow_job_templates/tasks/add_workflows_schema.yml
@@ -53,9 +53,9 @@
   workflow_job_template_node:
     identifier:                     "{{ __workflow_loop_node_item.identifier | mandatory }}"
     workflow:                       "{{ __workflow_loop_item.name | mandatory }}"
-    always_nodes:                   "{{ __workflow_loop_node_item.always_nodes | default( __workflow_loop_node_item.related.always_nodes | default([], true) | selectattr('identifier', 'defined') | map(attribute='identifier')) }}"  # Nodes to advance on success (green links) # noqa 204
-    success_nodes:                  "{{ __workflow_loop_node_item.success_nodes | default( __workflow_loop_node_item.related.success_nodes | default([], true) | selectattr('identifier', 'defined') | map(attribute='identifier')) }}"  # Nodes to advance on success (green links) # noqa 204
-    failure_nodes:                  "{{ __workflow_loop_node_item.failure_nodes | default( __workflow_loop_node_item.related.failure_nodes | default([], true) | selectattr('identifier', 'defined') | map(attribute='identifier')) }}"  # Nodes to advance on success (green links) # noqa 204
+    always_nodes:                   "{{ __workflow_loop_node_item.always_nodes | default( __workflow_loop_node_item.related.always_nodes | default([], true) | selectattr('identifier', 'defined') | map(attribute='identifier')) | list }}"  # Nodes to advance on always (blue links) # noqa 204
+    success_nodes:                  "{{ __workflow_loop_node_item.success_nodes | default( __workflow_loop_node_item.related.success_nodes | default([], true) | selectattr('identifier', 'defined') | map(attribute='identifier')) | list }}"  # Nodes to advance on success (green links) # noqa 204
+    failure_nodes:                  "{{ __workflow_loop_node_item.failure_nodes | default( __workflow_loop_node_item.related.failure_nodes | default([], true) | selectattr('identifier', 'defined') | map(attribute='identifier')) | list }}"  # Nodes to advance on failure (red links) # noqa 204
     state:                          "{{ __workflow_loop_node_item.state | default(controller_state | default('present')) }}"
     organization:                   "{{ __workflow_loop_item.organization.name | default( __workflow_loop_item.organization ) }}"  # Workflow job template organization
     controller_username:            "{{ controller_username | default(omit, true) }}"


### PR DESCRIPTION
### What does this PR do?
Update the controller_object_diff to let diff more objects.

### How should this be tested?
Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)
```
---
- hosts: localhost
  connection: local
  gather_facts: false
  vars:
    controller_user_accounts: 
      - username: "user1"
        password: "password1"
      - username: "user2"
        password: "password2"
  tasks:
    - name: "TEST: Find the difference of Groups between what is on the Controller versus CasC on SCM"
      set_fact:
        __user_accounts_difference: "{{ lookup('redhat_cop.controller_casc.controller_object_diff_temp',
          api_list=__controller_api_user_accounts, compare_list=controller_user_accounts,
          with_present=false, set_absent=true ) }}"

    - debug:
        var: __user_accounts_difference
...
```

### Is there a relevant Issue open for this?
No

### Other Relevant info, PRs, etc.
Related to the following PR. Adding more object types to diff lookup plugin: https://github.com/redhat-cop/tower_configuration/pull/270