### PR TITLE
Update readme's to remove references to Tower

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Red Hat Communties of Practice Controller Configuration Collection
 
-![Ansible Lint](https://github.com/redhat-cop/tower_configuration/workflows/Ansible%20Lint/badge.svg)
-![Galaxy Release](https://github.com/redhat-cop/tower_configuration/workflows/galaxy-release/badge.svg)
+![Ansible Lint](https://github.com/redhat-cop/controller_configuration/workflows/Ansible%20Lint/badge.svg)
+![Galaxy Release](https://github.com/redhat-cop/controller_configuration/workflows/galaxy-release/badge.svg)
 <!-- Further CI badges go here as above -->
 
 This Ansible collection allows for easy interaction with an AWX or Ansible Controller server via Ansible roles using the AWX/Controller collection modules.
 
-# REQUIREMENTS
-The AWX.AWX OR ANSIBLE.TOWER collections MUST be installed in order for this collection to work. It is recomended they be invoked in the playbook in the following way.
+## REQUIREMENTS
+
+The AWX.AWX OR ANSIBLE.CONTROLLER collections MUST be installed in order for this collection to work. It is recommended they be invoked in the playbook in the following way.
 
 ```yaml
 ---
@@ -28,7 +29,9 @@ Click the `Content` button to see the list of content included in this collectio
 
 You can install the redhat_cop controller_configuration collection with the Ansible Galaxy CLI:
 
-    ansible-galaxy collection install redhat_cop.controller_configuration
+```console
+ansible-galaxy collection install redhat_cop.controller_configuration
+```
 
 You can also include it in a `requirements.yml` file and install it with `ansible-galaxy collection install -r requirements.yml`, using the format:
 
@@ -39,17 +42,23 @@ collections:
     # If you need a specific version of the collection, you can specify like this:
     # version: ...
 ```
+
 ## Conversion from Tower_configuration
+
 If you were using a version of redhat_cop.tower_configuration, please refer to our Conversion Guide here: [Conversion Guide](docs/CONVERSION_GUIDE.md)
 
 ## Using this collection
+
 The awx.awx or ansible.controller collection must be invoked in the playbook in order for ansible to pick up the correct modules to use.
 
 The following command will invoke the playbook with the awx collection
+
 ```console
 ansible-playbook redhat_cop.controller_configuration.configure_awx.yml
 ```
+
 The following command will invoke the playbook with the ansible.controller collection
+
 ```console
 ansible-playbook redhat_cop.controller_configuration.configure_controller.yml
 ```
@@ -71,24 +80,24 @@ Define following vars here, or in `controller_configs/controller_auth.yml`
 
 You can also specify authentication by a combination of either:
 
- - `controller_hostname`, `controller_username`, `controller_password`
- - `controller_hostname`, `controller_oauthtoken`
+- `controller_hostname`, `controller_username`, `controller_password`
+- `controller_hostname`, `controller_oauthtoken`
 
-The OAuth2 token is the preferred method. You can obtain the token through the prefered `controller_token` module, or through the
-AWX CLI [login](https://docs.ansible.com/ansible-tower/latest/html/towercli/reference.html#awx-login)
+The OAuth2 token is the preferred method. You can obtain the token through the preferred `controller_token` module, or through the
+AWX CLI [login](https://docs.ansible.com/automation-controller/latest/html/controllercli/authentication.html)
 command.
 
 These can be specified via (from highest to lowest precedence):
 
- - direct role variables as mentioned above
- - environment variables (most useful when running against localhost)
- - a config file path specified by the `controller_config_file` parameter
- - a config file at `~/.controller_cli.cfg`
- - a config file at `/etc/controller/controller_cli.cfg`
+- direct role variables as mentioned above
+- environment variables (most useful when running against localhost)
+- a config file path specified by the `controller_config_file` parameter
+- a config file at `~/.controller_cli.cfg`
+- a config file at `/etc/controller/controller_cli.cfg`
 
 Config file syntax looks like this:
 
-```
+```ini
 [general]
 host = https://localhost:8043
 verify_ssl = true
@@ -96,6 +105,7 @@ oauth_token = LEdCpKVKc4znzffcpQL5vLG8oyeku6
 ```
 
 Controller token module would be invoked with this code:
+
 ```yaml
     - name: Create a new token using controller username/password
       awx.awx.token:
@@ -109,26 +119,29 @@ Controller token module would be invoked with this code:
 ```
 
 ### Controller Export
+
 The awx command line can export json that is compatable with this collection.
 More details can be found [here](examples/configs_export_model/README.md)
 
-### See Also:
+### See Also
 
-* [Ansible Using collections](https://docs.ansible.com/ansible/latest/user_guide/collections_using.html) for more details.
+- [Ansible Using collections](https://docs.ansible.com/ansible/latest/user_guide/collections_using.html) for more details.
 
 ## Release and Upgrade Notes
+
 For details on changes between versions, please see [the changelog for this collection](CHANGELOG.rst).
 
 ## Roadmap
+
 Adding the ability to use direct output from the awx export command in the roles along with the current data model.
 
 ## Contributing to this collection
 
-We welcome community contributions to this collection. If you find problems, please open an issue or create a PR against the [Controller Configuration collection repository](https://github.com/redhat-cop/tower_configuration).
-More information about contributing can be found in our [Contribution Guidelines.](https://github.com/redhat-cop/tower_configuration/blob/devel/.github/CONTRIBUTING.md)
+We welcome community contributions to this collection. If you find problems, please open an issue or create a PR against the [Controller Configuration collection repository](https://github.com/redhat-cop/controller_configuration).
+More information about contributing can be found in our [Contribution Guidelines.](https://github.com/redhat-cop/controller_configuration/blob/devel/.github/CONTRIBUTING.md)
 
 ## Licensing
 
 GNU General Public License v3.0 or later.
 
-See [LICENCE](https://www.gnu.org/licenses/gpl-3.0.txt) to see the full text.
+See [LICENSE](https://www.gnu.org/licenses/gpl-3.0.txt) to see the full text.

--- a/docs/CONVERSION_GUIDE.md
+++ b/docs/CONVERSION_GUIDE.md
@@ -1,9 +1,11 @@
 # Red Hat Communties of Practice Controller Configuration Collection Conversion Guide
 
-# REQUIREMENTS
-The AWX.AWX OR ANSIBLE.TOWER collections MUST be installed in order for this collection to work. It is recomended they be invoked in the playbook in the following way.
+## REQUIREMENTS
+
+The AWX.AWX OR ANSIBLE.CONTROLLER collections MUST be installed in order for this collection to work. It is recommended they be invoked in the playbook in the following way.
 
 ## Using this collection
+
 The awx.awx or ansible.controller collection must be invoked in the playbook in order for ansible to pick up the correct modules to use.
 
 Otherwise it will look for the modules only in your base installation. If there are errors complaining about "couldn't resolve module/action" this is the most likely cause.
@@ -19,9 +21,10 @@ Otherwise it will look for the modules only in your base installation. If there 
     - redhat_cop.controller_configuration
 ```
 
-# Variable name changes
+## Variable name changes
 
 ### Major Variable names changed
+
 The Following Variables need to be changed:
 |Tower Variable Name|Controller Variable Name|
 |:---:|:---:|
@@ -54,6 +57,7 @@ The Following Variables need to be changed:
 |`tower_workflow_launch_jobs`|`controller_workflow_launch_jobs`|
 
 ### Authentication Credentials
+
 |Tower Variable Name|Controller Variable Name|
 |:---:|:---:|
 |`tower_username`|`controller_username`|
@@ -66,10 +70,12 @@ The Following Variables need to be changed:
 ### Specific Changes in Roles
 
 ### Projects
+
 |Tower Variable Name|Controller Variable Name|Reason|
 |:---:|:---:|:---:|
-|`default_environment`|`custom_virtualenv`|`enviroments now refer to Execution Enviroments`|
+|`default_environment`|`custom_virtualenv`|`environments now refer to Execution Environments`|
 
 ## Notes
+
 Making these changes should be all the ones you need to make in order to use the updated collection.
 However there have been many changes and this list is in no way final or all encompassing.

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -1,5 +1,5 @@
 
-## Contributor's Guidelines
+# Contributor's Guidelines
 
 - All YAML files named with '.yml' extension
 - Use spaces around jinja variables. {{ var }} over {{var}}
@@ -10,4 +10,4 @@
 - Paths - When defining paths, do not include trailing slashes (e.g. my_path: /foo not my_path: /foo/). When concatenating paths, follow the same convention (e.g. {{ my_path }}/bar not {{ my_path }}bar)
 - Indentation - Use 2 spaces for each indent
 - `vars/` vs `defaults/` - if you have variables that don't need to change or be overridden by user, put those in `vars/` and those that a user would likely override, put those under `defaults/` directory.
-- All playbooks/roles should be focused on compatibility with Ansible Tower
+- All playbooks/roles should be focused on compatibility with Automation Controller

--- a/examples/configs_export_model/README.md
+++ b/examples/configs_export_model/README.md
@@ -1,19 +1,29 @@
-# Ansible Tower Export Documentation
+# Automation Controller Export Documentation
 
 ## Description
-This is documentation on how to use a the Tower export commands in development.
 
-This command for awx allows you to export all available endpoints for tower for use in import, use in your own templates, for backup and many other uses.
+This is documentation on how to use a the Automation Controller export commands in development.
+
+This command allows exporting all available endpoints for Automation Controller for use in importing, templates, backups and many other uses.
 
 ## Installation
-pip install awxkit
+
+```console
+pip3 install awxkit
+```
 
 ## Basic command options
-awx export --conf.host https://localhost --conf.username admin --conf.password ******** --conf.insecure --help
 
+```console
+awx export --conf.host https://localhost --conf.username admin --conf.password ******** --conf.insecure --help
+```
+
+```console
 awx export --conf.host https://localhost --conf.username admin --conf.password ******** --conf.insecure --job_templates
+```
 
 ## Available options for this command
+
 |Option|
 |:---:|
 |users|


### PR DESCRIPTION
### What does this PR do?
Changes Ansible Tower references to Automation Controller in various readme files. In addition it fixes a few spelling errors and some markdown linting rule standards.

### How should this be tested?
N/A as this is updates to readme files only

### Is there a relevant Issue open for this?
No

### Other Relevant info, PRs, etc.
None
