### PR TITLE
make async not have changed status

### DIFF
--- a/roles/applications/tasks/main.yml
+++ b/roles/applications/tasks/main.yml
@@ -25,6 +25,7 @@
   async: 1000
   poll: 0
   register: __applications_job_async
+  changed_when: not __applications_job_async.changed
 
 - name: "Create Applications | Wait for finish the Applications creation"
   async_status:

--- a/roles/credential_input_sources/tasks/main.yml
+++ b/roles/credential_input_sources/tasks/main.yml
@@ -22,6 +22,7 @@
   async: 1000
   poll: 0
   register: __credential_input_sources_job_async
+  changed_when: not __credential_input_sources_job_async.changed
 
 - name: "Create Controller Credential Input Sources | Wait for finish the Controller Credential Input Sources creation"
   async_status:

--- a/roles/credential_types/tasks/main.yml
+++ b/roles/credential_types/tasks/main.yml
@@ -22,6 +22,7 @@
   async: 1000
   poll: 0
   register: __credentialTypes_job_async
+  changed_when: not __credentialTypes_job_async.changed
 
 - name: "Configure Controller Credential Types | Wait for finish the credential types creation"
   async_status:

--- a/roles/credentials/tasks/main.yml
+++ b/roles/credentials/tasks/main.yml
@@ -27,6 +27,7 @@
   async: 1000
   poll: 0
   register: __credentials_job_async
+  changed_when: not __credentials_job_async.changed
 
 - name: "Configure Controller Credentials | Wait for finish the credential creation"
   async_status:

--- a/roles/execution_environments/tasks/main.yml
+++ b/roles/execution_environments/tasks/main.yml
@@ -25,6 +25,7 @@
   async: 1000
   poll: 0
   register: __execution_environments_job_async
+  changed_when: not __execution_environments_job_async.changed
 
 - name: "Create Controller Execution Environments | Wait for finish the Controller Execution Environments creation"
   async_status:

--- a/roles/groups/tasks/main.yml
+++ b/roles/groups/tasks/main.yml
@@ -26,6 +26,7 @@
   async: 1000
   poll: 0
   register: __group_job_async
+  changed_when: not __group_job_async.changed
 
 - name: "Create Controller Group | Wait for finish the Controller Group creation"
   async_status:

--- a/roles/hosts/tasks/main.yml
+++ b/roles/hosts/tasks/main.yml
@@ -23,6 +23,7 @@
   async: 1000
   poll: 0
   register: __host_job_async
+  changed_when: not __host_job_async.changed
 
 - name: "Configure Controller Hosts | Wait for finish the Hosts creation"
   async_status:

--- a/roles/instance_groups/tasks/main.yml
+++ b/roles/instance_groups/tasks/main.yml
@@ -28,6 +28,7 @@
   async: 1000
   poll: 0
   register: __instance_groups_job_async
+  changed_when: not __instance_groups_job_async.changed
 
 - name: "Configure Controller instance groups | Wait for finish the instance groups creation"
   async_status:

--- a/roles/inventories/tasks/main.yml
+++ b/roles/inventories/tasks/main.yml
@@ -25,6 +25,7 @@
   async: 1000
   poll: 0
   register: __inventories_job_async
+  changed_when: not __inventories_job_async.changed
 
 - name: "Create Controller inventories | Wait for finish the inventories creation"
   async_status:

--- a/roles/inventory_source_update/tasks/main.yml
+++ b/roles/inventory_source_update/tasks/main.yml
@@ -26,6 +26,7 @@
   async: 1000
   poll: 0
   register: __inventory_source_update_async
+  changed_when: not __inventory_source_update_async.changed
 
 - name: "Configure Inventory Source | Wait for finish the Inventory Source creation"
   async_status:

--- a/roles/inventory_sources/tasks/main.yml
+++ b/roles/inventory_sources/tasks/main.yml
@@ -42,6 +42,7 @@
   async: 1000
   poll: 0
   register: __inventory_source_job_async
+  changed_when: not __inventory_source_job_async.changed
 
 - name: "Configure Inventory Source | Wait for finish the Inventory Source creation"
   async_status:

--- a/roles/job_templates/tasks/main.yml
+++ b/roles/job_templates/tasks/main.yml
@@ -65,6 +65,7 @@
   async: 1000
   poll: 0
   register: __job_temaplates_job_async
