### PR TITLE
typo fixed extra spaces

### DIFF
--- a/roles/filetree_create/tasks/credential_types.yml
+++ b/roles/filetree_create/tasks/credential_types.yml
@@ -6,7 +6,7 @@
 
 - name: "Get current Credential Types from the API when Tower"
   set_fact:
-    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/', query_params={ 'managed_by_tower': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_al    l=true) }}"
+    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/', query_params={ 'managed_by_tower': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
   when: not is_aap
 
 - name: "Create the output directory for credential types: {{ output_path }}"


### PR DESCRIPTION
### What does this PR do?
Fixes a typo that avoids the extraction process for the credential_types to be executed from the `filetree_create` role.

### How should this be tested?
`ansible-playbook filetree_create.yml -e '{input_tag: [credential_types]}'`

### Is there a relevant Issue open for this?
No issue has been opened for this bug.
