### PR TITLE
Let the collection to use both awx.awx and ansible.controller collections, as per user decision

### DIFF
--- a/changelogs/fragments/awx_awx-ansible_controller-independence.yml
+++ b/changelogs/fragments/awx_awx-ansible_controller-independence.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+    - Add a way to detect which of `awx.awx` or `ansible.controller` collection is installed. Added to the playbooks and examples.
+...

--- a/examples/configure_controller.yml
+++ b/examples/configure_controller.yml
@@ -14,6 +14,26 @@
 
   pre_tasks:
 
+    - block:
+        - name: "Check if the collection ansible.controller is installed"
+          set_fact:
+            ansible_controller_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i ansible.controllersss') }}"
+      rescue:
+        - name: "Check if the collection awx.awx is installed"
+          set_fact:
+            awx_awx_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i awx.awx') }}"
+      always:
+        - name: "Set the collection providing the controller_api lookup plugin"
+          set_fact:
+            controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api' if awx_awx_collection_installed is defined) | default('NONE') }}"
+        - name: "Fail if no collection is detected"
+          fail:
+            msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."
+          when: controller_api_plugin is match('NONE')
+        - name: "Show the plugin we are using"
+          debug:
+            msg: "Using the 'controller_api' plugin from: {{ controller_api_plugin }}"
+
     - name: Wait for Controller to come up
       uri:
         url: "https://{{ controller_hostname }}/api/v2/ping"
@@ -95,7 +115,7 @@
 
     - name: Get the organization ID
       set_fact:
-        controller_organization_id: "{{ lookup('awx.awx.controller_api', 'organizations', query_params={ 'name': 'Default' } ,host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=false) }}"
+        controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={ 'name': 'Default' } ,host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=false) }}"
 
     - name: "Set empty lists for testing"
       set_fact:

--- a/examples/configure_controller_export_model.yml
+++ b/examples/configure_controller_export_model.yml
@@ -14,6 +14,26 @@
   # controller_password: changeme
   pre_tasks:
 
+    - block:
+        - name: "Check if the collection ansible.controller is installed"
+          set_fact:
+            ansible_controller_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i ansible.controllersss') }}"
+      rescue:
+        - name: "Check if the collection awx.awx is installed"
+          set_fact:
+            awx_awx_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i awx.awx') }}"
+      always:
+        - name: "Set the collection providing the controller_api lookup plugin"
+          set_fact:
+            controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api' if awx_awx_collection_installed is defined) | default('NONE') }}"
+        - name: "Fail if no collection is detected"
+          fail:
+            msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."
+          when: controller_api_plugin is match('NONE')
+        - name: "Show the plugin we are using"
+          debug:
+            msg: "Using the 'controller_api' plugin from: {{ controller_api_plugin }}"
+
     - name: Wait for Controller to come up
       uri:
         url: "{{ controller_hostname }}/api/v2/ping"

--- a/examples/tasks/differential.yml
+++ b/examples/tasks/differential.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get the API list of all {{ differential_item.name }} in the Default Organization"
   set_fact:
-    controller_api_results: "{{ lookup('awx.awx.controller_api', differential_item.name, query_params={ 'organization': controller_organization_id.id } ,host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=false) }}"
+    controller_api_results: "{{ lookup(controller_api_plugin, differential_item.name, query_params={ 'organization': controller_organization_id.id } ,host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=false) }}"
 
 - name: "Find the difference of {{ differential_item.name }} between what is on the Controller versus curated list."
   set_fact:

--- a/playbooks/configure_awx.yml
+++ b/playbooks/configure_awx.yml
@@ -39,6 +39,26 @@
     - redhat_cop.controller_configuration
   pre_tasks:
 
+    - block:
+        - name: "Check if the collection ansible.controller is installed"
+          set_fact:
+            ansible_controller_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i ansible.controllersss') }}"
+      rescue:
+        - name: "Check if the collection awx.awx is installed"
+          set_fact:
+            awx_awx_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i awx.awx') }}"
+      always:
+        - name: "Set the collection providing the controller_api lookup plugin"
+          set_fact:
+            controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api' if awx_awx_collection_installed is defined) | default('NONE') }}"
+        - name: "Fail if no collection is detected"
+          fail:
+            msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."
+          when: controller_api_plugin is match('NONE')
+        - name: "Show the plugin we are using"
+          debug:
+            msg: "Using the 'controller_api' plugin from: {{ controller_api_plugin }}"
+
     - name: Include vars from configs directory
       include_vars:
         dir: "{{ controller_configs_dir | default((lookup('env','CONTROLLER_CONFIGS_DIR') == '') | ternary('./configs', lookup('env','CONTROLLER_CONFIGS_DIR'))) }}"

--- a/playbooks/configure_awx.yml
+++ b/playbooks/configure_awx.yml
@@ -39,26 +39,6 @@
     - redhat_cop.controller_configuration
   pre_tasks:
 
-    - block:
-        - name: "Check if the collection ansible.controller is installed"
-          set_fact:
-            ansible_controller_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i ansible.controllersss') }}"
-      rescue:
-        - name: "Check if the collection awx.awx is installed"
-          set_fact:
-            awx_awx_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i awx.awx') }}"
-      always:
-        - name: "Set the collection providing the controller_api lookup plugin"
-          set_fact:
-            controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api' if awx_awx_collection_installed is defined) | default('NONE') }}"
-        - name: "Fail if no collection is detected"
-          fail:
-            msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."
-          when: controller_api_plugin is match('NONE')
-        - name: "Show the plugin we are using"
-          debug:
-            msg: "Using the 'controller_api' plugin from: {{ controller_api_plugin }}"
-
     - name: Include vars from configs directory
       include_vars:
         dir: "{{ controller_configs_dir | default((lookup('env','CONTROLLER_CONFIGS_DIR') == '') | ternary('./configs', lookup('env','CONTROLLER_CONFIGS_DIR'))) }}"

--- a/playbooks/configure_controller.yml
+++ b/playbooks/configure_controller.yml
@@ -39,6 +39,26 @@
     - redhat_cop.controller_configuration
   pre_tasks:
 
