### PR TITLE
Reduce memory utilization when exporting objects and organize the output files in directories

### DIFF
--- a/changelogs/fragments/reduce_memory_usage.yml
+++ b/changelogs/fragments/reduce_memory_usage.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - Reduce the memory usage on the filetree_create role.
+minor_changes:
+  - Organize the output in directories (one per each object type).
+  - Add the current object ID to the corresponding output yaml filename.
+...

--- a/roles/filetree_create/tasks/credential_types.yml
+++ b/roles/filetree_create/tasks/credential_types.yml
@@ -1,7 +1,11 @@
 ---
 - name: "Get current Credential Types from the API when AAP"
   set_fact:
-    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/', query_params={ 'managed': false }, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    credential_types_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credential_types/',
+                                        query_params={ 'managed': false },
+                                        host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                        return_all=true, max_objects=query_controller_api_max_objects)
+                               }}"
   when: is_aap
 
 - name: "Get current Credential Types from the API when Tower"

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -1,36 +1,35 @@
 ---
 - name: "Get current Credentials from the API"
   set_fact:
-    credentials_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credentials/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    credentials_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/credentials/',
+                                   query_params={'order_by': 'organization,id'},
+                                   host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                   return_all=true, max_objects=query_controller_api_max_objects)
+                          }}"
 
-- name: "Group the credentials by Organization"
-  set_fact:
-    credentials_orgs: "{{ (credentials_orgs | default({})) | combine({(credentials_org.organization | default('ORGANIZATIONLESS', true)): ((credentials_orgs[credentials_org.organization] | default([])) + [credentials_org])}) }}"
-    needed_paths: "{{ ((needed_paths | default([])) + [credentials_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true)]) | flatten | unique }}"
-  loop: "{{ credentials_lookvar }}"
-  loop_control:
-    loop_var: credentials_org
-    label: "{{ credentials_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }} - {{ credentials_org.name }}"
-
-- name: "Create the output directory for credentials: {{ output_path }}/<ORGANIZATION_NAME>"
+- name: "Create the output directory for credentials: {{ output_path }}/<ORGANIZATION_NAME>/credentials"
   file:
-    path: "{{ output_path }}/{{ needed_path }}"
+    path: "{{ output_path }}/{{ needed_path }}/credentials"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths | default([]) }}"
+  loop: "{{ (credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+            + (['ORGANIZATIONLESS'] if ((credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0 ) else [])
+         }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}"
+    label: "{{ output_path }}/{{ needed_path }}/credentials"
 
-- name: "Add current credentials to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/current_credentials.yaml"
+- name: "Add current credentials to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/credentials"
   template:
     src: "templates/current_credentials.j2"
-    dest: "{{ output_path }}/{{ credentials_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}/current_credentials.yaml"
+    dest: "{{ output_path }}/{{ credentials_organization }}/credentials/{{ credentials_id }}_{{ credentials_name }}.yaml"
     mode: '0644'
   vars:
-    current_credentials_asset_value: "{{ credentials_org_template.value }}"
-  loop: "{{ credentials_orgs | default({}) | dict2items }}"
+    credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+    credentials_id: "{{ current_credentials_asset_value.id }}"
+    credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/','_') }}"
+  loop: "{{ credentials_lookvar }}"
   loop_control:
-    loop_var: credentials_org_template
-    label: "{{ output_path }}/{{ credentials_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}/current_credentials.yaml"
+    loop_var: current_credentials_asset_value
+    label: "{{ output_path }}/{{ credentials_organization }}/credentials/{{ credentials_id }}_{{ credentials_name }}.yaml"
 ...

--- a/roles/filetree_create/tasks/execution_environments.yml
+++ b/roles/filetree_create/tasks/execution_environments.yml
@@ -1,7 +1,10 @@
 ---
 - name: "Get current Execution Environments from the API"
   set_fact:
-    execution_environments_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/execution_environments/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    execution_environments_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/execution_environments/',
+                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                              return_all=true, max_objects=query_controller_api_max_objects)
+                                     }}"
 
 - name: "Create the output directory for execution environments: {{ output_path }}"
   file:

--- a/roles/filetree_create/tasks/groups.yml
+++ b/roles/filetree_create/tasks/groups.yml
@@ -5,14 +5,10 @@
     state: directory
     mode: '0755'
 
-- name: "Add current groups to the output yaml file: {{ output_path }}/current_groups_<INVENTORY_NAME>.yaml"
+- name: "Add current groups to the output yaml file: {{ output_path }}/current_groups.yaml"
   template:
     src: "templates/current_groups.j2"
-    dest: "{{ output_path }}/current_groups_{{ current_groups_asset_value.name | regex_replace('/','_') }}.yaml"
+    dest: "{{ output_path }}/current_groups.yaml"
     mode: '0644'
-  loop: "{{ current_organization_inventories }}"
-  loop_control:
-    loop_var: current_groups_asset_value
-    label: "{{ output_path }}/current_groups_{{ current_groups_asset_value.name | regex_replace('/','_') }}.yaml"
-  when: current_groups_asset_value.groups | length > 0
+  when: current_groups_asset_value | length > 0
 ...

--- a/roles/filetree_create/tasks/hosts.yml
+++ b/roles/filetree_create/tasks/hosts.yml
@@ -5,14 +5,10 @@
     state: directory
     mode: '0755'
 
-- name: "Add current hosts to the output yaml file: {{ output_path }}/current_hosts_<INVENTORY_NAME>.yaml"
+- name: "Add current hosts to the output yaml file: {{ output_path }}/current_hosts.yaml"
   template:
     src: "templates/current_hosts.j2"
-    dest: "{{ output_path }}/current_hosts_{{ current_hosts_asset_value.name | regex_replace('/','_') }}.yaml"
+    dest: "{{ output_path }}/current_hosts.yaml"
     mode: '0644'
-  loop: "{{ current_organization_inventories }}"
-  loop_control:
-    loop_var: current_hosts_asset_value
-    label: "{{ output_path }}/current_hosts_{{ current_hosts_asset_value.name | regex_replace('/','_') }}.yaml"
-  when: current_hosts_asset_value.hosts | length > 0
+  when: current_hosts_asset_value | length > 0
 ...

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -1,57 +1,41 @@
 ---
 - name: "Get the inventoryes from the API"
   set_fact:
-    inventory_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/inventories/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects, query_params={
-                          'not__kind': 'smart',
-                          'order_by': 'organization'
-                        }
-                      )
-             }}"
+    inventory_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/inventories/',
+                                 query_params={
+                                   'not__kind': 'smart',
+                                   'order_by': 'organization,id'
+                                 },
+                                 host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                 return_all=true, max_objects=query_controller_api_max_objects
+                           )
+                        }}"
 
