### PR TITLE
Added README.md filetree_create requirements needed

### DIFF
--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -6,7 +6,17 @@ The role `filetree_create` is intended to be used as the first step to begin usi
 Requirements
 ------------
 
-That role requires the Ansible collection [ansible.controller](https://console.redhat.com/ansible/automation-hub/repo/published/ansible/controller?version=4.1.0) to be installed and accessible.
+That role requires the following:
+
+- [awx.awx](https://docs.ansible.com/ansible/latest/collections/awx/awx/index.html) or [ansible.controller]ansible collection.
+- [Community.General](https://docs.ansible.com/ansible/latest/collections/community/general/index.html#plugins-in-community-general)
+- jmespath library needs to be installed on the host running the playbook (needed for the json_query filter)
+
+```bash
+$ ansible-galaxy collection install community.general -p collections
+$ ansible-galaxy collection install ansible.controller -p collections
+$ pip3 install jmespath
+```
 
 Role Variables
 --------------


### PR DESCRIPTION
### What does this PR do?
Update README.md of the role filetree_create because it was missing the requirements to successfully run it.