+  changed_when: not __job_temaplates_job_async.changed
 
 - name: "Configure Controller Job Templates | Wait for finish the job templates creation"
   async_status:

--- a/roles/labels/tasks/main.yml
+++ b/roles/labels/tasks/main.yml
@@ -20,6 +20,7 @@
   async: 1000
   poll: 0
   register: __controller_label_job_async
+  changed_when: not __controller_label_job_async.changed
 
 - name: "Configure Labels | Wait for finish the Label creation"
   async_status:

--- a/roles/master_role_example/tasks/main.yml
+++ b/roles/master_role_example/tasks/main.yml
@@ -22,6 +22,7 @@
   async: 1000
   poll: 0
   register: __controller_***********_job_async
+  changed_when: not __controller_***********_job_async.changed
 
 - name: "Configure *********** | Wait for finish the *********** creation"
   async_status:

--- a/roles/notification_templates/tasks/main.yml
+++ b/roles/notification_templates/tasks/main.yml
@@ -25,6 +25,7 @@
   async: 1000
   poll: 0
   register: __controller_notification_job_async
+  changed_when: not __controller_notification_job_async.changed
 
 - name: "Configure notifications | Wait for finish the notifications creation"
   async_status:

--- a/roles/organizations/tasks/main.yml
+++ b/roles/organizations/tasks/main.yml
@@ -24,10 +24,11 @@
   loop: "{{ controller_organizations }}"
   loop_control:
     loop_var: __controller_organizations_item
+  no_log: "{{ controller_configuration_organizations_secure_logging }}"
   async: 1000
   poll: 0
   register: __organizations_job_async
-  no_log: "{{ controller_configuration_organizations_secure_logging }}"
+  changed_when: not __organizations_job_async.changed
 
 - name: "Configure Controller Organizations | Wait for finish the organization creation"
   async_status:

--- a/roles/project_update/README.md
+++ b/roles/project_update/README.md
@@ -26,12 +26,25 @@ Currently:
 The following Variables compliment each other.
 If Both variables are not set, secure logging defaults to false.
 The role defaults to False as normally the project update task does not include sensitive information.
-controller_configuration_project_update_secure_logging defaults to the value of controller_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of controller configuration roles with a single variable, or for the user to selectively use it.
+controller_configuration_project_update_secure_logging defaults to the value of controller_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`controller_configuration_project_update_secure_logging`|`False`|no|Whether or not to include the sensitive ad_hoc_command role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
+|`controller_configuration_project_update_secure_logging`|`False`|no|Whether or not to include the sensitive Project role tasks in the log.  Set this value to `True` if you will be providing your sensitive values from elsewhere.|
 |`controller_configuration_secure_logging`|`False`|no|This variable enables secure logging as well, but is shared accross multiple roles, see above.|
+
+### Asynchronous Retry Variables
+The following Variables set asynchronous retries for the role.
+If neither of the retries or delay or retries are set, they will default to their respective defaults.
+This allows for all items to be created, then checked that the task finishes successfully.
+This also speeds up the overall role.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`controller_configuration_async_retries`|60|no|This variable sets the number of retries to attempt for the role globally.|
+|`controller_configuration_project_update_async_retries`|60|no|This variable sets the number of retries to attempt for the role.|
+|`controller_configuration_async_delay`|10|no|This sets the delay between retries for the role globally.|
+|`controller_configuration_project_update_async_delay`|10|no|This sets the delay between retries for the role.|
 
 ## Data Structure
 ### Variables

--- a/roles/project_update/defaults/main.yml
+++ b/roles/project_update/defaults/main.yml
@@ -11,6 +11,6 @@
 # These are the default variables specific to the **** role
 
 controller_configuration_project_update_secure_logging: "{{controller_configuration_secure_logging | default('false')}}"
-controller_configuration_project_update_async_retries: 60
-controller_configuration_project_update_async_delay: 10
+controller_configuration_project_update_async_retries: "{{ controller_configuration_async_retries | default(60) }}"
+controller_configuration_project_update_async_delay: "{{ controller_configuration_async_delay | default(10) }}"
 ...

--- a/roles/project_update/defaults/main.yml
+++ b/roles/project_update/defaults/main.yml
@@ -11,4 +11,6 @@
 # These are the default variables specific to the **** role
 
 controller_configuration_project_update_secure_logging: "{{controller_configuration_secure_logging | default('false')}}"