-- name: "Translate the inventories to a useful structure"
-  set_fact:
-    current_inventories: "{{ (current_inventories | default({})) | combine({(inventory_lookvar_item_organization | default('ORGANIZATIONLESS', true)): (current_inventories[inventory_lookvar_item_organization] | default([])) + [{
-        'has_inventory_sources': inventory_lookvar_item.has_inventory_sources,
-        'id': inventory_lookvar_item.id,
-        'name': inventory_lookvar_item.name,
-        'description': inventory_lookvar_item.description,
-        'organization': inventory_lookvar_item_organization,
-        'host_filter': inventory_lookvar_item.host_filter,
-        'kind': inventory_lookvar_item.kind,
-        'variables': inventory_lookvar_item.variables,
-        'inventory_sources': query('ansible.controller.controller_api', inventory_lookvar_item.related.inventory_sources, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) if inventory_lookvar_item.has_inventory_sources else [],
-        'hosts': query('ansible.controller.controller_api', inventory_lookvar_item.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) if not inventory_lookvar_item.has_inventory_sources else [],
-        'groups': query('ansible.controller.controller_api', inventory_lookvar_item.related.groups, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) if not inventory_lookvar_item.has_inventory_sources else []
-      }]}) }}"
-    needed_paths: "{{ ((needed_paths | default([])) + [inventory_lookvar_item_organization]) | flatten | unique }}"
-  vars:
-    inventory_lookvar_item_organization: "{{ lookup('ansible.controller.controller_api', 'api/v2/organizations/'+(inventory_lookvar_item.organization|string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true)['name'] }}"
-  loop: "{{ inventory_lookvar }}"
-  loop_control:
-    loop_var: inventory_lookvar_item
-    label: "{{ inventory_lookvar_item_organization }} - {{ inventory_lookvar_item.name }}"
-
-- name: "Create the output directory for inventories: {{ output_path }}/<ORGANIZATION_NAME>"
+- name: "Create the output directory for inventories: {{ output_path }}/<ORGANIZATION_NAME>/inventories"
   file:
-    path: "{{ output_path }}/{{ needed_path }}"
+    path: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths | default([]) }}"
+  vars:
+    inventory_organization: "{{ needed_path.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+    inventory_name: "{{ needed_path.name | regex_replace('/','_') }}"
+  loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}"
+    label: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
 
-- name: "Add current inventories to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/current_inventories.yaml"
+- name: "Add current inventories to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/inventories"
   template:
     src: "templates/current_inventories.j2"
-    dest: "{{ output_path }}/{{ current_inventory_dir.key }}/current_inventories.yaml"
+    dest: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}/{{ current_inventories_asset_value.id }}_{{ inventory_name }}.yaml"
     mode: '0644'
   vars:
-    current_inventories_asset_value: "{{ current_inventory_dir.value }}"
-  loop: "{{ current_inventories | default({}) | dict2items }}"
+    inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+    inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/','_') }}"
+  loop: "{{ inventory_lookvar }}"
   loop_control:
-    loop_var: current_inventory_dir
-    label: "{{ output_path }}/{{ current_inventory_dir.key }}/current_inventories.yaml"
+    loop_var: current_inventories_asset_value
+    label: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ current_inventories_asset_value.id }}_{{ inventory_name }}.yaml"
 
 - name: "Set local_output_path"
   set_fact:
@@ -60,30 +44,48 @@
 - name: "Set the inventory's inventory sources"
   include_tasks: "inventory_sources.yml"
   vars:
-    output_path: "{{ local_output_path }}/{{ current_inventory_sources.key }}"
-    current_organization_inventories: "{{ current_inventory_sources.value }}"
-  loop: "{{ current_inventories | default({}) | dict2items }}"
+    inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+    inventory_name: "{{ current_inventory_sources.name | regex_replace('/','_') }}"
+    output_path: "{{ local_output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
+    current_inventory_sources_asset_value: "{{ query('ansible.controller.controller_api', current_inventory_sources.related.inventory_sources,
+                                                          host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                                          return_all=true, max_objects=query_controller_api_max_objects
+                                                    ) if current_inventory_sources.has_inventory_sources else []
+                                            }}"
+  loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: current_inventory_sources
-    label: "{{ local_output_path }}/{{ current_inventory_sources.key }}"
+    label: "{{ local_output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
 
 - name: "Set the inventory's hosts"
   include_tasks: "hosts.yml"
   vars:
-    output_path: "{{ local_output_path }}/{{ current_inventory_hosts.key }}"
-    current_organization_inventories: "{{ current_inventory_hosts.value }}"
-  loop: "{{ current_inventories | default({}) | dict2items }}"
+    inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+    inventory_name: "{{ current_inventory_hosts.name | regex_replace('/','_') }}"
+    output_path: "{{ local_output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
+    current_hosts_asset_value: "{{ query('ansible.controller.controller_api', current_inventory_hosts.related.hosts,
+                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                              return_all=true, max_objects=query_controller_api_max_objects
+                                        ) if not current_inventory_hosts.has_inventory_sources else []
+                                }}"
+  loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: current_inventory_hosts
-    label: "{{ local_output_path }}/{{ current_inventory_hosts.key }}"
+    label: "{{ local_output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
 
 - name: "Set the inventory's groups"
   include_tasks: "groups.yml"
   vars:
-    output_path: "{{ local_output_path }}/{{ current_inventory_groups.key }}"
-    current_organization_inventories: "{{ current_inventory_groups.value }}"
-  loop: "{{ current_inventories | default({}) | dict2items }}"
+    inventory_organization: "{{ current_inventory_groups.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+    inventory_name: "{{ current_inventory_groups.name | regex_replace('/','_') }}"
+    output_path: "{{ local_output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
+    current_groups_asset_value: "{{ query('ansible.controller.controller_api', current_inventory_groups.related.groups,
+                                               host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                               return_all=true, max_objects=query_controller_api_max_objects
+                                         ) if not current_inventory_groups.has_inventory_sources else []
+                                 }}"
+  loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: current_inventory_groups
-    label: "{{ local_output_path }}/{{ current_inventory_groups.key }}"
+    label: "{{ local_output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
 ...

--- a/roles/filetree_create/tasks/inventory_sources.yml
+++ b/roles/filetree_create/tasks/inventory_sources.yml
@@ -5,16 +5,10 @@
     state: directory
     mode: '0755'
 
-- name: "Add current inventory source to the output yaml file: {{ output_path }}/<INVENTORY_NAME>/current_inventory_sources.yaml"
+- name: "Add current inventory source to the output yaml file: {{ output_path }}/current_inventory_sources.yaml"
   template:
     src: "templates/current_inventory_sources.j2"
