### PR TITLE
fix example filetre_create with wrong checks

### DIFF
--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -30,29 +30,7 @@ Example Playbook
 - hosts: localhost
   connection: local
   gather_facts: false
-  vars:
-    controller_hostname: "{{ vault_controller_hostname }}"
-    controller_username: "{{ vault_controller_username }}"
-    controller_password: "{{ vault_controller_password }}"
-    controller_validate_certs: "{{ vault_controller_validate_certs }}"
-  pre_tasks:
-    - name: "Check if the required input variables are present"
-      assert:
-        that:
-          - input_tag is defined
-          - (input_tag | type_debug) == 'list'
-        fail_msg: 'A variable called ''input_tag'' of type ''list'' is needed: -e ''{input_tag: [organizations, projects]}'''
-        quiet: true
 
-    - name: "Check if the required input values are correct"
-      assert:
-        that:
-          - tag_item in valid_tags
-        fail_msg: "The valid tags are the following ones: {{ valid_tags | join(', ') }}"
-        quiet: true
-      loop: "{{ input_tag }}"
-      loop_control:
-        loop_var: tag_item
   roles:
     - redhat_cop.controller_configuration.filetree_create
 ...

--- a/roles/filetree_create/tests/filetree_create.yml
+++ b/roles/filetree_create/tests/filetree_create.yml
@@ -2,29 +2,7 @@
 - hosts: localhost
   connection: local
   gather_facts: false
-  vars:
-    controller_hostname: "{{ vault_controller_hostname }}"
-    controller_username: "{{ vault_controller_username }}"
-    controller_password: "{{ vault_controller_password }}"
-    controller_validate_certs: "{{ vault_controller_validate_certs }}"
-  pre_tasks:
-    - name: "Check if the required input variables are present"
-      assert:
-        that:
-          - input_tag is defined
-          - (input_tag | type_debug) == 'list'
-        fail_msg: 'A variable called ''input_tag'' of type ''list'' is needed: -e ''{input_tag: [organizations, projects]}'''
-        quiet: true
 
-    - name: "Check if the required input values are correct"
-      assert:
-        that:
-          - tag_item in valid_tags
-        fail_msg: "The valid tags are the following ones: {{ valid_tags | join(', ') }}"
-        quiet: true
-      loop: "{{ input_tag }}"
-      loop_control:
-        loop_var: tag_item
   roles:
     - redhat_cop.controller_configuration.filetree_create
 ...


### PR DESCRIPTION
### What does this PR do?
By mistake, we added some asserts in the examples of filetree_create role. These asserts depend of variables declared in the role itself, then, this example would be failed. In this PR we remove some vars and asserts which are already in the role:

https://github.com/redhat-cop/controller_configuration/blob/devel/roles/filetree_create/defaults/main.yml#L5-L8
https://github.com/redhat-cop/controller_configuration/blob/devel/roles/filetree_create/tasks/main.yml#L3-L19
https://github.com/redhat-cop/controller_configuration/blob/devel/roles/filetree_create/vars/main.yml

### How should this be tested?
Run test playbook 

### Is there a relevant Issue open for this?

### Other Relevant info, PRs, etc.
