### PR TITLE
Fix reference to tower_configuration for conversion guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ collections:
     # version: ...
 ```
 
-## Conversion from Controller_configuration
+## Conversion from tower_configuration
 
-If you were using a version of redhat_cop.controller_configuration, please refer to our Conversion Guide here: [Conversion Guide](docs/CONVERSION_GUIDE.md)
+If you were using a version of redhat_cop.tower_configuration, please refer to our Conversion Guide here: [Conversion Guide](docs/CONVERSION_GUIDE.md)
 
 ## Using this collection
 


### PR DESCRIPTION
### What does this PR do?
Update README section for conversion guide to refer to tower_configuration

### How should this be tested?
Read the README

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A