-    dest: "{{ output_path }}/current_inventory_sources_{{ current_organization_inventory.name | regex_replace('/','_') }}.yaml"
+    dest: "{{ output_path }}/current_inventory_sources.yaml"
     mode: '0644'
-  vars:
-    current_inventory_sources_asset_value: "{{ current_organization_inventory.inventory_sources }}"
-  loop: "{{ current_organization_inventories }}"
-  loop_control:
-    loop_var: current_organization_inventory
-    label: "{{ output_path }}/current_inventory_sources_{{ current_organization_inventory.name | regex_replace('/','_') }}.yaml"
   when: current_inventory_sources_asset_value | length > 0
 ...

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -1,36 +1,35 @@
 ---
 - name: "Get current Job Templates from the API"
   set_fact:
-    job_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/job_templates/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    job_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/job_templates/',
+                                     query_params={'order_by': 'organization,id'},
+                                     host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                     return_all=true, max_objects=query_controller_api_max_objects)
+                            }}"
 
-- name: "Group the job_templates by Organization"
-  set_fact:
-    job_templates_orgs: "{{ (job_templates_orgs | default({})) | combine({(job_templates_org.organization | default('ORGANIZATIONLESS', true)): ((job_templates_orgs[job_templates_org.organization] | default([])) + [job_templates_org])}) }}"
-    needed_paths: "{{ ((needed_paths | default([])) + [job_templates_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true)]) | flatten | unique }}"
-  loop: "{{ job_templates_lookvar }}"
-  loop_control:
-    loop_var: job_templates_org
-    label: "{{ job_templates_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }} - {{ job_templates_org.name }}"
-
-- name: "Create the output directory for job templates: {{ output_path }}/<ORGANIZATION_NAME>"
+- name: "Create the output directories for job templates: {{ output_path }}/<ORGANIZATION_NAME>"
   file:
-    path: "{{ output_path }}/{{ needed_path }}"
+    path: "{{ output_path }}/{{ needed_path }}/job_templates"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths | default([]) }}"
+  loop: "{{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+            + (['ORGANIZATIONLESS'] if ((job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0 ) else [])
+         }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}"
+    label: "{{ output_path }}/{{ needed_path }}/job_templates"
 
-- name: "Add current job_templates to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/current_job_templates.yaml"
+- name: "Add current job_templates to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/job_templates"
   template:
     src: "templates/current_job_templates.j2"
-    dest: "{{ output_path }}/{{ job_templates_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}/current_job_templates.yaml"
+    dest: "{{ output_path }}/{{ job_template_organization }}/job_templates/{{ job_template_id }}_{{ job_template_name }}.yaml"
     mode: '0644'
   vars:
-    current_job_templates_asset_value: "{{ job_templates_org_template.value }}"
-  loop: "{{ job_templates_orgs  | default({}) | dict2items }}"
+    job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+    job_template_id: "{{ current_job_templates_asset_value.id }}"
+    job_template_name: "{{ current_job_templates_asset_value.name | regex_replace('/','_') }}"
+  loop: "{{ job_templates_lookvar }}"
   loop_control:
-    loop_var: job_templates_org_template
-    label: "{{ output_path }}/{{ job_templates_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}/current_job_templates.yaml"
+    loop_var: current_job_templates_asset_value
+    label: "{{ output_path }}/{{ job_template_organization }}/job_templates/{{ job_template_id }}_{{ job_template_name }}.yaml"
 ...

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -1,36 +1,30 @@
 ---
 - name: "Get current Notification Templates from the API"
   set_fact:
-    notification_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/notification_templates/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    notification_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/notification_templates/',
+                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                              return_all=true, max_objects=query_controller_api_max_objects)
+                                     }}"
 
-- name: "Group the notification templates by Organization"
-  set_fact:
-    notification_templates_orgs: "{{ (notification_templates_orgs | default({})) | combine({(notification_templates_org.organization | default('ORGANIZATIONLESS', true)): ((notification_templates_orgs[notification_templates_org.organization] | default([])) + [notification_templates_org])}) }}"
-    needed_paths: "{{ ((needed_paths | default([])) + [notification_templates_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true)]) | flatten | unique }}"
-  loop: "{{ notification_templates_lookvar }}"
-  loop_control:
-    loop_var: notification_templates_org
-    label: "{{ notification_templates_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }} - {{ notification_templates_org.name }}"
-
-- name: "Create the output directory for notification templates: {{ output_path }}/<ORGANIZATION_NAME>"
+- name: "Create the output directory for notification templates: {{ output_path }}/<ORGANIZATION_NAME>/notification_templates"
   file:
-    path: "{{ output_path }}/{{ needed_path }}"
+    path: "{{ output_path }}/{{ needed_path }}/notification_templates"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths | default([]) }}"
+  loop: "{{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+            + (['ORGANIZATIONLESS'] if ((notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0 ) else [])
+         }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}"
+    label: "{{ output_path }}/{{ needed_path }}/notification_templates"
 
 - name: "Add current notification templates to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/current_notification_templates.yaml"
   template:
     src: "templates/current_notification_templates.j2"
-    dest: "{{ output_path }}/{{ notification_templates_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/current_notification_templates.yaml"
+    dest: "{{ output_path }}/{{ current_notification_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/notification_templates/{{ current_notification_templates_asset_value.name | regex_replace('/','_') }}.yaml"
     mode: '0644'
-  vars:
-    current_notification_templates_asset_value: "{{ notification_templates_org_template.value }}"
-  loop: "{{ notification_templates_orgs | default({}) | dict2items }}"
+  loop: "{{ notification_templates_lookvar }}"
   loop_control:
-    loop_var: notification_templates_org_template
-    label: "{{ output_path }}/{{ notification_templates_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/current_notification_templates.yaml"
+    loop_var: current_notification_templates_asset_value
+    label: "{{ output_path }}/{{ current_notification_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/notification_templates/{{ current_notification_templates_asset_value.name | regex_replace('/','_') }}.yaml"
 ...

--- a/roles/filetree_create/tasks/organizations.yml
+++ b/roles/filetree_create/tasks/organizations.yml
@@ -1,7 +1,11 @@
 ---
 - name: "Get current Organizations from the API"
   set_fact:
-    orgs_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/organizations/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    orgs_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/organizations/',
+                            query_params={'order_by': 'id'},
+                            host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                            return_all=true, max_objects=query_controller_api_max_objects)
+                   }}"
 
 - name: "Create the output directory for organizations: {{ output_path }}/{{ current_organization_dir.name }}"
   file:

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -1,36 +1,35 @@
 ---
 - name: "Get current Projects from the API"
   set_fact:
-    projects_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/projects/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    projects_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/projects/',
+                                query_params={'order_by': 'organization,id'},
+                                host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                return_all=true, max_objects=query_controller_api_max_objects)
+                       }}"
 
-- name: "Group the projects by Organization"
-  set_fact:
-    projects_orgs: "{{ (projects_orgs | default({})) | combine({(projects_org.organization | default('ORGANIZATIONLESS', true)): ((projects_orgs[projects_org.organization] | default([])) + [projects_org])}) }}"
-    needed_paths: "{{ ((needed_paths | default([])) + [projects_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true)]) | flatten | unique }}"
-  loop: "{{ projects_lookvar }}"
-  loop_control:
-    loop_var: projects_org
-    label: "{{ projects_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }} - {{ projects_org.name }}"
-
-- name: "Create the output directory for projects: {{ output_path }}/<ORGANIZATION_NAME>"
+- name: "Create the output directory for projects: {{ output_path }}/<ORGANIZATION_NAME>/projects"
   file:
-    path: "{{ output_path }}/{{ needed_path }}"
+    path: "{{ output_path }}/{{ needed_path }}/projects"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths | default([]) }}"
+  loop: "{{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+            + (['ORGANIZATIONLESS'] if ((projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0 ) else [])
+         }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}"
+    label: "{{ output_path }}/{{ needed_path }}/projects"
 
-- name: "Add current projects to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/current_projects.yaml"
+- name: "Add current projects to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/projects"
   template:
     src: "templates/current_projects.j2"
-    dest: "{{ output_path }}/{{ projects_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/current_projects.yaml"
+    dest: "{{ output_path }}/{{ project_organization }}/projects/{{ project_id }}_{{ project_name }}.yaml"
     mode: '0644'
   vars:
-    current_projects_asset_value: "{{ projects_org_template.value }}"
-  loop: "{{ projects_orgs | default({}) | dict2items }}"
+    project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
+    project_id: "{{ current_projects_asset_value.id }}"
+    project_name: "{{ current_projects_asset_value.name | regex_replace('/','_') }}"
+  loop: "{{ projects_lookvar }}"
   loop_control:
-    loop_var: projects_org_template
-    label: "{{ output_path }}/{{ projects_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/current_projects.yaml"
+    loop_var: current_projects_asset_value
+    label: "{{ output_path }}/{{ project_organization }}/projects/{{ project_id }}_{{ project_name }}.yaml"
 ...

--- a/roles/filetree_create/tasks/team_roles.yml
+++ b/roles/filetree_create/tasks/team_roles.yml
@@ -1,7 +1,10 @@
 ---
 - name: "Get current Team Roles from the API"
   set_fact:
-    team_roles_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/teams/' + teamid +'/roles/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    team_roles_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/teams/' + teamid +'/roles/',
+                                  host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                  return_all=true, max_objects=query_controller_api_max_objects)
+                         }}"
 
 - name: "Create the output directory for team roles: {{ output_path }}"
   file:

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -1,43 +1,44 @@
 ---
 - name: "Get current Teams from the API"
   set_fact:
-    teams_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/teams/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    teams_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/teams/',
+                             query_params={'order_by': 'organization,id'},
+                             host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                             return_all=true, max_objects=query_controller_api_max_objects)
+                    }}"
 
-- name: "Group the teams by Organization"
-  set_fact:
-    teams_orgs: "{{ (teams_orgs | default({})) | combine({(teams_org.organization | default('ORGANIZATIONLESS', true)): ((teams_orgs[teams_org.organization] | default([])) + [teams_org])}) }}"
-    needed_paths: "{{ ((needed_paths | default([])) + [teams_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true)]) | flatten | unique }}"
-  loop: "{{ teams_lookvar }}"
-  loop_control:
-    loop_var: teams_org
-    label: "{{ teams_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }} - {{ teams_org.name }}"
-
-- name: "Create the output directory for teams: {{ output_path }}/<ORGANIZATION_NAME>"
+- name: "Create the output directory for teams: {{ output_path }}/<ORGANIZATION_NAME>/teams"
   file:
-    path: "{{ output_path }}/{{ needed_path }}"
+    path: "{{ output_path }}/{{ needed_path }}/teams"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths | default([]) }}"
+  loop: "{{ (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+            + (['ORGANIZATIONLESS'] if ((teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0 ) else [])
+         }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}"
+    label: "{{ output_path }}/{{ needed_path }}/teams"
 
-- name: "Add current teams to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/current_teams.yaml"
+- name: "Add current teams to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/teams"
   template:
     src: "templates/current_teams.j2"
-    dest: "{{ output_path }}/{{ teams_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/current_teams.yaml"
+    dest: "{{ output_path }}/{{ team_organization }}/teams/{{ team_id }}_{{ team_name }}.yaml"
     mode: '0644'
   vars:
-    current_teams_asset_value: "{{ teams_org_template.value }}"
-  loop: "{{ teams_orgs  | default({}) | dict2items }}"
+    team_organization: "{{ current_teams_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
+    team_id: "{{ current_teams_asset_value.id }}"
+    team_name: "{{ current_teams_asset_value.name | regex_replace('/','_') }}"
+  loop: "{{ teams_lookvar }}"
   loop_control:
-    loop_var: teams_org_template
-    label: "{{ output_path }}/{{ teams_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/current_teams.yaml"
+    loop_var: current_teams_asset_value
+    label: "{{ output_path }}/{{ team_organization }}/teams/{{ team_id }}_{{ team_name }}.yaml"
 
 - name: "Set the team's roles"
   include_tasks: "team_roles.yml"
   vars:
-    teamname: "{{ item.name }}"
-    teamid: "{{ item.id }}"
+    teamname: "{{ current_team.name }}"
+    teamid: "{{ current_team.id }}"
   loop: "{{ teams_lookvar }}"
+  loop_control:
+    loop_var: current_team
 ...

--- a/roles/filetree_create/tasks/user_roles.yml
+++ b/roles/filetree_create/tasks/user_roles.yml
@@ -1,7 +1,10 @@
 ---
 - name: "Get current Users from the API"
   set_fact:
-    user_roles_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/users/' + username +'/roles/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    user_roles_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/users/' + (username|urlencode()) +'/roles/',
+                                  host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                  return_all=true, max_objects=query_controller_api_max_objects)
+                         }}"
 
 - name: "Create the output directory for user roles: {{ output_path }}"
   file:

--- a/roles/filetree_create/tasks/users.yml
+++ b/roles/filetree_create/tasks/users.yml
@@ -1,7 +1,10 @@
 ---
 - name: "Get current Users from the API"
   set_fact:
-    users_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/users/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    users_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/users/',
+                             host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                             return_all=true, max_objects=query_controller_api_max_objects)
+                    }}"
 
 - name: "Add the users the Organizations information"
   set_fact:

--- a/roles/filetree_create/tasks/workflow_job_template_nodes.yml
+++ b/roles/filetree_create/tasks/workflow_job_template_nodes.yml
@@ -1,35 +1,46 @@
 ---
 - name: "Get the current Workflow Job Template Nodes from the API"
   set_fact:
-    wfjtn_lookvar: "{{ (wfjtn_lookvar | default({})) | combine({wfjtn_lookvar_item.summary_fields.workflow_job_template.name: {'nodes': (wfjtn_lookvar[wfjtn_lookvar_item.summary_fields.workflow_job_template.name]['nodes']|default([]) + [wfjtn_lookvar_item] | flatten), 'organization': workflow_job_template_organization} }) }}"
-    needed_paths: "{{ ((needed_paths | default([])) + [workflow_job_template_organization]) | flatten | unique }}"
+    wfjtn_lookvar: "{{ (wfjtn_lookvar | default({})) | combine({wfjtn_lookvar_item.summary_fields.workflow_job_template.name: {
+                                                                 'nodes':
+                                                                   (wfjtn_lookvar[wfjtn_lookvar_item.summary_fields.workflow_job_template.name]['nodes']|default([]) + [wfjtn_lookvar_item] | flatten),
+                                                                   'organization': workflow_job_template_organization
+                                                               } })
+                    }}"
+    needed_paths: "{{ ((needed_paths | default([])) + [(workflow_job_template_organization|regex_replace('/','_'))]) | flatten | unique }}"
   vars:
-    workflow_job_template_organization: "{{ query('ansible.controller.controller_api', wfjtn_lookvar_item.related.workflow_job_template, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
-  loop: "{{ query('ansible.controller.controller_api', 'api/v2/workflow_job_template_nodes/', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    workflow_job_template_organization: "{{ query('ansible.controller.controller_api', wfjtn_lookvar_item.related.workflow_job_template,
+                                                  host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs
+                                            )[0].summary_fields.organization.name | default('ORGANIZATIONLESS')
+                                         }}"
+  loop: "{{ query('ansible.controller.controller_api', 'api/v2/workflow_job_template_nodes/',
+                  host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                  return_all=true, max_objects=query_controller_api_max_objects)
+         }}"
   loop_control:
     loop_var: wfjtn_lookvar_item
     label: "{{ workflow_job_template_organization + ' - ' + wfjtn_lookvar_item.summary_fields.workflow_job_template.name }}"
 
-- name: "Create the output directory for workflow job template nodes: {{ output_path }}/<ORGANIZATION_NAME>"
+- name: "Create the output directory for workflow job template nodes: {{ output_path }}/<ORGANIZATION_NAME>/workflow_job_template_nodes"
   file:
-    path: "{{ output_path }}/{{ needed_path }}"
+    path: "{{ output_path }}/{{ needed_path }}/workflow_job_template_nodes"
     state: directory
     mode: '0755'
   loop: "{{ needed_paths | default([]) }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}"
+    label: "{{ output_path }}/{{ needed_path }}/workflow_job_template_nodes"
 
-- name: "Add current workflow job template nodes to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/current_workflow_job_template_nodes_{{ workflow_job_template_name }}.yaml"
+- name: "Add current workflow job template nodes to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/workflow_job_template_nodes"
   template:
     src: "templates/current_workflow_job_template_nodes.j2"
-    dest: "{{ output_path }}/{{ current_wfjtn_asset_value.value.organization }}/current_workflow_job_template_nodes_{{ workflow_job_template_name }}.yaml"
+    dest: "{{ output_path }}/{{ workflow_job_template_organization }}/workflow_job_template_nodes/{{ workflow_job_template_name }}.yaml"
     mode: '0644'
   vars:
-    workflow_job_template_name: "{{ current_wfjtn_asset_value.key }}"
-    # workflow_job_template_organization: "{{ query('ansible.controller.controller_api', current_wfjtn_asset_value.value.wfjtn_url, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].summary_fields.organization.name | default('ToDo: The WF node  must have an organization') }}"
+    workflow_job_template_name: "{{ current_wfjtn_asset_value.key | regex_replace('/','_') }}"
+    workflow_job_template_organization: "{{ current_wfjtn_asset_value.value.organization | regex_replace('/','_') }}"
   loop: "{{ wfjtn_lookvar | default({}) | dict2items }}"
   loop_control:
     loop_var: current_wfjtn_asset_value
-    label: "{{ output_path }}/{{ current_wfjtn_asset_value.value.organization }}/current_workflow_job_template_nodes_{{ workflow_job_template_name }}.yaml"
+    label: "{{ output_path }}/{{ workflow_job_template_organization }}/workflow_job_template_nodes/{{ workflow_job_template_name }}.yaml"
 ...

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -1,38 +1,37 @@
 ---
 - name: "Get current Workflow Job Templates from the API"
   set_fact:
-    workflow_job_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/workflow_job_templates/', query_params={'order_by': 'organization'}, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) }}"
+    workflow_job_templates_lookvar: "{{ query('ansible.controller.controller_api', 'api/v2/workflow_job_templates/',
+                                              query_params={'order_by': 'organization,id'},
+                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                              return_all=true, max_objects=query_controller_api_max_objects)
+                                     }}"
 
-- name: "Group the workflow job templates by Organization"
-  set_fact:
-    workflow_job_templates_orgs: "{{ (workflow_job_templates_orgs | default({})) | combine({(workflow_job_templates_org.organization | default('ORGANIZATIONLESS', true)): ((workflow_job_templates_orgs[workflow_job_templates_org.organization] | default([])) + [workflow_job_templates_org])}) }}"
-    needed_paths: "{{ ((needed_paths | default([])) + [workflow_job_templates_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true)]) | flatten | unique }}"
-  loop: "{{ workflow_job_templates_lookvar }}"
-  loop_control:
-    loop_var: workflow_job_templates_org
-    label: "{{ workflow_job_templates_org.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }} - {{ workflow_job_templates_org.name }}"
-
-- name: "Create the output directory for workflow job templates: {{ output_path }}/<ORGANIZATION_NAME>"
+- name: "Create the output directory for workflow job templates: {{ output_path }}/<ORGANIZATION_NAME>/workflow_job_templates"
   file:
-    path: "{{ output_path }}/{{ needed_path }}"
+    path: "{{ output_path }}/{{ needed_path }}/workflow_job_templates/"
     state: directory
     mode: '0755'
-  loop: "{{ needed_paths | default([]) }}"
+  loop: "{{ (workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+            + (['ORGANIZATIONLESS'] if ((workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0 ) else [])
+         }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}"
+    label: "{{ output_path }}/{{ needed_path }}/workflow_job_templates/"
 
