### PR TITLE
default omit interval option so it will match upstream default

### DIFF
--- a/roles/ad_hoc_command/README.md
+++ b/roles/ad_hoc_command/README.md
@@ -50,7 +50,7 @@ controller_configuration_ad_hoc_command_secure_logging defaults to the value of 
 |`become_enabled`|""|no|bool|If the become flag should be set.|
 |`diff_mode`|""|no|bool|Show the changes made by Ansible tasks where supported|
 |`wait`|`False`|no|bool|Wait for the command to complete.|
-|`interval`|1|no|int|The interval to request an update from controller.|
+|`interval`|2|no|int|The interval to request an update from controller.|
 |`timeout`|""|no|int|If waiting for the command to complete this will abort after this amount of seconds.|
 
 

--- a/roles/ad_hoc_command/tasks/main.yml
+++ b/roles/ad_hoc_command/tasks/main.yml
@@ -15,7 +15,7 @@
     become_enabled:         "{{ __ad_hoc_command_item.become_enabled | default(omit) }}"
     diff_mode:              "{{ __ad_hoc_command_item.diff_mode | default(omit) }}"
     wait:                   "{{ __ad_hoc_command_item.wait | default(omit) }}"
-    interval:               "{{ __ad_hoc_command_item.interval | default(1) }}"
+    interval:               "{{ __ad_hoc_command_item.interval | default(omit) }}"
     timeout:                "{{ __ad_hoc_command_item.timeout | default(omit, true) }}"
 
     # Role Standard Options

--- a/roles/ad_hoc_command_cancel/README.md
+++ b/roles/ad_hoc_command_cancel/README.md
@@ -39,7 +39,7 @@ controller_configuration_ad_hoc_command_secure_logging defaults to the value of 
 |:---:|:---:|:---:|:---:|:---:|
 |`id`|""|no|int|ID of the command to cancel Recommended to be in a separate list of ID's see example, defaults to output of ad_hoc_command_role of controller_ad_hoc_commands_output.|
 |`fail_if_not_running`|""|no|bool|Fail loudly if the I(command_id) can not be canceled.|
-|`interval`|1|no|int|Limit to use for the ad hoc command.|
+|`interval`|2|no|int|Limit to use for the ad hoc command.|
 |`timeout`|""|yes|int|Credential to use for ad hoc command.|
 
 

--- a/roles/ad_hoc_command_cancel/tasks/main.yml
+++ b/roles/ad_hoc_command_cancel/tasks/main.yml
@@ -4,7 +4,7 @@
   ad_hoc_command_cancel:
     command_id:             "{{ __ad_hoc_command_cancel_item.id }}"
     fail_if_not_running:    "{{ __ad_hoc_command_cancel_item.fail_if_not_running | default(omit) }}"
-    interval:               "{{ __ad_hoc_command_cancel_item.interval | default(1) }}"
+    interval:               "{{ __ad_hoc_command_cancel_item.interval | default(omit) }}"
     timeout:                "{{ __ad_hoc_command_cancel_item.timeout | default(omit, true) }}"
 
     # Role Standard Options

--- a/roles/job_launch/README.md
+++ b/roles/job_launch/README.md
@@ -51,7 +51,7 @@ controller_configuration_job_launch_secure_logging defaults to the value of cont
 |`diff_mode`|""|no|str|Show the changes made by Ansible tasks where supported.|
 |`credential_passwords`|""|no|str|Passwords for credentials which are set to prompt on launch.|
 |`wait`|""|no|bool|Wait for the job to complete.|
-|`interval`|""|no|int|The interval to request an update from controller.|
+|`interval`|2|no|int|The interval to request an update from controller.|
 |`timeout`|""|no|int|If waiting for the job to complete this will abort after this amount of seconds.|
 
 ### Standard Project Data Structure

--- a/roles/job_launch/tasks/main.yml
+++ b/roles/job_launch/tasks/main.yml
@@ -17,7 +17,7 @@
     diff_mode:                "{{ __job_launch_item.diff_mode | default(omit) }}"
     credential_passwords:     "{{ __job_launch_item.credential_passwords | default(omit, true) }}"
     wait:                     "{{ __job_launch_item.wait | default(omit) }}"
-    interval:                 "{{ __job_launch_item.interval | default(1) }}"
+    interval:                 "{{ __job_launch_item.interval | default(omit) }}"
     timeout:                  "{{ __job_launch_item.timeout | default(omit, true) }}"
 
     # Role Standard Options

--- a/roles/workflow_launch/README.md
+++ b/roles/workflow_launch/README.md
@@ -44,7 +44,7 @@ controller_configuration_workflow_launch_secure_logging defaults to the value of
 |`scm_branch`|""|no|str|A specific of the SCM project to run the template on.|
 |`extra_vars`|""|no|str|Any extra vars required to launch the job. ask_extra_vars needs to be set to True via controller_job_template module.|
 |`wait`|""|no|bool|Wait for the job to complete.|
-|`interval`|""|no|int|The interval to request an update from controller.|
+|`interval`|2|no|int|The interval to request an update from controller.|
 |`timeout`|""|no|int|If waiting for the job to complete this will abort after this amount of seconds.|
 
 ### Standard Project Data Structure

--- a/roles/workflow_launch/tasks/main.yml
+++ b/roles/workflow_launch/tasks/main.yml
@@ -9,7 +9,7 @@
     scm_branch:               "{{ __workflow_launch_item.scm_branch | default(omit, true) }}"
     extra_vars:               "{{ __workflow_launch_item.extra_vars | default(omit, true) }}"
     wait:                     "{{ __workflow_launch_item.wait | default(omit) }}"
-    interval:                 "{{ __workflow_launch_item.interval | default(1) }}"
+    interval:                 "{{ __workflow_launch_item.interval | default(omit) }}"
     timeout:                  "{{ __workflow_launch_item.timeout | default(omit, true) }}"
 
     # Role Standard Options


### PR DESCRIPTION
### What does this PR do?
Omits the intervals because the upstream default has changed and this previously wouldn't have followed. It makes more sense for us to omit so the awx.awx/ansible.controller default is used instead

### How should this be tested?
N/A

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
https://github.com/ansible/awx/pull/12094