### PR TITLE
fix default behavior for controller_host in Manage Workflows task

### DIFF
--- a/roles/workflow_job_templates/tasks/main.yml
+++ b/roles/workflow_job_templates/tasks/main.yml
@@ -33,7 +33,7 @@
     controller_username:                "{{ controller_username | default(omit, true) }}"
     controller_password:                "{{ controller_password | default(omit, true) }}"
     controller_oauthtoken:              "{{ controller_oauthtoken | default(omit, true) }}"
-    controller_host:                    "{{ controller_hostname | default(omit) }}"
+    controller_host:                    "{{ controller_hostname | default(omit, true) }}"
     controller_config_file:             "{{ controller_config_file | default(omit, true) }}"
     validate_certs:                     "{{ controller_validate_certs | default(omit) }}"
   loop: "{{ controller_workflows }}"


### PR DESCRIPTION
### What does this PR do?
Configure the same behavior for controller_host parameter in Manage Workflows than the rest of roles with the similar type of task. I had an issue with this because I set controller_host as a var from the main playbook and it is working properly for all objects in the tower/controller but fail for workflows because the behavior of controller_host parameter is different.

### How should this be tested?
N/A

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A