+controller_configuration_project_update_async_retries: 60
+controller_configuration_project_update_async_delay: 10
 ...

--- a/roles/project_update/tasks/main.yml
+++ b/roles/project_update/tasks/main.yml
@@ -23,4 +23,21 @@
     - controller_projects is defined
     - __project_update_update_item.update
     - __project_update_update_item.state | default('present') != "absent"
+  async: 1000
+  poll: 0
+  register: __project_update_job_async
+  changed_when: not __project_update_job_async.changed
+
+- name: "Configure Controller Projects | Wait for finish the projects creation"
+  async_status:
+    jid: "{{ __project_update_job_async_results_item.ansible_job_id }}"
+  register: __project_update_job_async_result
+  until: __project_update_job_async_result.finished
+  retries: "{{ controller_configuration_project_update_async_retries }}"
+  delay: "{{ controller_configuration_project_update_async_delay }}"
+  loop: "{{ __project_update_job_async.results }}"
+  loop_control:
+    loop_var: __project_update_job_async_results_item
+  when: __project_update_job_async_results_item.ansible_job_id is defined
+  no_log: "{{ controller_configuration_project_update_secure_logging }}"
 ...

--- a/roles/projects/tasks/main.yml
+++ b/roles/projects/tasks/main.yml
@@ -42,6 +42,7 @@
   async: 1000
   poll: 0
   register: __projects_job_async
+  changed_when: not __projects_job_async.changed
 
 - name: "Configure Controller Projects | Wait for finish the projects creation"
   async_status:

--- a/roles/roles/tasks/main.yml
+++ b/roles/roles/tasks/main.yml
@@ -35,6 +35,7 @@
   async: 1000
   poll: 0
   register: __controller_role_job_async
+  changed_when: not __controller_role_job_async.changed
 
 - name: "Configure Roles | Wait for finish the Roles creation"
   async_status:

--- a/roles/schedules/tasks/main.yml
+++ b/roles/schedules/tasks/main.yml
@@ -32,6 +32,7 @@
   async: 1000
   poll: 0
   register: __controller_schedule_job_async
+  changed_when: not __controller_schedule_job_async.changed
 
 - name: "Configure Schedules | Wait for finish the Schedules creation"
   async_status:

--- a/roles/settings/tasks/main.yml
+++ b/roles/settings/tasks/main.yml
@@ -21,6 +21,7 @@
   async: 1000
   poll: 0
   register: __controller_setting_job_async
+  changed_when: not __controller_setting_job_async.changed
 
 - name: "Configure Settings | Wait for finish the Settings creation"
   async_status:

--- a/roles/teams/tasks/main.yml
+++ b/roles/teams/tasks/main.yml
@@ -21,6 +21,7 @@
   async: 1000
   poll: 0
   register: __controller_team_job_async
+  changed_when: not __controller_team_job_async.changed
 
 - name: "Configure Teams | Wait for finish the Teams creation"
   async_status:

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -27,6 +27,7 @@
   async: 1000
   poll: 0
   register: __controller_user_accounts_job_async
+  changed_when: not __controller_user_accounts_job_async.changed
 
 - name: "Configure Users | Wait for finish the Users creation"
   async_status:

--- a/roles/workflow_job_templates/tasks/add_workflows_schema.yml
+++ b/roles/workflow_job_templates/tasks/add_workflows_schema.yml
@@ -35,6 +35,7 @@
   async: 1000
   poll: 0
   register: __workflows_node_async
+  changed_when: not __workflows_node_async.changed
 
 - name: "Manage Workflows | Wait for finish the workflow creation"
   async_status:

--- a/roles/workflow_job_templates/tasks/main.yml
+++ b/roles/workflow_job_templates/tasks/main.yml
@@ -43,6 +43,7 @@
   async: 1000
   poll: 0
   register: __workflows_job_async
+  changed_when: not __workflows_job_async.changed
 
 - name: "Manage Workflows | Wait for finish the workflow creation"
   async_status:


### PR DESCRIPTION
### What does this PR do?
Put in changed_when on all async tasks to not show as changed, also added async to project_update role.

### How should this be tested?
Automated tests to make sure nothing is broken, you could verify by hand that it doesn't show anything as changed on the async task.

### Is there a relevant Issue open for this?
none

### Other Relevant info, PRs, etc.
none
