### PR TITLE
Added query_controller_api_max_objects to filetree_create

### DIFF
--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -25,4 +25,7 @@ controller_workflow_job_templates: []
 
 # Output directory path
 output_path: "/tmp/filetree_output"
+
+# Maximum number of objects to return from the list. If a list view returns more an max_objects an exception will be raised
+query_controller_api_max_objects: 10000
 ...

--- a/roles/filetree_create/tasks/credential_types.yml
+++ b/roles/filetree_create/tasks/credential_types.yml
@@ -1,12 +1,12 @@
 ---
 - name: "Get current Credential Types from the API when AAP"
   set_fact:
-    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/', query_params={ 'managed': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/', query_params={ 'managed': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
   when: is_aap
 
 - name: "Get current Credential Types from the API when Tower"
   set_fact:
-    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/', query_params={ 'managed_by_tower': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/', query_params={ 'managed_by_tower': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
   when: not is_aap
 
 - name: "Create the output directory for credential types: {{ output_path }}"

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Credentials from the API"
   set_fact:
-    credentials_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credentials/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    credentials_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credentials/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Group the credentials by Organization"
   set_fact:

--- a/roles/filetree_create/tasks/execution_environments.yml
+++ b/roles/filetree_create/tasks/execution_environments.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Execution Environments from the API"
   set_fact:
-    execution_environments_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/execution_environments/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    execution_environments_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/execution_environments/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Create the output directory for execution environments: {{ output_path }}"
   file:

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get the inventoryes from the API"
   set_fact:
-    inventory_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/inventories/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, query_params={
+    inventory_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/inventories/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects, query_params={
                           'not__kind': 'smart',
                           'order_by': 'organization'
                         }
@@ -19,9 +19,9 @@
         'host_filter': inventory_lookvar_item.host_filter,
         'kind': inventory_lookvar_item.kind,
         'variables': inventory_lookvar_item.variables,
-        'inventory_sources': query('ansible.controller.controller_api', inventory_lookvar_item.related.inventory_sources, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=10000) if inventory_lookvar_item.has_inventory_sources else [],
-        'hosts': query('ansible.controller.controller_api', inventory_lookvar_item.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=10000) if not inventory_lookvar_item.has_inventory_sources else [],
-        'groups': query('ansible.controller.controller_api', inventory_lookvar_item.related.groups, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=10000) if not inventory_lookvar_item.has_inventory_sources else []
+        'inventory_sources': query('ansible.controller.controller_api', inventory_lookvar_item.related.inventory_sources, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) if inventory_lookvar_item.has_inventory_sources else [],
+        'hosts': query('ansible.controller.controller_api', inventory_lookvar_item.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) if not inventory_lookvar_item.has_inventory_sources else [],
+        'groups': query('ansible.controller.controller_api', inventory_lookvar_item.related.groups, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) if not inventory_lookvar_item.has_inventory_sources else []
       }]}) }}"
     needed_paths: "{{ ((needed_paths | default([])) + [inventory_lookvar_item_organization]) | flatten | unique }}"
   vars:

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Job Templates from the API"
   set_fact:
-    job_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/job_templates/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    job_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/job_templates/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Group the job_templates by Organization"
   set_fact:

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Notification Templates from the API"
   set_fact:
-    notification_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/notification_templates/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    notification_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/notification_templates/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Group the notification templates by Organization"
   set_fact:

--- a/roles/filetree_create/tasks/organizations.yml
+++ b/roles/filetree_create/tasks/organizations.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Organizations from the API"
   set_fact:
-    orgs_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/organizations/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    orgs_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/organizations/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Create the output directory for organizations: {{ output_path }}/{{ current_organization_dir.name }}"
   file:

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Projects from the API"
   set_fact:
-    projects_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/projects/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    projects_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/projects/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Group the projects by Organization"
   set_fact:

--- a/roles/filetree_create/tasks/team_roles.yml
+++ b/roles/filetree_create/tasks/team_roles.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Team Roles from the API"
   set_fact:
-    team_roles_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/teams/' + teamid +'/roles/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    team_roles_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/teams/' + teamid +'/roles/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Create the output directory for team roles: {{ output_path }}"
   file:

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Teams from the API"
   set_fact:
-    teams_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/teams/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    teams_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/teams/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Group the teams by Organization"
   set_fact:

--- a/roles/filetree_create/tasks/user_roles.yml
+++ b/roles/filetree_create/tasks/user_roles.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Users from the API"
   set_fact:
-    user_roles_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/users/' + username +'/roles/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    user_roles_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/users/' + username +'/roles/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Create the output directory for user roles: {{ output_path }}"
   file:

--- a/roles/filetree_create/tasks/users.yml
+++ b/roles/filetree_create/tasks/users.yml
@@ -1,13 +1,13 @@
 ---
 - name: "Get current Users from the API"
   set_fact:
-    users_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/users/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    users_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/users/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Add the users the Organizations information"
   set_fact:
     current_users: "{{ (current_users | default([])) + [user_lookvar_item | combine({'organizations': user_lookvar_item_organizations})] }}"
   vars:
-    user_lookvar_item_organizations: "{{ query('ansible.controller.controller_api', user_lookvar_item.related.organizations, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) | selectattr('name', 'defined') | map(attribute='name') }}"
+    user_lookvar_item_organizations: "{{ query('ansible.controller.controller_api', user_lookvar_item.related.organizations, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) | selectattr('name', 'defined') | map(attribute='name') }}"
   loop: "{{ users_lookvar }}"
   loop_control:
     loop_var: user_lookvar_item

--- a/roles/filetree_create/tasks/workflow_job_template_nodes.yml
+++ b/roles/filetree_create/tasks/workflow_job_template_nodes.yml
@@ -5,7 +5,7 @@
     needed_paths: "{{ ((needed_paths | default([])) + [workflow_job_template_organization]) | flatten | unique }}"
   vars:
     workflow_job_template_organization: "{{ query('ansible.controller.controller_api', wfjtn_lookvar_item.related.workflow_job_template, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
-  loop: "{{ query('ansible.controller.controller_api', 'api/v2/workflow_job_template_nodes/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+  loop: "{{ query('ansible.controller.controller_api', 'api/v2/workflow_job_template_nodes/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
   loop_control:
     loop_var: wfjtn_lookvar_item
     label: "{{ workflow_job_template_organization + ' - ' + wfjtn_lookvar_item.summary_fields.workflow_job_template.name }}"

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get current Workflow Job Templates from the API"
   set_fact:
-    workflow_job_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/workflow_job_templates/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true) }}"
+    workflow_job_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/workflow_job_templates/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
 
 - name: "Group the workflow job templates by Organization"
   set_fact:

--- a/roles/filetree_create/templates/current_groups.j2
+++ b/roles/filetree_create/templates/current_groups.j2
@@ -5,6 +5,6 @@ configure_tower_groups:
     description: "{{ group.description }}"
     inventory: "{{ current_groups_asset_value.name }}"
     hosts:
-{{ query('ansible.controller.controller_api', group.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=10000) | selectattr("name", "defined") | map(attribute="name") | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
+{{ query('ansible.controller.controller_api', group.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) | selectattr("name", "defined") | map(attribute="name") | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
 {%- endfor -%}
 ...


### PR DESCRIPTION
### What does this PR do?
Added variable ´query_controller_api_max_objects´ to handle the maximum number of objects to return from the list when using query at controller_api. If a list view returns more an max_objects an exception will be raised. By default is [1]max_objects=1000, when you are working in large environments this number could be short, that why it would be better to create a variable for it. 

[1].-https://docs.ansible.com/ansible/3/collections/awx/awx/tower_api_lookup.html#parameter-max_objects