-- name: "Add current workflow job templates to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/current_workflow_job_templates.yaml"
+- name: "Add current workflow job templates to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/workflow_job_templates"
   template:
     src: "templates/current_workflow_job_templates.j2"
-    dest: "{{ output_path }}/{{ workflow_job_templates_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}/current_workflow_job_templates.yaml"
+    dest: "{{ output_path }}/{{ workflow_job_template_organization }}/workflow_job_templates/{{ workflow_job_template_id }}_{{ workflow_job_template_name }}.yaml"
     mode: '0644'
   vars:
-    current_workflow_job_templates_asset_value: "{{ workflow_job_templates_org_template.value }}"
-  loop: "{{ workflow_job_templates_orgs | default({}) | dict2items }}"
+    workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+    workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
+    workflow_job_template_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/','_') }}"
+  loop: "{{ workflow_job_templates_lookvar }}"
   loop_control:
-    loop_var: workflow_job_templates_org_template
-    label: "{{ output_path }}/{{ workflow_job_templates_org_template.value[0].summary_fields.organization.name | default('ORGANIZATIONLESS') }}/current_workflow_job_templates.yaml"
+    loop_var: current_workflow_job_templates_asset_value
+    label: "{{ output_path }}/{{ workflow_job_template_organization }}/workflow_job_templates/{{ workflow_job_template_id }}_{{ workflow_job_template_name }}.yaml"
 
 - name: "Set the workflow_job_template's nodes"
   include_tasks: "workflow_job_template_nodes.yml"

--- a/roles/filetree_create/templates/current_credentials.j2
+++ b/roles/filetree_create/templates/current_credentials.j2
@@ -1,13 +1,11 @@
 ---
 controller_credentials:
-{% for credential in current_credentials_asset_value %}
-  - name: "{{ credential.name }}"
-    description: "{{ credential.description }}"
-    credential_type: "{{ credential.summary_fields.credential_type.name }}"
-{% if credential.organization is defined and credential.organization is not none %}
-    organization: "{{ credential.summary_fields.organization.name }}"
+  - name: "{{ current_credentials_asset_value.name }}"
+    description: "{{ current_credentials_asset_value.description }}"
+    credential_type: "{{ current_credentials_asset_value.summary_fields.credential_type.name }}"
+{% if current_credentials_asset_value.organization is defined and current_credentials_asset_value.organization is not none %}
+    organization: "{{ current_credentials_asset_value.summary_fields.organization.name }}"
 {% endif %}
     inputs:
-{{ credential.inputs | to_nice_yaml(indent=2) | indent(width=6, first=True) | replace("$encrypted$", "\'\'")  }}
-{% endfor %}
+{{ current_credentials_asset_value.inputs | to_nice_yaml(indent=2) | indent(width=6, first=True) | replace("$encrypted$", "\'\'")  }}
 ...

--- a/roles/filetree_create/templates/current_groups.j2
+++ b/roles/filetree_create/templates/current_groups.j2
@@ -1,10 +1,14 @@
 ---
 configure_tower_groups:
-{% for group in current_groups_asset_value.groups %}
+{% for group in current_groups_asset_value %}
   - name: "{{ group.name }}"
     description: "{{ group.description }}"
-    inventory: "{{ current_groups_asset_value.name }}"
+    inventory: "{{ group.summary_fields.inventory.name }}"
     hosts:
-{{ query('ansible.controller.controller_api', group.related.hosts, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) | selectattr("name", "defined") | map(attribute="name") | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
+{{ query('ansible.controller.controller_api', group.related.hosts,
+         host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+         return_all=true, max_objects=query_controller_api_max_objects
+   ) | selectattr("name", "defined") | map(attribute="name") | to_nice_yaml(indent=2) | indent(width=6, first=True)
+}}
 {%- endfor -%}
 ...

--- a/roles/filetree_create/templates/current_hosts.j2
+++ b/roles/filetree_create/templates/current_hosts.j2
@@ -1,8 +1,8 @@
 ---
 controller_hosts:
-{% for host in current_hosts_asset_value.hosts if not host.has_inventory_sources %}
+{% for host in current_hosts_asset_value if not host.has_inventory_sources %}
   - name: "{{ host.name }}"
     description: "{{ host.description }}"
-    inventory: "{{ current_hosts_asset_value.name | default('ToDo: The host \'' + host.name + '\' must have an associated inventory') }}"
+    inventory: "{{ host.summary_fields.inventory.name | default('ToDo: The host \'' + host.name + '\' must have an associated inventory') }}"
 {% endfor %}
 ...

--- a/roles/filetree_create/templates/current_inventories.j2
+++ b/roles/filetree_create/templates/current_inventories.j2
@@ -1,17 +1,15 @@
 ---
 controller_inventories:
-{% for inventory in current_inventories_asset_value %}
-  - name: "{{ inventory.name }}"
-    description: "{{ inventory.description }}"
-    organization: "{{ inventory.organization }}"
-{% if inventory.host_filter %}
-    host_filter: "{{ inventory.host_filter }}"
+  - name: "{{ current_inventories_asset_value.name }}"
+    description: "{{ current_inventories_asset_value.description }}"
+    organization: "{{ current_inventories_asset_value.organization }}"
+{% if current_inventories_asset_value.host_filter %}
+    host_filter: "{{ current_inventories_asset_value.host_filter }}"
 {% endif %}
-{% if inventory.kind %}
-    kind: "{{ inventory.kind }}"
+{% if current_inventories_asset_value.kind %}
+    kind: "{{ current_inventories_asset_value.kind }}"
 {% endif %}
-{% if inventory.variables %}
-    variables: "{{ inventory.variables }}"
+{% if current_inventories_asset_value.variables %}
+    variables: "{{ current_inventories_asset_value.variables }}"
 {% endif %}
-{% endfor %}
 ...

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -1,37 +1,35 @@
 ---
 controller_templates:
-{% for job_template in current_job_templates_asset_value %}
-  - name: "{{ job_template.name }}"
-    description: "{{ job_template.description }}"
-    organization: "{{ job_template.summary_fields.organization.name | default('ToDo: The job template \'' + job_template.name + '\' must belong to an organization') }}"
-    project: "{{ job_template.summary_fields.project.name | default('ToDo: The job template \'' + job_template.name + '\' must have a project assigned') }}"
-{% if job_template.inventory %}
-    inventory: "{{ job_template.summary_fields.inventory.name }}"
+  - name: "{{ current_job_templates_asset_value.name }}"
+    description: "{{ current_job_templates_asset_value.description }}"
+    organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default('ToDo: The job template \'' + current_job_templates_asset_value.name + '\' must belong to an organization') }}"
+    project: "{{ current_job_templates_asset_value.summary_fields.project.name | default('ToDo: The job template \'' + current_job_templates_asset_value.name + '\' must have a project assigned') }}"
+{% if current_job_templates_asset_value.inventory %}
+    inventory: "{{ current_job_templates_asset_value.summary_fields.inventory.name }}"
 {% endif %}
