### PR TITLE
Add Jinja variables workaround for source_vars

### DIFF
--- a/changelogs/fragments/inventory_sources.yml
+++ b/changelogs/fragments/inventory_sources.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - inventory_sources - update ``source_vars`` to parse Jinja variables using the same workaround as inventories role.

--- a/roles/inventory_sources/README.md
+++ b/roles/inventory_sources/README.md
@@ -47,6 +47,22 @@ This also speeds up the overall role.
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_inventory_sources_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
 
+### Formating Variables
+Variables can use a standard Jinja templating format to describe the resource.
+
+Example:
+```json
+{{ variable }}
+```
+
+Because of this it is difficult to provide controller with the required format for these fields.
+
+The workaround is to use the following format:
+```json
+{  { variable }}
+```
+The role will strip the double space between the curly bracket in order to provide controller with the correct format for the Variables.
+
 ## Data Structure
 ### Variables
 |Variable Name|Default Value|Required|Description|

--- a/roles/inventory_sources/tasks/main.yml
+++ b/roles/inventory_sources/tasks/main.yml
@@ -8,7 +8,7 @@
     organization:                         "{{ __controller_source_item.inventory.organization.name | default( __controller_source_item.organization | default(omit, true)) }}"
     source:                               "{{ __controller_source_item.source | default(omit, true) }}"
     source_path:                          "{{ __controller_source_item.source_path | default(omit, true) }}"
-    source_vars:                          "{{ __controller_source_item.source_vars | default(omit, true) }}"
+    source_vars:                          "{{ __controller_source_item.source_vars | default(omit, true) | regex_replace('[ ]{2,}','') }}"
     enabled_var:                          "{{ __controller_source_item.enabled_var | default(omit, true) }}"
     enabled_value:                        "{{ __controller_source_item.enabled_value | default(omit, true) }}"
     host_filter:                          "{{ __controller_source_item.host_filter | default(omit, true) }}"


### PR DESCRIPTION
### What does this PR do?
This PR allows the user to pass Jinja variables to the `source_vars` option in the `inventory_sources` role by applying the same workaround found in the `inventories` role (using `{  { variable }}` instead of `{{ variable }}`).

### How should this be tested?
I've not added any tests to the roles test playbook as I wasn't sure how best to do so, but the following config can be used:

```yaml
---
controller_inventory_sources:
  - name: ec2
    inventory: Demo Inventory
    organization: Default
    source: ec2
    source_vars:
      plugin: aws_ec2
      regions:
        - eu-central-1
      include_filters:
        - tag:Environment: test
      exclude_filters:
        - instance-state-name: stopped
      hostnames:
        - tag:Name
      compose:
        ansible_host: private_dns_name
      keyed_groups:
        - key: tags.Sponsor
          separator: ''
        - key: tags.Project
          separator: ''
          parent_group: '{  { tags.Sponsor }}'
    overwrite: true
    update_on_launch: true
```

Running a playbook that uses this config shows that the inventory source is added successfully:

```
TASK [redhat_cop.controller_configuration.inventory_sources : Add an inventory source] ********************************************************************
ok: [localhost] => (item={'name': 'ec2', 'inventory': 'Demo Inventory', 'organization': 'Default', 'source': 'ec2', 'source_vars': {'plugin': 'aws_ec2', 'regions': ['eu-central-1'], 'include_filters': [{'tag:Environment': 'test'}], 'exclude_filters': [{'instance-state-name': 'stopped'}], 'hostnames': ['tag:Name'], 'compose': {'ansible_host': 'private_dns_name'}, 'keyed_groups': [{'key': 'tags.Sponsor', 'separator': ''}, {'key': 'tags.Project', 'separator': '', 'parent_group': '{  { tags.Sponsor }}'}]}, 'overwrite': True, 'update_on_launch': True})
TASK [redhat_cop.controller_configuration.inventory_sources : Configure Inventory Source | Wait for finish the Inventory Source creation] *****************
FAILED - RETRYING: [localhost]: Configure Inventory Source | Wait for finish the Inventory Source creation (30 retries left).
FAILED - RETRYING: [localhost]: Configure Inventory Source | Wait for finish the Inventory Source creation (29 retries left).
FAILED - RETRYING: [localhost]: Configure Inventory Source | Wait for finish the Inventory Source creation (28 retries left).
changed: [localhost] => (item={'failed': 0, 'started': 1, 'finished': 0, 'ansible_job_id': '44847185919.16955', 'results_file': '/tmp/.ansible_async/44847185919.16955', 'changed': False, '__controller_source_item': {'name': 'ec2', 'inventory': 'Demo Inventory', 'organization': 'Default', 'source': 'ec2', 'source_vars': {'plugin': 'aws_ec2', 'regions': ['eu-central-1'], 'include_filters': [{'tag:Environment': 'test'}], 'exclude_filters': [{'instance-state-name': 'stopped'}], 'hostnames': ['tag:Name'], 'compose': {'ansible_host': 'private_dns_name'}, 'keyed_groups': [{'key': 'tags.Sponsor', 'separator': ''}, {'key': 'tags.Project', 'separator': '', 'parent_group': '{  { tags.Sponsor }}'}]}, 'overwrite': True, 'update_on_launch': True}, 'ansible_loop_var': '__controller_source_item'})
[WARNING]: You are running collection version 0.0.1-devel but connecting to AWX version 21.0.0

TASK [redhat_cop.controller_configuration.inventory_source_update : Run Controller inventory source update] ***********************************************
ok: [localhost] => (item={'name': 'ec2', 'inventory': 'Demo Inventory', 'organization': 'Default', 'source': 'ec2', 'source_vars': {'plugin': 'aws_ec2', 'regions': ['eu-central-1'], 'include_filters': [{'tag:Environment': 'test'}], 'exclude_filters': [{'instance-state-name': 'stopped'}], 'hostnames': ['tag:Name'], 'compose': {'ansible_host': 'private_dns_name'}, 'keyed_groups': [{'key': 'tags.Sponsor', 'separator': ''}, {'key': 'tags.Project', 'separator': '', 'parent_group': '{  { tags.Sponsor }}'}]}, 'overwrite': True, 'update_on_launch': True})

TASK [redhat_cop.controller_configuration.inventory_source_update : Configure Inventory Source | Wait for finish the Inventory Source creation] ***********
FAILED - RETRYING: [localhost]: Configure Inventory Source | Wait for finish the Inventory Source creation (30 retries left).
FAILED - RETRYING: [localhost]: Configure Inventory Source | Wait for finish the Inventory Source creation (29 retries left).
FAILED - RETRYING: [localhost]: Configure Inventory Source | Wait for finish the Inventory Source creation (28 retries left).
changed: [localhost] => (item={'failed': 0, 'started': 1, 'finished': 0, 'ansible_job_id': '671744880524.17086', 'results_file': '/tmp/.ansible_async/671744880524.17086', 'changed': False, '__inventory_source_update_item': {'name': 'ec2', 'inventory': 'Demo Inventory', 'organization': 'Default', 'source': 'ec2', 'source_vars': {'plugin': 'aws_ec2', 'regions': ['eu-central-1'], 'include_filters': [{'tag:Environment': 'test'}], 'exclude_filters': [{'instance-state-name': 'stopped'}], 'hostnames': ['tag:Name'], 'compose': {'ansible_host': 'private_dns_name'}, 'keyed_groups': [{'key': 'tags.Sponsor', 'separator': ''}, {'key': 'tags.Project', 'separator': '', 'parent_group': '{  { tags.Sponsor }}'}]}, 'overwrite': True, 'update_on_launch': True}, 'ansible_loop_var': '__inventory_source_update_item'})
```

And the AWX controller confirms the braces have been retained and re-formatted:
![inventory_sources-source_vars](https://user-images.githubusercontent.com/453843/171841414-68cd809b-f0c9-40d5-9273-335b7d8171e5.png)

### Is there a relevant Issue open for this?
resolves #321 
