### PR TITLE
Fix lookup plugin docs

### DIFF
--- a/changelogs/fragments/object_diff_docs.yml
+++ b/changelogs/fragments/object_diff_docs.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed broken documentation for controller_object_diff plugin
+...

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -28,12 +28,12 @@ options:
     required: True
   set_absent:
     description:
-      - Set items not in the compare list to state: absent
+      - Set state of items not in the compare list to 'absent'
     type: boolean
     default: True
   with_present:
     description:
-      - Include items in the original compare list in the output, and set state: present
+      - Include items in the original compare list in the output, and set state to 'present'
     type: boolean
     default: True
   warn_on_empty_api:


### PR DESCRIPTION
### What does this PR do?
Fixes docs which aren't built properly

### How should this be tested?
Doc change from this to this....

<img width="1247" alt="Screenshot 2022-06-01 at 15 41 50" src="https://user-images.githubusercontent.com/9056568/171431701-c70523ef-65bf-4981-9796-54dbc0eaa62a.png">

<img width="1190" alt="Screenshot 2022-06-01 at 15 42 21" src="https://user-images.githubusercontent.com/9056568/171431819-d969bc88-938e-4da2-ac79-de924c1898a1.png">

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A