+    - block:
+        - name: "Check if the collection ansible.controller is installed"
+          set_fact:
+            ansible_controller_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i ansible.controllersss') }}"
+      rescue:
+        - name: "Check if the collection awx.awx is installed"
+          set_fact:
+            awx_awx_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i awx.awx') }}"
+      always:
+        - name: "Set the collection providing the controller_api lookup plugin"
+          set_fact:
+            controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api' if awx_awx_collection_installed is defined) | default('NONE') }}"
+        - name: "Fail if no collection is detected"
+          fail:
+            msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."
+          when: controller_api_plugin is match('NONE')
+        - name: "Show the plugin we are using"
+          debug:
+            msg: "Using the 'controller_api' plugin from: {{ controller_api_plugin }}"
+
     - name: Include vars from configs directory
       include_vars:
         dir: "{{ controller_configs_dir | default((lookup('env','CONTROLLER_CONFIGS_DIR') == '') | ternary('./configs', lookup('env','CONTROLLER_CONFIGS_DIR'))) }}"

--- a/playbooks/configure_controller.yml
+++ b/playbooks/configure_controller.yml
@@ -39,26 +39,6 @@
     - redhat_cop.controller_configuration
   pre_tasks:
 
-    - block:
-        - name: "Check if the collection ansible.controller is installed"
-          set_fact:
-            ansible_controller_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i ansible.controllersss') }}"
-      rescue:
-        - name: "Check if the collection awx.awx is installed"
-          set_fact:
-            awx_awx_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i awx.awx') }}"
-      always:
-        - name: "Set the collection providing the controller_api lookup plugin"
-          set_fact:
-            controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api' if awx_awx_collection_installed is defined) | default('NONE') }}"
-        - name: "Fail if no collection is detected"
-          fail:
-            msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."
-          when: controller_api_plugin is match('NONE')
-        - name: "Show the plugin we are using"
-          debug:
-            msg: "Using the 'controller_api' plugin from: {{ controller_api_plugin }}"
-
     - name: Include vars from configs directory
       include_vars:
         dir: "{{ controller_configs_dir | default((lookup('env','CONTROLLER_CONFIGS_DIR') == '') | ternary('./configs', lookup('env','CONTROLLER_CONFIGS_DIR'))) }}"

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -46,50 +46,20 @@ options:
 """
 
 EXAMPLES = """
-# Set the controller_api_plugin manually:
-- name: Set the name for the collection to provide the plugin controller_api
-  set_fact:
-    controller_api_plugin: "awx.awx.controller_api"
-
-# Set the controller_api_plugin automatically:
-- block:
-    - name: "Check if the collection ansible.controller is installed"
-      set_fact:
-        ansible_controller_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i ansible.controllersss') }}"
-  rescue:
-    - name: "Check if the collection awx.awx is installed"
-      set_fact:
-        awx_awx_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i awx.awx') }}"
-  always:
-    - name: "Set the collection providing the controller_api lookup plugin"
-      set_fact:
-        controller_api_plugin: "{{        ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) |
-                                   default('awx.awx.controller_api' if awx_awx_collection_installed is defined) |
-                                   default('NONE')
-                                }}"
-    - name: "Fail if no collection is detected"
-      fail:
-        msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."
-      when: controller_api_plugin is match('NONE')
-    - name: "Show the plugin we are using"
-      debug:
-        msg: "Using the 'controller_api' plugin from: {{ controller_api_plugin }}"
-
-# Examples for the lookup plugin
 - name: Get the organization ID
   set_fact:
-    controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={ 'name': 'Default' },
+    controller_organization_id: "{{ lookup('awx.awx.controller_api', 'organizations', query_params={ 'name': 'Default' },
       host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=false) }}"
 
 - name: "Get the API list of all Projects in the Default Organization"
   set_fact:
-    controller_api_results: "{{ lookup(controller_api_plugin, 'projects', query_params={ 'organization':
+    controller_api_results: "{{ lookup('awx.awx.controller_api', 'projects', query_params={ 'organization':
       controller_organization_id.id } ,host=controller_hostname, username=controller_username,
       password=controller_password, verify_ssl=false) }}"
 
 - name: "Get the API in a list form. Useful for making sure the results of one item is set to a list.
   set_fact:
-    controller_api_results: "{{ query(controller_api_plugin, 'inventories', query_params={ 'organization':
+    controller_api_results: "{{ query('awx.awx.controller_api', 'inventories', query_params={ 'organization':
       controller_organization_id.id } ,host=controller_hostname, username=controller_username,
       password=controller_password, verify_ssl=false) }}"
 

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -63,7 +63,10 @@ EXAMPLES = """
   always:
     - name: "Set the collection providing the controller_api lookup plugin"
       set_fact:
-        controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api' if awx_awx_collection_installed is defined) | default('NONE') }}"
+        controller_api_plugin: "{{        ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) |
+                                   default('awx.awx.controller_api' if awx_awx_collection_installed is defined) |
+                                   default('NONE')
+                                }}"
     - name: "Fail if no collection is detected"
       fail:
         msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -17,8 +17,8 @@ The following variables are required for that role to work properly:
 
 | Variable Name | Default Value | Required | Description |
 | :------------ | :-----------: | :------: | :---------- |
-| **`controller_api_plugin`**: | N/A | yes | Full path for the controller_api_plugin to be used. <br/> Can have two possible values: <br/>&nbsp;&nbsp;- awx.awx.controller_api             # For the community Collection version <br/>&nbsp;&nbsp;- ansible.controller.controller_api  # For the Red Hat Certified Collection version|
-| **`output_path:`** | N/A | yes | The path to the output directory where all the generated `yaml` files with the corresponding Objects as code will be written to. The default path is `/tmp/filetree_output`. |
+| `controller_api_plugin` | `ansible.controller` | yes | Full path for the controller_api_plugin to be used. <br/> Can have two possible values: <br/>&nbsp;&nbsp;- awx.awx.controller_api             # For the community Collection version <br/>&nbsp;&nbsp;- ansible.controller.controller_api  # For the Red Hat Certified Collection version|
+| `output_path` | `/tmp/filetree_output` | yes | The path to the output directory where all the generated `yaml` files with the corresponding Objects as code will be written to. |
 
 Dependencies
 ------------

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -15,7 +15,10 @@ Role Variables
 
 The following variables are required for that role to work properly:
 
-- **`output_path`**: The path to the output directory where all the generated `yaml` files with the corresponding Objects as code will be written to. The default path is `/tmp/filetree_output`.
+| Variable Name | Default Value | Required | Description |
+| :------------ | :-----------: | :------: | :---------- |
+| **`controller_api_plugin`**: | N/A | yes | Full path for the controller_api_plugin to be used. <br/> Can have two possible values: <br/>&nbsp;&nbsp;- awx.awx.controller_api             # For the community Collection version <br/>&nbsp;&nbsp;- ansible.controller.controller_api  # For the Red Hat Certified Collection version|
+| **`output_path:`** | N/A | yes | The path to the output directory where all the generated `yaml` files with the corresponding Objects as code will be written to. The default path is `/tmp/filetree_output`. |
 
 Dependencies
 ------------

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -29,6 +29,4 @@ output_path: "/tmp/filetree_output"
 # Maximum number of objects to return from the list. If a list view returns more an max_objects an exception will be raised
 query_controller_api_max_objects: 10000
 
-# Collection to access the plugin 'controller_api'
-controller_api_plugin: "ansible.controller"
 ...

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -28,4 +28,7 @@ output_path: "/tmp/filetree_output"
 
 # Maximum number of objects to return from the list. If a list view returns more an max_objects an exception will be raised
 query_controller_api_max_objects: 10000
+
+# Collection to access the plugin 'controller_api'
+controller_api_plugin: "ansible.controller"
 ...

--- a/roles/filetree_create/tasks/all.yml
+++ b/roles/filetree_create/tasks/all.yml
@@ -18,7 +18,7 @@
 
 - name: "Check if the connection is to an Ansible Tower or to Automation Platform"
   set_fact:
-    is_aap: "{{ lookup('ansible.controller.controller_api', 'ping', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs).version is version('4.0.0', '>=') }}"
+    is_aap: "{{ lookup(controller_api_plugin, 'ping', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs).version is version('4.0.0', '>=') }}"
 
 - block:
     - name: "Export Inventories and related Groups and Hosts"

--- a/roles/filetree_create/tasks/credential_types.yml
+++ b/roles/filetree_create/tasks/credential_types.yml
@@ -1,12 +1,12 @@
 ---
 - name: "Get current Credential Types from the API when AAP"
   set_fact:
-    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/', query_params={ 'managed': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    credential_types_lookvar: "{{ query(controller_api_plugin, 'api/v2/credential_types/', query_params={ 'managed': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
   when: is_aap
 
 - name: "Get current Credential Types from the API when Tower"
   set_fact:
-    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/', query_params={ 'managed_by_tower': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    credential_types_lookvar: "{{ query(controller_api_plugin, 'api/v2/credential_types/', query_params={ 'managed_by_tower': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
   when: not is_aap
 
 - name: "Create the output directory for credential types: {{ output_path }}"

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Credentials from the API"
   set_fact:
-    credentials_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credentials/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    credentials_lookvar: "{{ query(controller_api_plugin, 'api/v2/credentials/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Group the credentials by Organization"
   set_fact:

--- a/roles/filetree_create/tasks/execution_environments.yml
+++ b/roles/filetree_create/tasks/execution_environments.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Execution Environments from the API"
   set_fact:
-    execution_environments_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/execution_environments/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    execution_environments_lookvar: "{{ query(controller_api_plugin, 'api/v2/execution_environments/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Create the output directory for execution environments: {{ output_path }}"
   file:

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get the inventoryes from the API"
   set_fact:
-    inventory_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/inventories/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects, query_params={
+    inventory_lookvar: "{{ query(controller_api_plugin, 'api/v2/inventories/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects, query_params={
                           'not__kind': 'smart',
                           'order_by': 'organization'
                         }
@@ -19,13 +19,13 @@
         'host_filter': inventory_lookvar_item.host_filter,
         'kind': inventory_lookvar_item.kind,
         'variables': inventory_lookvar_item.variables,
-        'inventory_sources': query('ansible.controller.controller_api', inventory_lookvar_item.related.inventory_sources, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) if inventory_lookvar_item.has_inventory_sources else [],
-        'hosts': query('ansible.controller.controller_api', inventory_lookvar_item.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) if not inventory_lookvar_item.has_inventory_sources else [],
-        'groups': query('ansible.controller.controller_api', inventory_lookvar_item.related.groups, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) if not inventory_lookvar_item.has_inventory_sources else []
+        'inventory_sources': query(controller_api_plugin, inventory_lookvar_item.related.inventory_sources, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) if inventory_lookvar_item.has_inventory_sources else [],
+        'hosts': query(controller_api_plugin, inventory_lookvar_item.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) if not inventory_lookvar_item.has_inventory_sources else [],
+        'groups': query(controller_api_plugin, inventory_lookvar_item.related.groups, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) if not inventory_lookvar_item.has_inventory_sources else []
       }]}) }}"
     needed_paths: "{{ ((needed_paths | default([])) + [inventory_lookvar_item_organization]) | flatten | unique }}"
   vars:
-    inventory_lookvar_item_organization: "{{ lookup('ansible.controller.controller_api', 'api/v2/organizations/'+(inventory_lookvar_item.organization|string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true)['name'] }}"
+    inventory_lookvar_item_organization: "{{ lookup(controller_api_plugin, 'api/v2/organizations/'+(inventory_lookvar_item.organization|string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true)['name'] }}"
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: inventory_lookvar_item

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Job Templates from the API"
   set_fact:
-    job_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/job_templates/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    job_templates_lookvar: "{{ query(controller_api_plugin, 'api/v2/job_templates/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Group the job_templates by Organization"
   set_fact:

--- a/roles/filetree_create/tasks/main.yml
+++ b/roles/filetree_create/tasks/main.yml
@@ -1,13 +1,25 @@
 ---
 # tasks file for filetree_create
 - block:
-    - name: "Check if the controller_api plugin is correctly selected"
-      ansible.builtin.assert:
-        that:
-          - controller_api_plugin is defined
-          - controller_api_plugin is match('awx.awx.controller_api') or controller_api_plugin is match('ansible.controller.controller_api')
-        fail_msg: "'controller_api_plugin' variable must be defined with one of the following possible values: 'awx.awx.controller_api' or 'ansible.controller.controller_api'"
-        quiet: true
+    - block:
+        - name: "Check if the collection ansible.controller is installed"
+          set_fact:
+            ansible_controller_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i ansible.controller') }}"
+      rescue:
+        - name: "Check if the collection awx.awx is installed"
+          set_fact:
+            awx_awx_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i awx.awx') }}"
+      always:
+        - name: "Set the collection providing the controller_api lookup plugin"
+          set_fact:
+            controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api' if awx_awx_collection_installed is defined) | default('NONE') }}"
+        - name: "Fail if no collection is detected"
+          fail:
+            msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."
+          when: controller_api_plugin is match('NONE')
+        - name: "Show the plugin we are using"
+          debug:
+            msg: "Using the 'controller_api' plugin from: {{ controller_api_plugin }}"
 
     - name: "Check if the required input variables are present"
       ansible.builtin.assert:

--- a/roles/filetree_create/tasks/main.yml
+++ b/roles/filetree_create/tasks/main.yml
@@ -1,22 +1,34 @@
 ---
 # tasks file for filetree_create
-- name: "Check if the required input variables are present"
-  assert:
-    that:
-      - input_tag is defined
-      - (input_tag | type_debug) == 'list'
-    fail_msg: 'A variable called ''input_tag'' of type ''list'' is needed: -e ''{input_tag: [organizations, projects]}'''
-    quiet: true
+- block:
+    - name: "Check if the controller_api plugin is correctly selected"
+      ansible.builtin.assert:
+        that:
+          - controller_api_plugin is defined
+          - controller_api_plugin is match('awx.awx.controller_api') or controller_api_plugin is match('ansible.controller.controller_api')
+        fail_msg: "'controller_api_plugin' variable must be defined with one of the following possible values: 'awx.awx.controller_api' or 'ansible.controller.controller_api'"
+        quiet: true
 
-- name: "Check if the required input values are correct"
-  assert:
-    that:
-      - tag_item in valid_tags
-    fail_msg: "The valid tags are the following ones: {{ valid_tags | join(', ') }}"
-    quiet: true
-  loop: "{{ input_tag }}"
-  loop_control:
-    loop_var: tag_item
+    - name: "Check if the required input variables are present"
+      ansible.builtin.assert:
+        that:
+          - input_tag is defined
+          - (input_tag | type_debug) == 'list'
+        fail_msg: 'A variable called ''input_tag'' of type ''list'' is needed: -e ''{input_tag: [organizations, projects]}'''
+        quiet: true
+
+    - name: "Check if the required input values are correct"
+      ansible.builtin.assert:
+        that:
+          - tag_item in valid_tags
+        fail_msg: "The valid tags are the following ones: {{ valid_tags | join(', ') }}"
+        quiet: true
+      loop: "{{ input_tag }}"
+      loop_control:
+        loop_var: tag_item
+
+  tags:
+    - always
 
 - name: "Include Tasks to get all objects of type {{ input_tag }}"
   include_tasks: all.yml

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Notification Templates from the API"
   set_fact:
-    notification_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/notification_templates/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    notification_templates_lookvar: "{{ query(controller_api_plugin, 'api/v2/notification_templates/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Group the notification templates by Organization"
   set_fact:

--- a/roles/filetree_create/tasks/organizations.yml
+++ b/roles/filetree_create/tasks/organizations.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Organizations from the API"
   set_fact:
-    orgs_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/organizations/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    orgs_lookvar: "{{ query(controller_api_plugin, 'api/v2/organizations/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Create the output directory for organizations: {{ output_path }}/{{ current_organization_dir.name }}"
   file:

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Projects from the API"
   set_fact:
-    projects_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/projects/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    projects_lookvar: "{{ query(controller_api_plugin, 'api/v2/projects/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Group the projects by Organization"
   set_fact:

--- a/roles/filetree_create/tasks/team_roles.yml
+++ b/roles/filetree_create/tasks/team_roles.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Team Roles from the API"
   set_fact:
-    team_roles_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/teams/' + teamid +'/roles/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    team_roles_lookvar: "{{ query(controller_api_plugin, 'api/v2/teams/' + teamid +'/roles/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Create the output directory for team roles: {{ output_path }}"
   file:

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Teams from the API"
   set_fact:
-    teams_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/teams/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    teams_lookvar: "{{ query(controller_api_plugin, 'api/v2/teams/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Group the teams by Organization"
   set_fact:

--- a/roles/filetree_create/tasks/user_roles.yml
+++ b/roles/filetree_create/tasks/user_roles.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Users from the API"
   set_fact:
-    user_roles_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/users/' + username +'/roles/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    user_roles_lookvar: "{{ query(controller_api_plugin, 'api/v2/users/' + username +'/roles/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Create the output directory for user roles: {{ output_path }}"
   file:

--- a/roles/filetree_create/tasks/users.yml
+++ b/roles/filetree_create/tasks/users.yml
@@ -1,13 +1,13 @@
 ---
 - name: "Get current Users from the API"
   set_fact:
-    users_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/users/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    users_lookvar: "{{ query(controller_api_plugin, 'api/v2/users/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Add the users the Organizations information"
   set_fact:
     current_users: "{{ (current_users | default([])) + [user_lookvar_item | combine({'organizations': user_lookvar_item_organizations})] }}"
   vars:
-    user_lookvar_item_organizations: "{{ query('ansible.controller.controller_api', user_lookvar_item.related.organizations, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) | selectattr('name', 'defined') | map(attribute='name') }}"
+    user_lookvar_item_organizations: "{{ query(controller_api_plugin, user_lookvar_item.related.organizations, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) | selectattr('name', 'defined') | map(attribute='name') }}"
   loop: "{{ users_lookvar }}"
   loop_control:
     loop_var: user_lookvar_item

--- a/roles/filetree_create/tasks/workflow_job_template_nodes.yml
+++ b/roles/filetree_create/tasks/workflow_job_template_nodes.yml
@@ -4,8 +4,8 @@
     wfjtn_lookvar: "{{ (wfjtn_lookvar | default({})) | combine({wfjtn_lookvar_item.summary_fields.workflow_job_template.name: {'nodes': (wfjtn_lookvar[wfjtn_lookvar_item.summary_fields.workflow_job_template.name]['nodes']|default([]) + [wfjtn_lookvar_item] | flatten), 'organization': workflow_job_template_organization} }) }}"
     needed_paths: "{{ ((needed_paths | default([])) + [workflow_job_template_organization]) | flatten | unique }}"
   vars:
-    workflow_job_template_organization: "{{ query('ansible.controller.controller_api', wfjtn_lookvar_item.related.workflow_job_template, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
-  loop: "{{ query('ansible.controller.controller_api', 'api/v2/workflow_job_template_nodes/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    workflow_job_template_organization: "{{ query(controller_api_plugin, wfjtn_lookvar_item.related.workflow_job_template, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+  loop: "{{ query(controller_api_plugin, 'api/v2/workflow_job_template_nodes/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
   loop_control:
     loop_var: wfjtn_lookvar_item
     label: "{{ workflow_job_template_organization + ' - ' + wfjtn_lookvar_item.summary_fields.workflow_job_template.name }}"
@@ -27,7 +27,7 @@
     mode: '0644'
   vars:
     workflow_job_template_name: "{{ current_wfjtn_asset_value.key }}"
-    # workflow_job_template_organization: "{{ query('ansible.controller.controller_api', current_wfjtn_asset_value.value.wfjtn_url, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].summary_fields.organization.name | default('ToDo: The WF node  must have an organization') }}"
+    # workflow_job_template_organization: "{{ query(controller_api_plugin, current_wfjtn_asset_value.value.wfjtn_url, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].summary_fields.organization.name | default('ToDo: The WF node  must have an organization') }}"
   loop: "{{ wfjtn_lookvar | default({}) | dict2items }}"
   loop_control:
     loop_var: current_wfjtn_asset_value

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Workflow Job Templates from the API"
   set_fact:
-    workflow_job_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/workflow_job_templates/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    workflow_job_templates_lookvar: "{{ query(controller_api_plugin, 'api/v2/workflow_job_templates/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Group the workflow job templates by Organization"
   set_fact:

--- a/roles/filetree_create/templates/current_groups.j2
+++ b/roles/filetree_create/templates/current_groups.j2
@@ -5,6 +5,6 @@ configure_tower_groups:
     description: "{{ group.description }}"
     inventory: "{{ current_groups_asset_value.name }}"
     hosts:
-{{ query('ansible.controller.controller_api', group.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) | selectattr("name", "defined") | map(attribute="name") | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
+{{ query(controller_api_plugin, group.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) | selectattr("name", "defined") | map(attribute="name") | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
 {%- endfor -%}
 ...

--- a/roles/filetree_create/templates/current_workflow_job_template_nodes.j2
+++ b/roles/filetree_create/templates/current_workflow_job_template_nodes.j2
@@ -12,19 +12,19 @@ controller_workflow_nodes:
 {% if node.success_nodes is defined and node.success_nodes | length > 0 %}
     success_nodes:
 {% for success in node.success_nodes %}
-      - {{ query('ansible.controller.controller_api', 'workflow_job_template_nodes/'+(success | string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
+      - {{ query(controller_api_plugin, 'workflow_job_template_nodes/'+(success | string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
 {% endfor %}
 {% endif %}
 {% if node.always_nodes and node.always_nodes | length > 0 %}
     always_nodes:
 {% for always in node.always_nodes %}
-      - {{ query('ansible.controller.controller_api', 'workflow_job_template_nodes/'+(always | string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
+      - {{ query(controller_api_plugin, 'workflow_job_template_nodes/'+(always | string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
 {% endfor %}
 {% endif %}
 {% if node.failure_nodes and node.failure_nodes | length > 0 %}
     failure_nodes:
 {% for failure in node.failure_nodes %}
-      - {{ query('ansible.controller.controller_api', 'workflow_job_template_nodes/'+(failure | string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
+      - {{ query(controller_api_plugin, 'workflow_job_template_nodes/'+(failure | string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/roles/filetree_read/tests/config-controller-filetree.yml
+++ b/roles/filetree_read/tests/config-controller-filetree.yml
@@ -7,26 +7,6 @@
     controller_configuration_projects_async_delay: 2
   pre_tasks:
     - block:
-        - name: "Check if the collection ansible.controller is installed"
-          set_fact:
-            ansible_controller_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i ansible.controllersss') }}"
-      rescue:
-        - name: "Check if the collection awx.awx is installed"
-          set_fact:
-            awx_awx_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i awx.awx') }}"
-      always:
-        - name: "Set the collection providing the controller_api lookup plugin"
-          set_fact:
-            controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api' if awx_awx_collection_installed is defined) | default('NONE') }}"
-        - name: "Fail if no collection is detected"
-          fail:
-            msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."
-          when: controller_api_plugin is match('NONE')
-        - name: "Show the plugin we are using"
-          debug:
-            msg: "Using the 'controller_api' plugin from: {{ controller_api_plugin }}"
-
-    - block:
         - name: Include Tasks to load Galaxy credentials to be added to Organizations
           ansible.builtin.include_role:
             name: redhat_cop.controller_configuration.filetree_read

--- a/roles/filetree_read/tests/config-controller-filetree.yml
+++ b/roles/filetree_read/tests/config-controller-filetree.yml
@@ -7,6 +7,26 @@
     controller_configuration_projects_async_delay: 2
   pre_tasks:
     - block:
+        - name: "Check if the collection ansible.controller is installed"
+          set_fact:
+            ansible_controller_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i ansible.controllersss') }}"
+      rescue:
+        - name: "Check if the collection awx.awx is installed"
+          set_fact:
+            awx_awx_collection_installed: "{{ lookup('pipe', 'ansible-galaxy collection list | grep -i awx.awx') }}"
+      always:
+        - name: "Set the collection providing the controller_api lookup plugin"
+          set_fact:
+            controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api' if awx_awx_collection_installed is defined) | default('NONE') }}"
+        - name: "Fail if no collection is detected"
+          fail:
+            msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."
+          when: controller_api_plugin is match('NONE')
+        - name: "Show the plugin we are using"
+          debug:
+            msg: "Using the 'controller_api' plugin from: {{ controller_api_plugin }}"
+
+    - block:
         - name: Include Tasks to load Galaxy credentials to be added to Organizations
           ansible.builtin.include_role:
             name: redhat_cop.controller_configuration.filetree_read

--- a/roles/object_diff/README.md
+++ b/roles/object_diff/README.md
@@ -17,9 +17,9 @@ The following Variables set the organization where should be applied the configu
 
 | Variable Name | Default Value | Required | Description |
 | :------------ | :-----------: | :------: | :---------- |
-| `controller_api_plugin`: | N/A | yes | Full path for the controller_api_plugin to be used. <br/> Can have two possible values: <br/>&nbsp;&nbsp;- awx.awx.controller_api             # For the community Collection version <br/>&nbsp;&nbsp;- ansible.controller.controller_api  # For the Red Hat Certified Collection version|
-|`drop_user_external_accounts:`|N/A|no|When is true, all users will be taken to compare with SCM configuration as code|
-|`drop_teams:`|N/A|no|When is true, all teams will be taken to compare with SCM configuration as code|
+| `controller_api_plugin` | `ansible.controller` | yes | Full path for the controller_api_plugin to be used. <br/> Can have two possible values: <br/>&nbsp;&nbsp;- awx.awx.controller_api             # For the community Collection version <br/>&nbsp;&nbsp;- ansible.controller.controller_api  # For the Red Hat Certified Collection version|
+| `drop_user_external_accounts` | `False` | no | When is true, all users will be taken to compare with SCM configuration as code |
+| `drop_teams` | `False` | no | When is true, all teams will be taken to compare with SCM configuration as code |
 
 Role Tags
 ----------------

--- a/roles/object_diff/README.md
+++ b/roles/object_diff/README.md
@@ -7,7 +7,7 @@ An ansible role to manage the object diff of the AWX or Automation Controller co
 Requirements
 ------------
 
-ansible-galaxy collection install -r tests/collections/requirements.yml to be installed Currently: awx.awx or ansible.controller and redhat_cop.controller_configuration.
+`ansible-galaxy collection install -r tests/collections/requirements.yml` to be installed. Currently: `awx.awx` or `ansible.controller` and `redhat_cop.controller_configuration`.
 
 Role Variables
 --------------
@@ -15,8 +15,9 @@ Role Variables
 ### Organization and Environment Variables
 The following Variables set the organization where should be applied the configuration, the absolute or relative of the directory structure where the variables will be stored and the life-cycle enviroment to use.
 
-|Variable Name|Default Value|Required|Description|
-|:---:|:---:|:---:|:---:|
+| Variable Name | Default Value | Required | Description |
+| :------------ | :-----------: | :------: | :---------- |
+| `controller_api_plugin`: | N/A | yes | Full path for the controller_api_plugin to be used. <br/> Can have two possible values: <br/>&nbsp;&nbsp;- awx.awx.controller_api             # For the community Collection version <br/>&nbsp;&nbsp;- ansible.controller.controller_api  # For the Red Hat Certified Collection version|
 |`drop_user_external_accounts:`|N/A|no|When is true, all users will be taken to compare with SCM configuration as code|
 |`drop_teams:`|N/A|no|When is true, all teams will be taken to compare with SCM configuration as code|
 

--- a/roles/object_diff/defaults/main.yml
+++ b/roles/object_diff/defaults/main.yml
@@ -47,4 +47,7 @@ controller_configuration_object_diff_tasks:
   - {name: credentials, var: controller_credentials, tags: credentials}
   - {name: credential_types, var: controller_credential_types, tags: credential_types}
   - {name: organizations, var: controller_organizations, tags: organizations}
+
+# Collection to access the plugin 'controller_api'
+controller_api_plugin: "ansible.controller"
 ...

--- a/roles/object_diff/defaults/main.yml
+++ b/roles/object_diff/defaults/main.yml
@@ -48,6 +48,4 @@ controller_configuration_object_diff_tasks:
   - {name: credential_types, var: controller_credential_types, tags: credential_types}
   - {name: organizations, var: controller_organizations, tags: organizations}
 
-# Collection to access the plugin 'controller_api'
-controller_api_plugin: "ansible.controller"
 ...

--- a/roles/object_diff/tasks/credential_types.yml
+++ b/roles/object_diff/tasks/credential_types.yml
@@ -2,12 +2,12 @@
 # tasks file for controller_credential_types
 - name: Get the organization ID
   set_fact:
-    __controller_organization_id: "{{ lookup('ansible.controller.controller_api', 'organizations', query_params={ 'name': orgs },
+    __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={ 'name': orgs },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 
 - name: "OBJECT DIFF: Get the API list of all Projects {{ orgs }} Organization"
   set_fact:
-    __controller_api_credential_types: "{{ query('ansible.controller.controller_api', 'credential_types',
+    __controller_api_credential_types: "{{ query(controller_api_plugin, 'credential_types',
       query_params={ 'organization': __controller_organization_id.id },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 

--- a/roles/object_diff/tasks/credentials.yml
+++ b/roles/object_diff/tasks/credentials.yml
@@ -2,12 +2,12 @@
 # tasks file for controller_credentials
 - name: Get the organization ID
   set_fact:
-    __controller_organization_id: "{{ lookup('ansible.controller.controller_api', 'organizations', query_params={ 'name': orgs },
+    __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={ 'name': orgs },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 
 - name: "OBJECT DIFF: Get the API list of all Projects {{ orgs }} Organization"
   set_fact:
-    __controller_api_credentials: "{{ query('ansible.controller.controller_api', 'credentials',
+    __controller_api_credentials: "{{ query(controller_api_plugin, 'credentials',
       query_params={ 'organization': __controller_organization_id.id },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 

--- a/roles/object_diff/tasks/groups.yml
+++ b/roles/object_diff/tasks/groups.yml
@@ -1,12 +1,12 @@
 ---
 - name: Get the organization ID
   set_fact:
-    controller_organization_id: "{{ lookup('ansible.controller.controller_api', 'organizations', query_params={ 'name': orgs },
+    controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={ 'name': orgs },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 
 - name: "OBJECT DIFF: Get the API list of all inventories"
   set_fact:
-    __controller_api_inventories: "{{ query('ansible.controller.controller_api', 'inventories',
+    __controller_api_inventories: "{{ query(controller_api_plugin, 'inventories',
       query_params={
         'organization': controller_organization_id.id,
         'has_inventory_sources': 'false',
@@ -18,7 +18,7 @@
 
 - name: "OBJECT DIFF: Get the API list of all groups in the inventories at organization {{ orgs }}"
   set_fact:
-    __controller_api_groups: "{{ (__controller_api_groups | default([])) + query('ansible.controller.controller_api', 'groups',
+    __controller_api_groups: "{{ (__controller_api_groups | default([])) + query(controller_api_plugin, 'groups',
       query_params={ 'inventory': current_inventory.id },
       host=controller_hostname, username=controller_username,
       password=controller_password, verify_ssl=false) }}"

--- a/roles/object_diff/tasks/hosts.yml
+++ b/roles/object_diff/tasks/hosts.yml
@@ -1,12 +1,12 @@
 ---
 - name: Get the organization ID
   set_fact:
-    controller_organization_id: "{{ lookup('ansible.controller.controller_api', 'organizations', query_params={ 'name': orgs },
+    controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={ 'name': orgs },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 
 - name: "OBJECT DIFF: Get the API list of all inventories"
   set_fact:
-    __controller_api_inventories: "{{ query('ansible.controller.controller_api', 'inventories',
+    __controller_api_inventories: "{{ query(controller_api_plugin, 'inventories',
       query_params={
         'organization': controller_organization_id.id,
         'has_inventory_sources': 'false',
@@ -18,7 +18,7 @@
 
 - name: "OBJECT DIFF: Get the API list of all hosts in the inventories at organization {{ orgs }}"
   set_fact:
-    __controller_api_hosts: "{{ (__controller_api_hosts | default([])) + query('ansible.controller.controller_api', 'hosts',
+    __controller_api_hosts: "{{ (__controller_api_hosts | default([])) + query(controller_api_plugin, 'hosts',
       query_params={ 'inventory': current_inventory.id },
       host=controller_hostname, username=controller_username,
       password=controller_password, verify_ssl=false) }}"

--- a/roles/object_diff/tasks/inventories.yml
+++ b/roles/object_diff/tasks/inventories.yml
@@ -1,12 +1,12 @@
 ---
 - name: Get the organization ID
   set_fact:
-    __controller_organization_id: "{{ lookup('ansible.controller.controller_api', 'organizations', query_params={ 'name': orgs },
+    __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={ 'name': orgs },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 
 - name: "OBJECT DIFF: Get the API list of all Inventories"
   set_fact:
-    __controller_api_inventories: "{{ query('ansible.controller.controller_api', 'inventories',
+    __controller_api_inventories: "{{ query(controller_api_plugin, 'inventories',
       query_params={ 'organization': __controller_organization_id.id },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 

--- a/roles/object_diff/tasks/inventory_sources.yml
+++ b/roles/object_diff/tasks/inventory_sources.yml
@@ -1,12 +1,12 @@
 ---
 - name: Get the organization ID
   set_fact:
-    __controller_organization_id: "{{ lookup('ansible.controller.controller_api', 'organizations', query_params={ 'name': orgs },
+    __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={ 'name': orgs },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 
 - name: "OBJECT DIFF: Get the API list of all Inventories"
   set_fact:
-    __controller_api_inventory_sources: "{{ query('ansible.controller.controller_api', 'inventory_sources',
+    __controller_api_inventory_sources: "{{ query(controller_api_plugin, 'inventory_sources',
       query_params={ 'organization': __controller_organization_id.id },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 

--- a/roles/object_diff/tasks/job_templates.yml
+++ b/roles/object_diff/tasks/job_templates.yml
@@ -1,12 +1,12 @@
 ---
 - name: Get the organization ID
   set_fact:
-    __controller_organization_id: "{{ lookup('ansible.controller.controller_api', 'organizations', query_params={ 'name': orgs },
+    __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={ 'name': orgs },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 
 - name: "OBJECT DIFF: Get the API list of all Job Templates {{ orgs }} Organization"
   set_fact:
-    __controller_api_job_templates: "{{ query('ansible.controller.controller_api', 'job_templates',
+    __controller_api_job_templates: "{{ query(controller_api_plugin, 'job_templates',
       query_params={ 'organization': __controller_organization_id.id },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 

--- a/roles/object_diff/tasks/main.yml
+++ b/roles/object_diff/tasks/main.yml
@@ -1,14 +1,6 @@
 ---
 # tasks file for object_diff
 - block:
-    - name: "Check if the controller_api plugin is correctly selected"
-      ansible.builtin.assert:
-        that:
-          - controller_api_plugin is defined
-          - controller_api_plugin is match('awx.awx.controller_api') or controller_api_plugin is match('ansible.controller.controller_api')
-        fail_msg: "'controller_api_plugin' variable must be defined with one of the following possible values: 'awx.awx.controller_api' or 'ansible.controller.controller_api'"
-        quiet: true
-
     - name: "Get the Authentication Token for the future requests"
       uri:
         url: "https://{{ controller_hostname }}/api/v2/tokens/"

--- a/roles/object_diff/tasks/main.yml
+++ b/roles/object_diff/tasks/main.yml
@@ -1,5 +1,14 @@
 ---
+# tasks file for object_diff
 - block:
+    - name: "Check if the controller_api plugin is correctly selected"
+      ansible.builtin.assert:
+        that:
+          - controller_api_plugin is defined
+          - controller_api_plugin is match('awx.awx.controller_api') or controller_api_plugin is match('ansible.controller.controller_api')
+        fail_msg: "'controller_api_plugin' variable must be defined with one of the following possible values: 'awx.awx.controller_api' or 'ansible.controller.controller_api'"
+        quiet: true
+
     - name: "Get the Authentication Token for the future requests"
       uri:
         url: "https://{{ controller_hostname }}/api/v2/tokens/"

--- a/roles/object_diff/tasks/organizations.yml
+++ b/roles/object_diff/tasks/organizations.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Gets current Organizations configured"
   set_fact:
-    __controller_api_organizations: "{{ query('ansible.controller.controller_api', 'organizations',
+    __controller_api_organizations: "{{ query(controller_api_plugin, 'organizations',
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs) }}"
 
 - name: "OBJECT DIFF: Find the difference of Organizations between what is on the Controller versus curated list."

--- a/roles/object_diff/tasks/projects.yml
+++ b/roles/object_diff/tasks/projects.yml
@@ -1,12 +1,12 @@
 ---
 - name: Get the organization ID
   set_fact:
-    __controller_organization_id: "{{ lookup('ansible.controller.controller_api', 'organizations', query_params={ 'name': orgs },
+    __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={ 'name': orgs },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 
 - name: "OBJECT DIFF: Get the API list of all Projects {{ orgs }} Organization"
   set_fact:
-    __controller_api_projects: "{{ query('ansible.controller.controller_api', 'projects',
+    __controller_api_projects: "{{ query(controller_api_plugin, 'projects',
       query_params={ 'organization': __controller_organization_id.id },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 

--- a/roles/object_diff/tasks/roles.yml
+++ b/roles/object_diff/tasks/roles.yml
@@ -1,13 +1,13 @@
 ---
 - name: "OBJECT DIFF: Get the current controller user to determine if it is super-admin"
   set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup('ansible.controller.controller_api', 'users', query_params={ 'username': controller_username },
+    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users', query_params={ 'username': controller_username },
         host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 - block:
 
     - name: "OBJECT DIFF: Get the API list of all roles"
       set_fact:
-        __controller_api_roles: "{{ query('ansible.controller.controller_api', 'roles',
+        __controller_api_roles: "{{ query(controller_api_plugin, 'roles',
           host=controller_hostname, username=controller_username,
           password=controller_password, verify_ssl=false) }}"
 

--- a/roles/object_diff/tasks/teams.yml
+++ b/roles/object_diff/tasks/teams.yml
@@ -1,17 +1,17 @@
 ---
 - name: "OBJECT DIFF: Get the current controller user to determine if it is super-admin"
   set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup('ansible.controller.controller_api', 'users', query_params={ 'username': controller_username },
+    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users', query_params={ 'username': controller_username },
         host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 - block:
     - name: Get the organization ID
       set_fact:
-        __controller_organization_id: "{{ lookup('ansible.controller.controller_api', 'organizations', query_params={ 'name': orgs },
+        __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={ 'name': orgs },
           host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 
     - name: "OBJECT DIFF: Get the API list of all teams {{ orgs }} Organization"
       set_fact:
-        __controller_api_teams: "{{ query('ansible.controller.controller_api', 'teams',
+        __controller_api_teams: "{{ query(controller_api_plugin, 'teams',
           query_params={ 'organization': __controller_organization_id.id },
           host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 

--- a/roles/object_diff/tasks/user_accounts.yml
+++ b/roles/object_diff/tasks/user_accounts.yml
@@ -2,12 +2,12 @@
 # tasks file for controller_ldap_settings
 - name: "OBJECT DIFF: Get the current controller user to determine if it is super-admin"
   set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup('ansible.controller.controller_api', 'users', query_params={ 'username': controller_username },
+    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users', query_params={ 'username': controller_username },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 
 - name: "OBJECT DIFF: Sets the current controller user to determine if it is super-admin"
   set_fact:
-    __controller_api_user_accounts: "{{ query('ansible.controller.controller_api', 'users',
+    __controller_api_user_accounts: "{{ query(controller_api_plugin, 'users',
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 
 - block:

--- a/roles/object_diff/tasks/workflow_job_templates.yml
+++ b/roles/object_diff/tasks/workflow_job_templates.yml
@@ -1,12 +1,12 @@
 ---
 - name: Get the organization ID
   set_fact:
-    __controller_organization_id: "{{ lookup('ansible.controller.controller_api', 'organizations', query_params={ 'name': orgs },
+    __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={ 'name': orgs },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 
 - name: "OBJECT DIFF: Get the API list of all Workflow Job Templates"
   set_fact:
-    __controller_api_workflow_job_templates: "{{ query('ansible.controller.controller_api', 'workflow_job_templates',
+    __controller_api_workflow_job_templates: "{{ query(controller_api_plugin, 'workflow_job_templates',
       query_params={ 'organization': __controller_organization_id.id },
       host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
 


### PR DESCRIPTION
add variable to set the plugin name to use everywhere

### What does this PR do?
Right now, the tasks in filetree_create and object_diff roles are using the `ansible.controller` collection to make use of the `controller_api` plugin, so anyone trying to use the `awx.awx` collection will get in trouble as the `ansible.controller` collection should not be present. To let the end users to chose freely what collection they want to use, I've modified the code to get that collection name from a variable, which must be defined with the correct value to work successfully.

### How should this be tested?
```
$ cat filetree_create.yml
---
- hosts: localhost
  connection: local
  gather_facts: false
  vars:
    controller_hostname: "{{ vault_controller_hostname }}"
    controller_username: "{{ vault_controller_username }}"
    controller_password: "{{ vault_controller_password }}"
    controller_validate_certs: "{{ vault_controller_validate_certs }}"
    controller_api_plugin: "ansible.controller.controller_api"
  pre_tasks:
    - name: "Check if the required input variables are present"
      assert:
        that:
          - input_tag is defined
          - (input_tag | type_debug) == 'list'
        fail_msg: 'A variable called ''input_tag'' of type ''list'' is needed: -e ''{input_tag: [organizations, projects]}'''
        quiet: true

    - name: "Check if the required input values are correct"
      assert:
        that:
          - tag_item in valid_tags
        fail_msg: "The valid tags are the following ones: {{ valid_tags | join(', ') }}"
        quiet: true
      loop: "{{ input_tag }}"
      loop_control:
        loop_var: tag_item
  roles:
    - redhat_cop.controller_configuration.filetree_create
...
$ ansible-playbook filetree_create.yml -e '{input_tag: [inventory], output_path: ~/iam/filetree_create.2.1.7 }'
```

### Is there a relevant Issue open for this?
No issue opened for this.

### Other Relevant info, PRs, etc.
N/A