### PR TITLE
Escaping injectors at credential_types template filetree-create 

### DIFF
--- a/roles/filetree_create/templates/current_credential_types.j2
+++ b/roles/filetree_create/templates/current_credential_types.j2
@@ -7,6 +7,8 @@ controller_credential_types:
     inputs:
 {{ credential_type.inputs | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
     injectors:
-{{ credential_type.injectors | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
+{# https://docs.ansible.com/ansible/latest/user_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings #}
+{{ credential_type.injectors | to_nice_yaml(indent=2) | indent(width=6, first=True) | replace("'{{", "unsafe! \'{{") }}
+
 {% endfor %}
 ...


### PR DESCRIPTION
### What does this PR do?


Added data type unsafe[1] to block credential_types templating when exporting in  filetree-create role. It needs to be added in order to be consumed by awx.awx.credential_type module.
....
    injectors:
      env:
        SN_INSTANCE: unsafe! '{{ SN_INSTANCE }}'
        SN_PASSWORD: unsafe! '{{ SN_PASSWORD }}'
        SN_USERNAME: unsafe! '{{ SN_USERNAME }}'
....

[1].- https://docs.ansible.com/ansible/latest/user_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings

### How should this be tested?

ansible-playbook filetree_create.yml -e {'input_tag: [credential_types]'} -e @orgs_vars/env/demo-dev/configure_connection_controller_credentials.yml --vault-password-file ./.vault_pass.txt

$ cat /tmp/filetree_output/current_credential_types.yaml 
---
controller_credential_types:
  - name: "AAP_Monitor"
    description: "Monitor Ansible Automation Platform credential"
    kind: "cloud"
    inputs:
      fields:
      - id: controller_url
        label: Controller
        type: string
      - id: oauthtoken
        label: Token
        secret: true
        type: string
      required:
      - controller_url
      - oauthtoken

    injectors:
      extra_vars:
        local_users_controller_api_token: unsafe! '{{ oauthtoken }}'
        local_users_controller_api_url: unsafe! '{{ controller_url }}'
