### PR TITLE
fix survey_spec not being an applicable option

### DIFF
--- a/changelogs/fragments/survey.yml
+++ b/changelogs/fragments/survey.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixes option of `survey_spec` on job_templates role.
+...

--- a/examples/configs/templates.yml
+++ b/examples/configs/templates.yml
@@ -25,6 +25,21 @@ controller_templates:
     credentials: Demo Credential
     verbosity: 0
     inventory: localhost
+    survey_spec:
+      name: ''
+      description: ''
+      spec:
+      - question_name: Target Host
+        question_description: target host is required for playbook to work, this host
+          needs to exist in the inventory
+        required: true
+        type: text
+        variable: target_hosts
+        min: 0
+        max: 1024
+        default: infra-ansible-tower-testing.infra.sat.rdu2.redhat.com
+        choices: ''
+        new_question: true
 
 # You can retrieve a job along with its survey spec using tower cli as follows:
 # tower-cli receive --job_template <Name> --user admin --format yaml

--- a/examples/configs/templates.yml
+++ b/examples/configs/templates.yml
@@ -29,17 +29,17 @@ controller_templates:
       name: ''
       description: ''
       spec:
-      - question_name: Target Host
-        question_description: target host is required for playbook to work, this host
-          needs to exist in the inventory
-        required: true
-        type: text
-        variable: target_hosts
-        min: 0
-        max: 1024
-        default: infra-ansible-tower-testing.infra.sat.rdu2.redhat.com
-        choices: ''
-        new_question: true
+        - question_name: Target Host
+          question_description: target host is required for playbook to work, this host
+            needs to exist in the inventory
+          required: true
+          type: text
+          variable: target_hosts
+          min: 0
+          max: 1024
+          default: infra-ansible-tower-testing.infra.sat.rdu2.redhat.com
+          choices: ''
+          new_question: true
 
 # You can retrieve a job along with its survey spec using tower cli as follows:
 # tower-cli receive --job_template <Name> --user admin --format yaml
@@ -48,15 +48,15 @@ controller_templates:
 #   name: ''
 #   description: ''
 #   spec:
-#   - question_name: Target Host
-#     question_description: target host is required for playbook to work, this host
-#       needs to exist in the inventory
-#     required: true
-#     type: text
-#     variable: target_hosts
-#     min: 0
-#     max: 1024
-#     default: infra-ansible-tower-testing.infra.sat.rdu2.redhat.com
-#     choices: ''
-#     new_question: true
+#     - question_name: Target Host
+#       question_description: target host is required for playbook to work, this host
+#         needs to exist in the inventory
+#       required: true
+#       type: text
+#       variable: target_hosts
+#       min: 0
+#       max: 1024
+#       default: infra-ansible-tower-testing.infra.sat.rdu2.redhat.com
+#       choices: ''
+#       new_question: true
 ...

--- a/roles/job_templates/tasks/main.yml
+++ b/roles/job_templates/tasks/main.yml
@@ -35,7 +35,7 @@
     ask_inventory_on_launch:              "{{ __controller_template_item.ask_inventory_on_launch | default(omit) }}"
     ask_credential_on_launch:             "{{ __controller_template_item.ask_credential_on_launch | default(omit) }}"
     survey_enabled:                       "{{ __controller_template_item.survey_enabled | default(omit) }}"
-    survey_spec:                          "{{ __controller_template_item.related.survey_spec | default(__controller_template_item.survey | default(omit, true)) }}"
+    survey_spec:                          "{{ __controller_template_item.related.survey_spec | default(__controller_template_item.survey_spec | default(__controller_template_item.survey | default(omit, true))) }}"
     become_enabled:                       "{{ __controller_template_item.become_enabled | default(omit) }}"
     allow_simultaneous:                   "{{ __controller_template_item.allow_simultaneous | default(omit) }}"
     timeout:                              "{{ __controller_template_item.timeout | default(omit, true) }}"


### PR DESCRIPTION
### What does this PR do?
Added survey_spec as an applicable option. The Readme for the JT role states `survey_spec` is the option to use and `survey` was an alias, but the only currently usable option was `survey`

### How should this be tested?
Added a CI test for survey_spec

### Is there a relevant Issue open for this?
resolves #291 

### Other Relevant info, PRs, etc.
N/A