### PR TITLE
Export the dynamic inventories (with inventory_sources defined) without the hosts and without the groups.

### DIFF
--- a/roles/filetree_create/tasks/groups.yml
+++ b/roles/filetree_create/tasks/groups.yml
@@ -8,10 +8,10 @@
 - name: "Add current groups to the output yaml file: {{ output_path }}/current_groups_<INVENTORY_NAME>.yaml"
   template:
     src: "templates/current_groups.j2"
-    dest: "{{ output_path }}/current_groups_{{ current_groups_asset_value.name }}.yaml"
+    dest: "{{ output_path }}/current_groups_{{ current_groups_asset_value.name | regex_replace('/','_') }}.yaml"
     mode: '0644'
   loop: "{{ current_organization_inventories }}"
   loop_control:
     loop_var: current_groups_asset_value
-    label: "{{ output_path }}/current_groups_{{ current_groups_asset_value.name }}.yaml"
+    label: "{{ output_path }}/current_groups_{{ current_groups_asset_value.name | regex_replace('/','_') }}.yaml"
 ...

--- a/roles/filetree_create/tasks/groups.yml
+++ b/roles/filetree_create/tasks/groups.yml
@@ -14,4 +14,5 @@
   loop_control:
     loop_var: current_groups_asset_value
     label: "{{ output_path }}/current_groups_{{ current_groups_asset_value.name | regex_replace('/','_') }}.yaml"
+  when: current_groups_asset_value.groups | length > 0
 ...

--- a/roles/filetree_create/tasks/hosts.yml
+++ b/roles/filetree_create/tasks/hosts.yml
@@ -8,10 +8,10 @@
 - name: "Add current hosts to the output yaml file: {{ output_path }}/current_hosts_<INVENTORY_NAME>.yaml"
   template:
     src: "templates/current_hosts.j2"
-    dest: "{{ output_path }}/current_hosts_{{ current_hosts_asset_value.name }}.yaml"
+    dest: "{{ output_path }}/current_hosts_{{ current_hosts_asset_value.name | regex_replace('/','_') }}.yaml"
     mode: '0644'
   loop: "{{ current_organization_inventories }}"
   loop_control:
     loop_var: current_hosts_asset_value
-    label: "{{ output_path }}/current_hosts_{{ current_hosts_asset_value.name }}.yaml"
+    label: "{{ output_path }}/current_hosts_{{ current_hosts_asset_value.name | regex_replace('/','_') }}.yaml"
 ...

--- a/roles/filetree_create/tasks/hosts.yml
+++ b/roles/filetree_create/tasks/hosts.yml
@@ -14,4 +14,5 @@
   loop_control:
     loop_var: current_hosts_asset_value
     label: "{{ output_path }}/current_hosts_{{ current_hosts_asset_value.name | regex_replace('/','_') }}.yaml"
+  when: current_hosts_asset_value.hosts | length > 0
 ...

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -2,7 +2,6 @@
 - name: "Get the inventoryes from the API"
   set_fact:
     inventory_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/inventories/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, query_params={
-                          'has_inventory_sources': 'false',
                           'not__kind': 'smart',
                           'order_by': 'organization'
                         }
@@ -20,9 +19,9 @@
         'host_filter': inventory_lookvar_item.host_filter,
         'kind': inventory_lookvar_item.kind,
         'variables': inventory_lookvar_item.variables,
-        'inventory_sources': query('ansible.controller.controller_api', inventory_lookvar_item.related.inventory_sources, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true),
-        'hosts': query('ansible.controller.controller_api', inventory_lookvar_item.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true),
-        'groups': query('ansible.controller.controller_api', inventory_lookvar_item.related.groups, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true)
+        'inventory_sources': query('ansible.controller.controller_api', inventory_lookvar_item.related.inventory_sources, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=10000) if inventory_lookvar_item.has_inventory_sources else [],
+        'hosts': query('ansible.controller.controller_api', inventory_lookvar_item.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=10000) if not inventory_lookvar_item.has_inventory_sources else [],
+        'groups': query('ansible.controller.controller_api', inventory_lookvar_item.related.groups, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=10000) if not inventory_lookvar_item.has_inventory_sources else []
       }]}) }}"
     needed_paths: "{{ ((needed_paths | default([])) + [inventory_lookvar_item_organization]) | flatten | unique }}"
   vars:

--- a/roles/filetree_create/tasks/inventory_sources.yml
+++ b/roles/filetree_create/tasks/inventory_sources.yml
@@ -8,13 +8,13 @@
 - name: "Add current inventory source to the output yaml file: {{ output_path }}/<INVENTORY_NAME>/current_inventory_sources.yaml"
   template:
     src: "templates/current_inventory_sources.j2"
-    dest: "{{ output_path }}/current_inventory_sources_{{ current_organization_inventory.name }}.yaml"
+    dest: "{{ output_path }}/current_inventory_sources_{{ current_organization_inventory.name | regex_replace('/','_') }}.yaml"
     mode: '0644'
   vars:
     current_inventory_sources_asset_value: "{{ current_organization_inventory.inventory_sources }}"
   loop: "{{ current_organization_inventories }}"
   loop_control:
     loop_var: current_organization_inventory
-    label: "{{ output_path }}/current_inventory_sources_{{ current_organization_inventory.name }}.yaml"
+    label: "{{ output_path }}/current_inventory_sources_{{ current_organization_inventory.name | regex_replace('/','_') }}.yaml"
   when: current_inventory_sources_asset_value | length > 0
 ...

--- a/roles/filetree_create/templates/current_groups.j2
+++ b/roles/filetree_create/templates/current_groups.j2
@@ -5,6 +5,6 @@ configure_tower_groups:
     description: "{{ group.description }}"
     inventory: "{{ current_groups_asset_value.name }}"
     hosts:
-{{ query('ansible.controller.controller_api', group.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) | selectattr("name", "defined") | map(attribute="name") | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
+{{ query('ansible.controller.controller_api', group.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=10000) | selectattr("name", "defined") | map(attribute="name") | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
 {%- endfor -%}
 ...

--- a/roles/filetree_create/templates/current_hosts.j2
+++ b/roles/filetree_create/templates/current_hosts.j2
@@ -1,6 +1,6 @@
 ---
 controller_hosts:
-{% for host in current_hosts_asset_value.hosts %}
+{% for host in current_hosts_asset_value.hosts if not host.has_inventory_sources %}
   - name: "{{ host.name }}"
     description: "{{ host.description }}"
     inventory: "{{ current_hosts_asset_value.name | default('ToDo: The host \'' + host.name + '\' must have an associated inventory') }}"


### PR DESCRIPTION


### What does this PR do?
Currently, the inventory object itself is not exported, so this is fixing that.

- remove the filter for inventories with inventory sources
 
- the organization's name can have an /, so we need to use another character when creating the destination paths
 
- don't export hosts that have has_inventory_sources to true
 
- increase the max_objects limit. ToDo: make a variable for that
 
- don't need the hosts list when the inventory has inventory_sources
 
- don't need the hosts list when the inventory has inventory_sources
 
- the organization's name can have an /, so we need to use another character when creating the destination paths
 
- DO need the hosts list when the inventory has inventory_sources
 
- DO NOT need the hosts list when the inventory has inventory_sources. Unaffordable by now: out of resources at large environments

### How should this be tested?

`ansible-playbook filetree_create.yml -e '{input_tag: [inventory], output_path: ~/iam/filetree_create.2.1.7/}'` 

### Is there a relevant Issue open for this?
No issue opened for this bug.

### Other Relevant info, PRs, etc.
N/A