### PR TITLE
Add organization support to user creation

### DIFF
--- a/changelogs/fragments/users.yml
+++ b/changelogs/fragments/users.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Allow setting the organization when creating users.
+...

--- a/roles/users/README.md
+++ b/roles/users/README.md
@@ -58,6 +58,7 @@ This also speeds up the overall role.
 |`last_name`|""|no|str|The last name of the user|
 |`is_superuser`|false|no|bool|Whether the user is a superuser|
 |`is_system_auditor`|false|no|bool|Whether the user is an auditor|
+|`organization`|""|no|str|The name of the organization the user belongs to|
 |`state`|`present`|no|str|Desired state of the resource.|
 |`update_secrets`|true|no|bool| True will always change password if user specifies password, even if API gives $encrypted$ for password. False will only set the password if other values change too.|
 

--- a/roles/users/README.md
+++ b/roles/users/README.md
@@ -58,7 +58,7 @@ This also speeds up the overall role.
 |`last_name`|""|no|str|The last name of the user|
 |`is_superuser`|false|no|bool|Whether the user is a superuser|
 |`is_system_auditor`|false|no|bool|Whether the user is an auditor|
-|`organization`|""|no|str|The name of the organization the user belongs to|
+|`organization`|""|no|str|The name of the organization the user belongs to.<br />Added in awx.awx >= 20.0.0 and ansible.controller >= 4.1.1|
 |`state`|`present`|no|str|Desired state of the resource.|
 |`update_secrets`|true|no|bool| True will always change password if user specifies password, even if API gives $encrypted$ for password. False will only set the password if other values change too.|
 

--- a/roles/users/defaults/main.yml
+++ b/roles/users/defaults/main.yml
@@ -20,6 +20,7 @@ controller_user_accounts: []
 #  last_name: "Smith"  # optional
 #  is_superuser: false  # optional, boolean
 #  is_auditor: false  # optional, boolean
+#  organization: Default # optional
 #  state: present  # optional, choices: present, absent
 
 # if you're too lazy to give your users a password, this is the default they will get

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -10,6 +10,7 @@
     is_superuser:             "{{ __controller_user_accounts_item.is_superuser | default(__controller_user_accounts_item.superuser | default(omit)) }}"
     is_system_auditor:        "{{ __controller_user_accounts_item.is_auditor | default(__controller_user_accounts_item.is_system_auditor | default(omit)) }}"
     update_secrets:           "{{ __controller_user_accounts_item.update_secrets | default(omit) }}"
+    organization:             "{{ __controller_user_accounts_item.organization | default(__controller_user_accounts_item.organization | default(omit)) }}"
     state:                    "{{ __controller_user_accounts_item.state | default(controller_state | default(omit, true)) }}"
 
     # Role Standard Options

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -10,7 +10,7 @@
     is_superuser:             "{{ __controller_user_accounts_item.is_superuser | default(__controller_user_accounts_item.superuser | default(omit)) }}"
     is_system_auditor:        "{{ __controller_user_accounts_item.is_auditor | default(__controller_user_accounts_item.is_system_auditor | default(omit)) }}"
     update_secrets:           "{{ __controller_user_accounts_item.update_secrets | default(omit) }}"
-    organization:             "{{ __controller_user_accounts_item.organization | default(__controller_user_accounts_item.organization | default(omit)) }}"
+    organization:             "{{ __controller_user_accounts_item.organization | default(omit) }}"
     state:                    "{{ __controller_user_accounts_item.state | default(controller_state | default(omit, true)) }}"
 
     # Role Standard Options


### PR DESCRIPTION
### What does this PR do?
Allow setting the organisation when creating users.

The awx collection already supports specifying the organization when creating users (see https://github.com/ansible/awx/blob/devel/awx_collection/plugins/modules/user.py#L141).
 

### How should this be tested?
The change can easily be tested running the playbook below, on an automation controller. 
Before this PR, the `organization` field within `controller_user_accounts` would be ignored, and the user wouldn't be a member of any organization. Variable can be left empty, and has a ` | default(omit)`.

```
- name: Playbook to configure ansible controller
  hosts: automationcontroller
  vars:
    controller_validate_certs: false
    controller_hostname: aap00
    controller_username: admin
    controller_password: change_me
  collections:
    - awx.awx
    - redhat_cop.controller_configuration
  roles:
    - name: organizations
      vars:
        controller_organizations:
          - name: "evil_corp"
            custom_virtualenv: "/var/lib/awx/myvenv"
            max_hosts: 0
            state: present 

    - name: users
      vars:
        controller_user_accounts:
          - username: "ctodea" 
            email: "ctodea@redhat.com"
            state: present
            organization: "evil_corp" # this will make the user a member of the org
```

### Is there a relevant Issue open for this?
No

### Other Relevant info, PRs, etc.
N/A