-    playbook: "{{ job_template.playbook }}"
-    job_type: "{{ job_template.job_type }}"
-    fact_caching_enabled: "{{ job_template.use_fact_cache }}"
-{% if job_template.summary_fields.credentials %}
+    playbook: "{{ current_job_templates_asset_value.playbook }}"
+    job_type: "{{ current_job_templates_asset_value.job_type }}"
+    fact_caching_enabled: "{{ current_job_templates_asset_value.use_fact_cache }}"
+{% if current_job_templates_asset_value.summary_fields.credentials %}
     credentials:
-{% for credential in job_template.summary_fields.credentials %}
+{% for credential in current_job_templates_asset_value.summary_fields.credentials %}
       - "{{ credential.name }}"
 {% endfor %}
 {% endif %}
-    concurrent_jobs_enabled: "{{ job_template.allow_simultaneous }}"
-    ask_scm_branch_on_launch: "{{ job_template.ask_scm_branch_on_launch }}"
-    ask_tags_on_launch: "{{ job_template.ask_tags_on_launch }}"
-    ask_verbosity_on_launch: "{{ job_template.ask_verbosity_on_launch }}"
-    ask_variables_on_launch: "{{ job_template.ask_variables_on_launch }}"
-{% if (job_template.extra_vars | length) > 3 %}
+    concurrent_jobs_enabled: "{{ current_job_templates_asset_value.allow_simultaneous }}"
+    ask_scm_branch_on_launch: "{{ current_job_templates_asset_value.ask_scm_branch_on_launch }}"
+    ask_tags_on_launch: "{{ current_job_templates_asset_value.ask_tags_on_launch }}"
+    ask_verbosity_on_launch: "{{ current_job_templates_asset_value.ask_verbosity_on_launch }}"
+    ask_variables_on_launch: "{{ current_job_templates_asset_value.ask_variables_on_launch }}"
+{% if (current_job_templates_asset_value.extra_vars | length) > 3 %}
     extra_vars:
-{% if (job_template.extra_vars[0] is match('{')) %}
-{{ job_template.extra_vars | from_json | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
+{% if (current_job_templates_asset_value.extra_vars[0] is match('{')) %}
+{{ current_job_templates_asset_value.extra_vars | from_json | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
 {% else %}
-{{ job_template.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
+{{ current_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
 {% endif %}
 {%- endif -%}
 {% if is_aap %}
-    execution_environment: "{{ job_template.summary_fields.execution_environment.name | default(omit) }}"
+    execution_environment: "{{ current_job_templates_asset_value.summary_fields.execution_environment.name | default(omit) }}"
 {% endif %}
-{% endfor %}
 ...

--- a/roles/filetree_create/templates/current_notification_templates.j2
+++ b/roles/filetree_create/templates/current_notification_templates.j2
@@ -1,16 +1,14 @@
 ---
 controller_notification_templates:
-{% for notification_template in current_notification_templates_asset_value %}
-- name: "{{ notification_template.name }}"
+- name: "{{ current_notification_templates_asset_value.name }}"
   notification_template:
-    name: "{{ notification_template.name }}"
-    organization: "{{ notification_template.summary_fields.organization.name }}"
-    notification_type: "{{ notification_template.notification_type }}"
+    name: "{{ current_notification_templates_asset_value.name }}"
+    organization: "{{ current_notification_templates_asset_value.summary_fields.organization.name }}"
+    notification_type: "{{ current_notification_templates_asset_value.notification_type }}"
     notification_configuration:
-{{ notification_template.notification_configuration | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
-{% if notification_template.messages is defined and notification_template.messages %}
+{{ current_notification_templates_asset_value.notification_configuration | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
+{% if current_notification_templates_asset_value.messages is defined and current_notification_templates_asset_value.messages %}
     messages:
-{{ notification_template.messages | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
+{{ current_notification_templates_asset_value.messages | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
 {% endif %}
-{% endfor %}
 ...

--- a/roles/filetree_create/templates/current_projects.j2
+++ b/roles/filetree_create/templates/current_projects.j2
@@ -1,20 +1,18 @@
 ---
 controller_projects:
-{% for project in current_projects_asset_value %}
-  - name: "{{ project.name }}"
-    description: "{{ project.description }}"
-    organization: "{{ project.summary_fields.organization.name | default('ToDo: The project \'' + project.name + '\' must have an organization') }}"
-{% if project.scm_type %}
-    scm_type: "{{ project.scm_type }}"
-    scm_url: "{{ project.scm_url }}"
-    scm_credential: "{{ project.summary_fields.credential.name | default('ToDo: The project \'' + project.name + '\' is missing the SCM credential') }}"
-    scm_branch: "{{ project.scm_branch }}"
-    scm_clean: "{{ project.scm_clean }}"
-    scm_delete_on_update: "{{ project.scm_delete_on_update }}"
-    scm_update_on_launch: "{{ project.scm_update_on_launch }}"
-    scm_update_cache_timeout: "{{ project.scm_update_cache_timeout }}"
+  - name: "{{ current_projects_asset_value.name }}"
+    description: "{{ current_projects_asset_value.description }}"
+    organization: "{{ current_projects_asset_value.summary_fields.organization.name | default('ToDo: The project \'' + current_projects_asset_value.name + '\' must have an organization') }}"
+{% if current_projects_asset_value.scm_type %}
+    scm_type: "{{ current_projects_asset_value.scm_type }}"
+    scm_url: "{{ current_projects_asset_value.scm_url }}"
+    scm_credential: "{{ current_projects_asset_value.summary_fields.credential.name | default('ToDo: The project \'' + current_projects_asset_value.name + '\' is missing the SCM credential') }}"
+    scm_branch: "{{ current_projects_asset_value.scm_branch }}"
+    scm_clean: "{{ current_projects_asset_value.scm_clean }}"
+    scm_delete_on_update: "{{ current_projects_asset_value.scm_delete_on_update }}"
+    scm_update_on_launch: "{{ current_projects_asset_value.scm_update_on_launch }}"
+    scm_update_cache_timeout: "{{ current_projects_asset_value.scm_update_cache_timeout }}"
 {% endif %}
-    allow_override: "{{ project.allow_override }}"
-    timeout: {{ project.timeout }}
-{% endfor %}
+    allow_override: "{{ current_projects_asset_value.allow_override }}"
+    timeout: {{ current_projects_asset_value.timeout }}
 ...

--- a/roles/filetree_create/templates/current_teams.j2
+++ b/roles/filetree_create/templates/current_teams.j2
@@ -1,8 +1,6 @@
 ---
 controller_teams:
-{% for team in current_teams_asset_value %}
-  - name: "{{ team.name }}"
-    description: "{{ team.description }}"
-    organization: "{{ team.summary_fields.organization.name }}"
-{% endfor %}
+  - name: "{{ current_teams_asset_value.name }}"
+    description: "{{ current_teams_asset_value.description }}"
+    organization: "{{ current_teams_asset_value.summary_fields.organization.name }}"
 ...

--- a/roles/filetree_create/templates/current_workflow_job_template_nodes.j2
+++ b/roles/filetree_create/templates/current_workflow_job_template_nodes.j2
@@ -3,7 +3,7 @@ controller_workflow_nodes:
 {% for node in current_wfjtn_asset_value.value.nodes %}
   - identifier: "{{ node.identifier }}"
     workflow_job_template: "{{ node.summary_fields.workflow_job_template.name }}"
-    unified_job_template: "{{ node.summary_fields.unified_job_template.name }}"
+    unified_job_template: "{{ node.summary_fields.unified_job_template.name | default('ToDo: The node is pointing to a deleted Job Template' ) }}"
 {% if node.job_type %}
     job_type: "{{ node.job_type }}"
 {% endif %}
@@ -12,19 +12,28 @@ controller_workflow_nodes:
 {% if node.success_nodes is defined and node.success_nodes | length > 0 %}
     success_nodes:
 {% for success in node.success_nodes %}
-      - {{ query('ansible.controller.controller_api', 'workflow_job_template_nodes/'+(success | string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
+      - {{ query('ansible.controller.controller_api', 'workflow_job_template_nodes/'+(success | string),
+                 host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs
+           )[0].identifier
+        }}
 {% endfor %}
 {% endif %}
 {% if node.always_nodes and node.always_nodes | length > 0 %}
     always_nodes:
 {% for always in node.always_nodes %}
-      - {{ query('ansible.controller.controller_api', 'workflow_job_template_nodes/'+(always | string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
+      - {{ query('ansible.controller.controller_api', 'workflow_job_template_nodes/'+(always | string),
+                 host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs
+           )[0].identifier
+        }}
 {% endfor %}
 {% endif %}
 {% if node.failure_nodes and node.failure_nodes | length > 0 %}
     failure_nodes:
 {% for failure in node.failure_nodes %}
-      - {{ query('ansible.controller.controller_api', 'workflow_job_template_nodes/'+(failure | string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
+      - {{ query('ansible.controller.controller_api', 'workflow_job_template_nodes/'+(failure | string),
+                 host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs
+           )[0].identifier
+        }}
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -1,13 +1,11 @@
 --
 controller_workflows:
-{% for workflow_job_template in current_workflow_job_templates_asset_value %}
-  - name: "{{ workflow_job_template.name }}"
-    description: "{{ workflow_job_template.description }}"
-    organization: "{{ workflow_job_template.summary_fields.organization.name | default('ToDo: The WF \'' + workflow_job_template.name + '\' must belong to an organization') }}"
-    survey_enabled: "{{ workflow_job_template.survey_enabled }}"
-    ask_variables_on_launch: "{{ workflow_job_template.ask_variables_on_launch }}"
-    allow_simultaneous: "{{ workflow_job_template.allow_simultaneous }}"
-    scm_branch: "{{ workflow_job_template.scm_branch }}"
-    webhook_service: "{{ workflow_job_template.webhook_service }}"
-{% endfor %}
+  - name: "{{ current_workflow_job_templates_asset_value.name }}"
+    description: "{{ current_workflow_job_templates_asset_value.description }}"
+    organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default('ToDo: The WF \'' + current_workflow_job_templates_asset_value.name + '\' must belong to an organization') }}"
+    survey_enabled: "{{ current_workflow_job_templates_asset_value.survey_enabled }}"
+    ask_variables_on_launch: "{{ current_workflow_job_templates_asset_value.ask_variables_on_launch }}"
+    allow_simultaneous: "{{ current_workflow_job_templates_asset_value.allow_simultaneous }}"
+    scm_branch: "{{ current_workflow_job_templates_asset_value.scm_branch }}"
+    webhook_service: "{{ current_workflow_job_templates_asset_value.webhook_service }}"
 ...


### PR DESCRIPTION
- Reduce the number of used variables.
- Organize the output in directories.
- Add the object ID as part of the generated file

### What does this PR do?
When exporting `job_templates` (and can be extensible to other objects), we get out of resources:
![image](https://user-images.githubusercontent.com/26822043/190576560-127d4499-2848-4d23-88af-98653f061178.png)
```
...
ok: [localhost] => (item=ORGANIZATIONLESS - TestLoop)
ok: [localhost] => (item=ORGANIZATIONLESS - Reboot Servers - [PROD])
ok: [localhost] => (item=ORGANIZATIONLESS - Reboot Servers - [NONPROD])
ERROR! A worker was found in a dead state

real    16m0.070s
user    13m23.096s
sys     1m45.619s
(venv) [lab] $ 
```
This PR is fixing this issue (it appears in large environments -more than 300 Job Templates, inventories, etc.- and organizing the output better.

### How should this be tested?
```
$ cat filetree_create.yml
---
- hosts: localhost
  connection: local
  gather_facts: false
  vars:
    controller_hostname: "{{ vault_controller_hostname }}"
    controller_username: "{{ vault_controller_username }}"
    controller_password: "{{ vault_controller_password }}"
    controller_validate_certs: "{{ vault_controller_validate_certs }}"
    controller_api_plugin: "ansible.controller.controller_api"
  pre_tasks:
    - name: "Check if the required input variables are present"
      assert:
        that:
          - input_tag is defined
          - (input_tag | type_debug) == 'list'
        fail_msg: 'A variable called ''input_tag'' of type ''list'' is needed: -e ''{input_tag: [organizations, projects]}'''
        quiet: true

    - name: "Check if the required input values are correct"
      assert:
        that:
          - tag_item in valid_tags
        fail_msg: "The valid tags are the following ones: {{ valid_tags | join(', ') }}"
        quiet: true
      loop: "{{ input_tag }}"
      loop_control:
        loop_var: tag_item
  roles:
    - redhat_cop.controller_configuration.filetree_create
...
$ ansible-playbook filetree_create.yml -e '{input_tag: [job_templates], output_path: ~/iam/filetree_create.2.1.7 }'
```
### Is there a relevant Issue open for this?
No issue opened for this.

### Other Relevant info, PRs, etc.
N/A
