### PR TITLE
adjusted reference org. argument, feature not in ansible.controller yet

### DIFF
--- a/roles/users/README.md
+++ b/roles/users/README.md
@@ -58,7 +58,7 @@ This also speeds up the overall role.
 |`last_name`|""|no|str|The last name of the user|
 |`is_superuser`|false|no|bool|Whether the user is a superuser|
 |`is_system_auditor`|false|no|bool|Whether the user is an auditor|
-|`organization`|""|no|str|The name of the organization the user belongs to.<br />Added in awx.awx >= 20.0.0 and ansible.controller >= 4.1.1|
+|`organization`|""|no|str|The name of the organization the user belongs to.<br />Added in awx.awx >= 20.0.0 DOES NOT exist in ansible.controller yet.|
 |`state`|`present`|no|str|Desired state of the resource.|
 |`update_secrets`|true|no|bool| True will always change password if user specifies password, even if API gives $encrypted$ for password. False will only set the password if other values change too.|
 


### PR DESCRIPTION
### What does this PR do?
Changes documentation to reflect that the user module does not take organization as argument in the ansible.controller collection, it's just in awx.awx.

### How should this be tested?
Validate against ansible.controller (4.1.1/4.1.2) documentation, here: https://console.redhat.com/ansible/automation-hub/repo/published/ansible/controller/content/module/user

### Is there a relevant Issue open for this?
No

### Other Relevant info, PRs, etc.
Please provide link to other PRs that may be related (blocking, resolves, etc. etc.)
