### PR TITLE
[#341] issue Remove jsonquery from filetree_create role

### DIFF
--- a/changelogs/fragments/remove_json_query_dependency.yml
+++ b/changelogs/fragments/remove_json_query_dependency.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+    - Remove json_query and jmespath dependency from filetree_create role.
+...

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -10,12 +10,6 @@ That role requires the following:
 
 - [awx.awx](https://docs.ansible.com/ansible/latest/collections/awx/awx/index.html) or [ansible.controller]ansible collection.
 
-```bash
-$ ansible-galaxy collection install community.general -p collections
-$ ansible-galaxy collection install ansible.controller -p collections
-$ pip3 install jmespath
-```
-
 Role Variables
 --------------
 

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -9,8 +9,6 @@ Requirements
 That role requires the following:
 
 - [awx.awx](https://docs.ansible.com/ansible/latest/collections/awx/awx/index.html) or [ansible.controller]ansible collection.
-- [Community.General](https://docs.ansible.com/ansible/latest/collections/community/general/index.html#plugins-in-community-general)
-- jmespath library needs to be installed on the host running the playbook (needed for the json_query filter)
 
 ```bash
 $ ansible-galaxy collection install community.general -p collections

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -21,8 +21,8 @@
         'kind': inventory_lookvar_item.kind,
         'variables': inventory_lookvar_item.variables,
         'inventory_sources': query('ansible.controller.controller_api', inventory_lookvar_item.related.inventory_sources, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true),
-        'hosts': query('ansible.controller.controller_api', inventory_lookvar_item.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) | json_query('[*].{name: name, description: description}'),
-        'groups': query('ansible.controller.controller_api', inventory_lookvar_item.related.groups, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) | json_query('[*].{name: name, description: description, hosts_url: related.hosts}') | map('combine', {'inventory': inventory_lookvar_item.name}) | list
+        'hosts': query('ansible.controller.controller_api', inventory_lookvar_item.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true),
+        'groups': query('ansible.controller.controller_api', inventory_lookvar_item.related.groups, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true)
       }]}) }}"
     needed_paths: "{{ ((needed_paths | default([])) + [inventory_lookvar_item_organization]) | flatten | unique }}"
   vars:
@@ -72,7 +72,7 @@
   include_tasks: "hosts.yml"
   vars:
     output_path: "{{ local_output_path }}/{{ current_inventory_hosts.key }}"
-    current_organization_inventories: "{{ current_inventory_hosts.value | json_query('[*].{hosts: hosts, name: name}') }}"
+    current_organization_inventories: "{{ current_inventory_hosts.value }}"
   loop: "{{ current_inventories | default({}) | dict2items }}"
   loop_control:
     loop_var: current_inventory_hosts

--- a/roles/filetree_create/tasks/users.yml
+++ b/roles/filetree_create/tasks/users.yml
@@ -7,7 +7,7 @@
   set_fact:
     current_users: "{{ (current_users | default([])) + [user_lookvar_item | combine({'organizations': user_lookvar_item_organizations})] }}"
   vars:
-    user_lookvar_item_organizations: "{{ query('ansible.controller.controller_api', user_lookvar_item.related.organizations, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) | json_query('[*].name') }}"
+    user_lookvar_item_organizations: "{{ query('ansible.controller.controller_api', user_lookvar_item.related.organizations, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) | selectattr('name', 'defined') | map(attribute='name') }}"
   loop: "{{ users_lookvar }}"
   loop_control:
     loop_var: user_lookvar_item
@@ -18,7 +18,7 @@
     path: "{{ output_path }}/{{ current_user_dir }}"
     state: directory
     mode: '0755'
-  loop: "{{ current_users | json_query('[*].organizations') | flatten | unique }}"
+  loop: "{{ current_users | selectattr('organizations', 'defined') | map(attribute='organizations') | flatten | unique }}"
   loop_control:
     loop_var: current_user_dir
     label: "{{ output_path }}/{{ current_user_dir }}"

--- a/roles/filetree_create/templates/current_groups.j2
+++ b/roles/filetree_create/templates/current_groups.j2
@@ -5,6 +5,6 @@ configure_tower_groups:
     description: "{{ group.description }}"
     inventory: "{{ current_groups_asset_value.name }}"
     hosts:
-{{ query('ansible.controller.controller_api', group.hosts_url, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) | json_query('[*].name') | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
+{{ query('ansible.controller.controller_api', group.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) | selectattr("name", "defined") | map(attribute="name") | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
 {%- endfor -%}
 ...

--- a/roles/filetree_create/templates/current_roles.j2
+++ b/roles/filetree_create/templates/current_roles.j2
@@ -1,4 +1,5 @@
 ---
+controller_roles:
 {% for role in current_user_roles.value %}
 {% if role.content_object is defined %}
 {% if object_type is match('user') %}

--- a/roles/filetree_create/templates/current_team_roles.j2
+++ b/roles/filetree_create/templates/current_team_roles.j2
@@ -1,4 +1,5 @@
 ---
+controller_roles:
 {% for role in team_roles_lookvar %}
 {% if role.summary_fields.resource_type is defined %}
   - team: "{{ teamname }}"

--- a/roles/filetree_create/templates/current_user_roles.j2
+++ b/roles/filetree_create/templates/current_user_roles.j2
@@ -1,4 +1,5 @@
 ---
+controller_roles:
 {% for role in user_roles_lookvar %}
 {% if role.summary_fields.resource_type is defined %}
   - user: "{{ username }}"


### PR DESCRIPTION
### What does this PR do?
Fix issue #341: remove json_query to avoid dependencies with  Community.General and jmespath library.

### How should this be tested?
test playbook: https://github.com/redhat-cop/controller_configuration/tree/devel/roles/filetree_create/tests/filetree_create.yml

### Is there a relevant Issue open for this?
resolves #341 
