### PR TITLE
Improve oauthtoken

### DIFF
--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -170,7 +170,7 @@ class LookupModule(LookupBase):
                 item.update({"unified_job_template": item["summary_fields"]["unified_job_template"]["name"]})
                 item.update({"workflow_job_template": item["summary_fields"]["workflow_job_template"]["name"]})
                 item.pop("summary_fields")
-        elif api_list[0]["type"] != "organization" and api_list[0]["type"] != "user":
+        elif api_list[0]["type"] != "organization" and api_list[0]["type"] != "user" and api_list[0]["type"] != "credential_type":
             for item in api_list_reduced:
                 item.update({"organization": item["summary_fields"]["organization"]["name"]})
                 item.pop("summary_fields")

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -29,4 +29,6 @@ output_path: "/tmp/filetree_output"
 # Maximum number of objects to return from the list. If a list view returns more an max_objects an exception will be raised
 query_controller_api_max_objects: 10000
 
+controller_configuration_filetree_create_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
+
 ...

--- a/roles/filetree_create/tasks/all.yml
+++ b/roles/filetree_create/tasks/all.yml
@@ -1,20 +1,21 @@
 ---
-- block:
-  - name: "Get the Authentication Token for the future requests"
-    ansible.builtin.uri:
-      url: "https://{{ controller_hostname }}/api/v2/tokens/"
-      user: "{{ controller_username }}"
-      password: "{{ controller_password }}"
-      method: POST
-      force_basic_auth: true
-      validate_certs: "{{ controller_validate_certs }}"
-      status_code: 201
-    register: authtoken_res
+- name: Generate oauth otken (block)
+  block:
+    - name: "Get the Authentication Token for the future requests"
+      ansible.builtin.uri:
+        url: "https://{{ controller_hostname }}/api/v2/tokens/"
+        user: "{{ controller_username }}"
+        password: "{{ controller_password }}"
+        method: POST
+        force_basic_auth: true
+        validate_certs: "{{ controller_validate_certs }}"
+        status_code: 201
+      register: authtoken_res
 
-  - name: "Set the oauth token to be used since now"
-    ansible.builtin.set_fact:
-      controller_oauthtoken: "{{ authtoken_res.json.token }}"
-      controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
+    - name: "Set the oauth token to be used since now"
+      ansible.builtin.set_fact:
+        controller_oauthtoken: "{{ authtoken_res.json.token }}"
+        controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
   when: controller_oauthtoken is not defined
 

--- a/roles/filetree_create/tasks/all.yml
+++ b/roles/filetree_create/tasks/all.yml
@@ -14,7 +14,7 @@
   - name: "Set the oauth token to be used since now"
     ansible.builtin.set_fact:
       controller_oauthtoken: "{{ authtoken_res.json.token }}"
-      oauthtoken_url: "{{ authtoken_res.json.url }}"
+      controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
   when: controller_oauthtoken is not defined
 
@@ -61,12 +61,12 @@
 
 - name: "Delete the Authentication Token used"
   ansible.builtin.uri:
-    url: "https://{{ controller_hostname }}{{ oauthtoken_url }}"
+    url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
     user: "{{ controller_username }}"
     password: "{{ controller_password }}"
     method: DELETE
     force_basic_auth: true
     validate_certs: "{{ controller_validate_certs }}"
     status_code: 204
-  when: oauthtoken_url is defined
+  when: controller_oauthtoken_url is defined
 ...

--- a/roles/filetree_create/tasks/all.yml
+++ b/roles/filetree_create/tasks/all.yml
@@ -1,24 +1,26 @@
 ---
-- name: "Get the Authentication Token for the future requests"
-  ansible.builtin.uri:
-    url: "https://{{ controller_hostname }}/api/v2/tokens/"
-    user: "{{ controller_username }}"
-    password: "{{ controller_password }}"
-    method: POST
-    force_basic_auth: true
-    validate_certs: "{{ controller_validate_certs }}"
-    status_code: 201
-  register: authtoken_res
+- block:
+  - name: "Get the Authentication Token for the future requests"
+    ansible.builtin.uri:
+      url: "https://{{ controller_hostname }}/api/v2/tokens/"
+      user: "{{ controller_username }}"
+      password: "{{ controller_password }}"
+      method: POST
+      force_basic_auth: true
+      validate_certs: "{{ controller_validate_certs }}"
+      status_code: 201
+    register: authtoken_res
 
-- name: "Set the oauth token to be used since now"
-  ansible.builtin.set_fact:
-    oauthtoken: "{{ authtoken_res.json.token }}"
-    oauthtoken_url: "{{ authtoken_res.json.url }}"
-  no_log: true
+  - name: "Set the oauth token to be used since now"
+    ansible.builtin.set_fact:
+      controller_oauthtoken: "{{ authtoken_res.json.token }}"
+      oauthtoken_url: "{{ authtoken_res.json.url }}"
+  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+  when: controller_oauthtoken is not defined
 
 - name: "Check if the connection is to an Ansible Tower or to Automation Platform"
   ansible.builtin.set_fact:
-    is_aap: "{{ lookup(controller_api_plugin, 'ping', host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs).version is version('4.0.0', '>=') }}"
+    is_aap: "{{ lookup(controller_api_plugin, 'ping', host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs).version is version('4.0.0', '>=') }}"
 
 - name: Include tasks (block)
   block:
@@ -66,4 +68,5 @@
     force_basic_auth: true
     validate_certs: "{{ controller_validate_certs }}"
     status_code: 204
+  when: oauthtoken_url is defined
 ...

--- a/roles/filetree_create/tasks/credential_types.yml
+++ b/roles/filetree_create/tasks/credential_types.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     credential_types_lookvar: "{{ query(controller_api_plugin, 'api/v2/credential_types/',
                                         query_params={'managed': false},
-                                        host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                        host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                         return_all=true, max_objects=query_controller_api_max_objects)
                                }}"
   when: is_aap
@@ -12,7 +12,7 @@
   ansible.builtin.set_fact:
     credential_types_lookvar: "{{ query(controller_api_plugin, 'api/v2/credential_types/',
                                         query_params={'managed_by_tower': false},
-                                        host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                        host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                         return_all=true, max_objects=query_controller_api_max_objects)
                                }}"
   when: not is_aap

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     credentials_lookvar: "{{ query(controller_api_plugin, 'api/v2/credentials/',
                                    query_params={'order_by': 'organization,id'},
-                                   host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                   host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                    return_all=true, max_objects=query_controller_api_max_objects)
                           }}"
 

--- a/roles/filetree_create/tasks/execution_environments.yml
+++ b/roles/filetree_create/tasks/execution_environments.yml
@@ -2,7 +2,7 @@
 - name: "Get current Execution Environments from the API"
   ansible.builtin.set_fact:
     execution_environments_lookvar: "{{ query(controller_api_plugin, 'api/v2/execution_environments/',
-                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                               return_all=true, max_objects=query_controller_api_max_objects)
                                      }}"
 

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     inventory_lookvar: "{{ query(controller_api_plugin, 'api/v2/inventories/',
                                  query_params={'not__kind': 'smart', 'order_by': 'organization,id'},
-                                 host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                 host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                  return_all=true, max_objects=query_controller_api_max_objects)
                         }}"
 
@@ -40,7 +40,7 @@
     inventory_name: "{{ current_inventory_sources.name | regex_replace('/','_') }}"
     inventory_sources_output_path: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
     current_inventory_sources_asset_value: "{{ query(controller_api_plugin, current_inventory_sources.related.inventory_sources,
-                                                          host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                                           return_all=true, max_objects=query_controller_api_max_objects
                                                     ) if current_inventory_sources.has_inventory_sources else []
                                             }}"
@@ -56,7 +56,7 @@
     inventory_name: "{{ current_inventory_hosts.name | regex_replace('/','_') }}"
     hosts_output_path: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
     current_hosts_asset_value: "{{ query(controller_api_plugin, current_inventory_hosts.related.hosts,
-                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                               return_all=true, max_objects=query_controller_api_max_objects
                                         ) if not current_inventory_hosts.has_inventory_sources else []
                                 }}"
@@ -72,7 +72,7 @@
     inventory_name: "{{ current_inventory_groups.name | regex_replace('/','_') }}"
     groups_output_path: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
     current_groups_asset_value: "{{ query(controller_api_plugin, current_inventory_groups.related.groups,
-                                               host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                                return_all=true, max_objects=query_controller_api_max_objects
                                          ) if not current_inventory_groups.has_inventory_sources else []
                                  }}"

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     job_templates_lookvar: "{{ query(controller_api_plugin, 'api/v2/job_templates/',
                                      query_params={'order_by': 'organization,id'},
-                                     host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                     host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                      return_all=true, max_objects=query_controller_api_max_objects)
                             }}"
 

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -2,7 +2,7 @@
 - name: "Get current Notification Templates from the API"
   ansible.builtin.set_fact:
     notification_templates_lookvar: "{{ query(controller_api_plugin, 'api/v2/notification_templates/',
-                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                               return_all=true, max_objects=query_controller_api_max_objects)
                                      }}"
 

--- a/roles/filetree_create/tasks/organizations.yml
+++ b/roles/filetree_create/tasks/organizations.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     orgs_lookvar: "{{ query(controller_api_plugin, 'api/v2/organizations/',
                             query_params={'order_by': 'id'},
-                            host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                             return_all=true, max_objects=query_controller_api_max_objects)
                    }}"
 

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     projects_lookvar: "{{ query(controller_api_plugin, 'api/v2/projects/',
                                 query_params={'order_by': 'organization,id'},
-                                host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                 return_all=true, max_objects=query_controller_api_max_objects)
                        }}"
 

--- a/roles/filetree_create/tasks/team_roles.yml
+++ b/roles/filetree_create/tasks/team_roles.yml
@@ -2,7 +2,7 @@
 - name: "Get current Team Roles from the API"
   ansible.builtin.set_fact:
     team_roles_lookvar: "{{ query(controller_api_plugin, 'api/v2/teams/' + teamid + '/roles/',
-                                  host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                   return_all=true, max_objects=query_controller_api_max_objects)
                          }}"
 

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     teams_lookvar: "{{ query(controller_api_plugin, 'api/v2/teams/',
                              query_params={'order_by': 'organization,id'},
-                             host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                              return_all=true, max_objects=query_controller_api_max_objects)
                     }}"
 

--- a/roles/filetree_create/tasks/user_roles.yml
+++ b/roles/filetree_create/tasks/user_roles.yml
@@ -2,7 +2,7 @@
 - name: "Get current Users from the API"
   ansible.builtin.set_fact:
     user_roles_lookvar: "{{ query(controller_api_plugin, 'api/v2/users/' + (username | urlencode()) + '/roles/',
-                                  host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                   return_all=true, max_objects=query_controller_api_max_objects)
                          }}"
 

--- a/roles/filetree_create/tasks/users.yml
+++ b/roles/filetree_create/tasks/users.yml
@@ -2,7 +2,7 @@
 - name: "Get current Users from the API"
   ansible.builtin.set_fact:
     users_lookvar: "{{ query(controller_api_plugin, 'api/v2/users/',
-                             host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                              return_all=true, max_objects=query_controller_api_max_objects)
                     }}"
 
@@ -10,7 +10,7 @@
   ansible.builtin.set_fact:
     current_users: "{{ (current_users | default([])) + [user_lookvar_item | combine({'organizations': user_lookvar_item_organizations})] }}"
   vars:
-    user_lookvar_item_organizations: "{{ query(controller_api_plugin, user_lookvar_item.related.organizations, host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) | selectattr('name', 'defined') | map(attribute='name') }}"
+    user_lookvar_item_organizations: "{{ query(controller_api_plugin, user_lookvar_item.related.organizations, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs, return_all=true, max_objects=query_controller_api_max_objects) | selectattr('name', 'defined') | map(attribute='name') }}"
   loop: "{{ users_lookvar }}"
   loop_control:
     loop_var: user_lookvar_item

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     workflow_job_templates_lookvar: "{{ query(controller_api_plugin, 'api/v2/workflow_job_templates/',
                                               query_params={'order_by': 'organization,id'},
-                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                               return_all=true, max_objects=query_controller_api_max_objects)
                                      }}"
 

--- a/roles/filetree_create/templates/current_groups.j2
+++ b/roles/filetree_create/templates/current_groups.j2
@@ -6,7 +6,7 @@ configure_tower_groups:
     inventory: "{{ group.summary_fields.inventory.name }}"
     hosts:
 {{ query(controller_api_plugin, group.related.hosts,
-         host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+         host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
          return_all=true, max_objects=query_controller_api_max_objects
    ) | selectattr("name", "defined") | map(attribute="name") | to_nice_yaml(indent=2) | indent(width=6, first=True)
 }}

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -6,7 +6,7 @@ controller_workflows:
     simplified_workflow_nodes:
 {% for node in query(controller_api_plugin, 'api/v2/workflow_job_template_nodes/',
                      query_params={'workflow_job_template': current_workflow_job_templates_asset_value.id},
-                     host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs,
+                     host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) %}
       - identifier: "{{ node.identifier }}"
         workflow_job_template: "{{ node.summary_fields.workflow_job_template.name }}"
@@ -19,19 +19,19 @@ controller_workflows:
 {% if node.success_nodes is defined and node.success_nodes | length > 0 %}
         success_nodes:
 {% for success in node.success_nodes %}
-          - {{ query(controller_api_plugin, 'workflow_job_template_nodes/'+(success | string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
+          - {{ query(controller_api_plugin, 'workflow_job_template_nodes/'+(success | string), host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
 {% endfor %}
 {% endif %}
 {% if node.always_nodes and node.always_nodes | length > 0 %}
         always_nodes:
 {% for always in node.always_nodes %}
-          - {{ query(controller_api_plugin, 'workflow_job_template_nodes/'+(always | string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
+          - {{ query(controller_api_plugin, 'workflow_job_template_nodes/'+(always | string), host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
 {% endfor %}
 {% endif %}
 {% if node.failure_nodes and node.failure_nodes | length > 0 %}
         failure_nodes:
 {% for failure in node.failure_nodes %}
-          - {{ query(controller_api_plugin, 'workflow_job_template_nodes/'+(failure | string), host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
+          - {{ query(controller_api_plugin, 'workflow_job_template_nodes/'+(failure | string), host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)[0].identifier }}
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/roles/filetree_read/README.md
+++ b/roles/filetree_read/README.md
@@ -296,6 +296,26 @@ The role is designed to be used with tags, each tags correspond to an AWX or Aut
     controller_configuration_projects_async_retries: 60
     controller_configuration_projects_async_delay: 2
   pre_tasks:
+    - name: "Setup authentication (block)"
+      block:
+        - name: "Get the Authentication Token for the future requests"
+          ansible.builtin.uri:
+            url: "https://{{ controller_hostname }}/api/v2/tokens/"
+            user: "{{ controller_username }}"
+            password: "{{ controller_password }}"
+            method: POST
+            force_basic_auth: true
+            validate_certs: "{{ controller_validate_certs }}"
+            status_code: 201
+          register: authtoken_res
+
+        - name: "Set the oauth token to be used since now"
+          ansible.builtin.set_fact:
+            controller_oauthtoken: "{{ authtoken_res.json.token }}"
+            oauthtoken_url: "{{ authtoken_res.json.url }}"
+          no_log: true
+      when: controller_oauthtoken is not defined
+
     - block:
         - name: Include Tasks to load Galaxy credentials to be added to Organizations
           ansible.builtin.include_role:
@@ -323,6 +343,18 @@ The role is designed to be used with tags, each tags correspond to an AWX or Aut
   roles:
     - {role: redhat_cop.controller_configuration.filetree_read }
     - {role: redhat_cop.controller_configuration.dispatch }
+
+  post_tasks:
+    - name: "Delete the Authentication Token used"
+      ansible.builtin.uri:
+        url: "https://{{ controller_hostname }}{{ oauthtoken_url }}"
+        user: "{{ controller_username }}"
+        password: "{{ controller_password }}"
+        method: DELETE
+        force_basic_auth: true
+        validate_certs: "{{ controller_validate_certs }}"
+        status_code: 204
+      when: oauthtoken_url is defined
 ...
 
 ```

--- a/roles/filetree_read/README.md
+++ b/roles/filetree_read/README.md
@@ -312,7 +312,7 @@ The role is designed to be used with tags, each tags correspond to an AWX or Aut
         - name: "Set the oauth token to be used since now"
           ansible.builtin.set_fact:
             controller_oauthtoken: "{{ authtoken_res.json.token }}"
-            oauthtoken_url: "{{ authtoken_res.json.url }}"
+            controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
           no_log: true
       when: controller_oauthtoken is not defined
 
@@ -347,14 +347,14 @@ The role is designed to be used with tags, each tags correspond to an AWX or Aut
   post_tasks:
     - name: "Delete the Authentication Token used"
       ansible.builtin.uri:
-        url: "https://{{ controller_hostname }}{{ oauthtoken_url }}"
+        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
         user: "{{ controller_username }}"
         password: "{{ controller_password }}"
         method: DELETE
         force_basic_auth: true
         validate_certs: "{{ controller_validate_certs }}"
         status_code: 204
-      when: oauthtoken_url is defined
+      when: controller_oauthtoken_url is defined
 ...
 
 ```

--- a/roles/filetree_read/tasks/main.yml
+++ b/roles/filetree_read/tasks/main.yml
@@ -1,29 +1,5 @@
 ---
 # tasks file for filetree_read
-
-- name: "Setup authentication (block)"
-  block:
-    - name: "Get the Authentication Token for the future requests"
-      ansible.builtin.uri:
-        url: "https://{{ controller_hostname }}/api/v2/tokens/"
-        user: "{{ controller_username }}"
-        password: "{{ controller_password }}"
-        method: POST
-        force_basic_auth: true
-        validate_certs: "{{ controller_validate_certs }}"
-        status_code: 201
-      register: authtoken_res
-
-    - name: "Set the oauth token to be used since now"
-      ansible.builtin.set_fact:
-        controller_oauthtoken: "{{ authtoken_res.json.token }}"
-        oauthtoken_url: "{{ authtoken_res.json.url }}"
-      no_log: true
-
-  tags:
-    - always
-
-
 - name: "Include Tasks to config {{  __task_filetree_read.name }}"
   ansible.builtin.include_tasks: "{{  __task_filetree_read.name }}.yml"
   args:
@@ -33,5 +9,4 @@
   loop: "{{ controller_configuration_filetree_read_tasks }}"
   loop_control:
     loop_var: __task_filetree_read
-
 ...

--- a/roles/filetree_read/tests/config-controller-filetree.yml
+++ b/roles/filetree_read/tests/config-controller-filetree.yml
@@ -6,6 +6,26 @@
     controller_configuration_projects_async_retries: 60
     controller_configuration_projects_async_delay: 2
   pre_tasks:
+    - name: "Setup authentication (block)"
+      block:
+        - name: "Get the Authentication Token for the future requests"
+          ansible.builtin.uri:
+            url: "https://{{ controller_hostname }}/api/v2/tokens/"
+            user: "{{ controller_username }}"
+            password: "{{ controller_password }}"
+            method: POST
+            force_basic_auth: true
+            validate_certs: "{{ controller_validate_certs }}"
+            status_code: 201
+          register: authtoken_res
+
+        - name: "Set the oauth token to be used since now"
+          ansible.builtin.set_fact:
+            controller_oauthtoken: "{{ authtoken_res.json.token }}"
+            oauthtoken_url: "{{ authtoken_res.json.url }}"
+      no_log: "{{ controller_configuration_filetree_read_secure_logging | default('false') }}"
+      when: controller_oauthtoken is not defined
+
     - block:
         - name: Include Tasks to load Galaxy credentials to be added to Organizations
           ansible.builtin.include_role:
@@ -33,4 +53,16 @@
   roles:
     - {role: redhat_cop.controller_configuration.filetree_read}
     - {role: redhat_cop.controller_configuration.dispatch}
+
+  post_tasks:
+    - name: "Delete the Authentication Token used"
+      ansible.builtin.uri:
+        url: "https://{{ controller_hostname }}{{ oauthtoken_url }}"
+        user: "{{ controller_username }}"
+        password: "{{ controller_password }}"
+        method: DELETE
+        force_basic_auth: true
+        validate_certs: "{{ controller_validate_certs }}"
+        status_code: 204
+      when: oauthtoken_url is defined
 ...

--- a/roles/filetree_read/tests/config-controller-filetree.yml
+++ b/roles/filetree_read/tests/config-controller-filetree.yml
@@ -22,7 +22,7 @@
         - name: "Set the oauth token to be used since now"
           ansible.builtin.set_fact:
             controller_oauthtoken: "{{ authtoken_res.json.token }}"
-            oauthtoken_url: "{{ authtoken_res.json.url }}"
+            controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
       no_log: "{{ controller_configuration_filetree_read_secure_logging | default('false') }}"
       when: controller_oauthtoken is not defined
 
@@ -57,12 +57,12 @@
   post_tasks:
     - name: "Delete the Authentication Token used"
       ansible.builtin.uri:
-        url: "https://{{ controller_hostname }}{{ oauthtoken_url }}"
+        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
         user: "{{ controller_username }}"
         password: "{{ controller_password }}"
         method: DELETE
         force_basic_auth: true
         validate_certs: "{{ controller_validate_certs }}"
         status_code: 204
-      when: oauthtoken_url is defined
+      when: controller_oauthtoken_url is defined
 ...

--- a/roles/object_diff/defaults/main.yml
+++ b/roles/object_diff/defaults/main.yml
@@ -48,4 +48,6 @@ controller_configuration_object_diff_tasks:
   - {name: credential_types, var: controller_credential_types, tags: credential_types}
   - {name: organizations, var: controller_organizations, tags: organizations}
 
+controller_configuration_object_diff_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
+
 ...

--- a/roles/object_diff/tasks/credential_types.yml
+++ b/roles/object_diff/tasks/credential_types.yml
@@ -1,17 +1,11 @@
 ---
 # tasks file for controller_credential_types
-- name: Get the organization ID
-  ansible.builtin.set_fact:
-    __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={'name': orgs},
-      host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
-
-- name: "OBJECT DIFF: Get the API list of all Projects {{ orgs }} Organization"
+- name: "OBJECT DIFF: Get the API list of all Credential Types"
   ansible.builtin.set_fact:
     __controller_api_credential_types: "{{ query(controller_api_plugin, 'credential_types',
-      query_params={'organization': __controller_organization_id.id},
-      host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false) }}"
+      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false) }}"
 
-- name: "OBJECT DIFF: Find the difference of Project between what is on the Controller versus CasC on SCM"
+- name: "OBJECT DIFF: Find the difference of Credential Types between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
     __credential_types_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
       api_list=__controller_api_credential_types, compare_list=controller_credential_types,

--- a/roles/object_diff/tasks/credentials.yml
+++ b/roles/object_diff/tasks/credentials.yml
@@ -4,17 +4,17 @@
   ansible.builtin.set_fact:
     __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                               query_params={'name': orgs},
-                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all Projects {{ orgs }} Organization"
+- name: "OBJECT DIFF: Get the API list of all Credentials {{ orgs }} Organization"
   ansible.builtin.set_fact:
     __controller_api_credentials: "{{ query(controller_api_plugin, 'credentials',
                                             query_params={'organization': __controller_organization_id.id},
-                                            host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                    }}"
 
-- name: "OBJECT DIFF: Find the difference of Project between what is on the Controller versus CasC on SCM"
+- name: "OBJECT DIFF: Find the difference of Credentials between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
     __credentials_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                           api_list=__controller_api_credentials, compare_list=controller_credentials,

--- a/roles/object_diff/tasks/groups.yml
+++ b/roles/object_diff/tasks/groups.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                             query_params={'name': orgs},
-                                            host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                  }}"
 
 - name: "OBJECT DIFF: Get the API list of all inventories"
@@ -30,7 +30,7 @@
 
 - name: "Group differences (block)"
   block:
-    - name: "OBJECT DIFF: Find the difference of Project between what is on the Controller versus CasC on SCM"
+    - name: "OBJECT DIFF: Find the difference of Groups between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         __groups_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                         query_params={'summary_fields.inventory.organization_id': controller_organization_id.id},

--- a/roles/object_diff/tasks/hosts.yml
+++ b/roles/object_diff/tasks/hosts.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                             query_params={'name': orgs},
-                                            host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                  }}"
 
 - name: "OBJECT DIFF: Get the API list of all inventories"
@@ -30,7 +30,7 @@
 
 - name: "Host differences (block)"
   block:
-    - name: "OBJECT DIFF: Find the difference of Project between what is on the Controller versus CasC on SCM"
+    - name: "OBJECT DIFF: Find the difference of Hosts between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         __hosts_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                         query_params={'summary_fields.inventory.organization_id': controller_organization_id.id},

--- a/roles/object_diff/tasks/inventories.yml
+++ b/roles/object_diff/tasks/inventories.yml
@@ -3,17 +3,17 @@
   ansible.builtin.set_fact:
     __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                              query_params={'name': orgs},
-                                             host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                    }}"
 
 - name: "OBJECT DIFF: Get the API list of all Inventories"
   ansible.builtin.set_fact:
     __controller_api_inventories: "{{ query(controller_api_plugin, 'inventories',
                                             query_params={'organization': __controller_organization_id.id},
-                                            host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                    }}"
 
-- name: "OBJECT DIFF: Find the difference of Project between what is on the Controller versus CasC on SCM"
+- name: "OBJECT DIFF: Find the difference of Inventories between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
     __inventories_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                          api_list=__controller_api_inventories, compare_list=controller_inventories,

--- a/roles/object_diff/tasks/inventory_sources.yml
+++ b/roles/object_diff/tasks/inventory_sources.yml
@@ -3,17 +3,17 @@
   ansible.builtin.set_fact:
     __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                              query_params={'name': orgs},
-                                             host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all Inventories"
+- name: "OBJECT DIFF: Get the API list of all Inventory Sources"
   ansible.builtin.set_fact:
     __controller_api_inventory_sources: "{{ query(controller_api_plugin, 'inventory_sources',
                                                   query_params={'organization': __controller_organization_id.id},
-                                                  host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                          }}"
 
-- name: "OBJECT DIFF: Find the difference of Project between what is on the Controller versus CasC on SCM"
+- name: "OBJECT DIFF: Find the difference of Inventory Sources between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
     __inventory_sources_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                                 api_list=__controller_api_inventory_sources,

--- a/roles/object_diff/tasks/job_templates.yml
+++ b/roles/object_diff/tasks/job_templates.yml
@@ -3,14 +3,14 @@
   ansible.builtin.set_fact:
     __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                               query_params={'name': orgs},
-                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                    }}"
 
 - name: "OBJECT DIFF: Get the API list of all Job Templates {{ orgs }} Organization"
   ansible.builtin.set_fact:
     __controller_api_job_templates: "{{ query(controller_api_plugin, 'job_templates',
                                               query_params={'organization': __controller_organization_id.id},
-                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                      }}"
 
 - name: "OBJECT DIFF: Find the difference of Job Templates between what is on the Controller versus CasC on SCM"

--- a/roles/object_diff/tasks/main.yml
+++ b/roles/object_diff/tasks/main.yml
@@ -43,7 +43,7 @@
     - name: "Set the oauth token to be used since now"
       ansible.builtin.set_fact:
         controller_oauthtoken: "{{ authtoken_res.json.token }}"
-        oauthtoken_url: "{{ authtoken_res.json.url }}"
+        controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
   no_log: "{{ controller_configuration_object_diff_secure_logging }}"
   when: controller_oauthtoken is not defined
   tags:
@@ -61,12 +61,12 @@
 
 - name: "Delete the Authentication Token used"
   ansible.builtin.uri:
-    url: "https://{{ controller_hostname }}{{ oauthtoken_url }}"
+    url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
     user: "{{ controller_username }}"
     password: "{{ controller_password }}"
     method: DELETE
     force_basic_auth: true
     validate_certs: "{{ controller_validate_certs }}"
     status_code: 204
-  when: oauthtoken_url is defined
+  when: controller_oauthtoken_url is defined
 ...

--- a/roles/object_diff/tasks/main.yml
+++ b/roles/object_diff/tasks/main.yml
@@ -1,5 +1,32 @@
 ---
 # tasks file for object_diff
+- name: "Check requirements (block)"
+  block:
+    - name: "Check installed collections (block)"
+      block:
+        - name: "Check if the collection ansible.controller is installed"
+          ansible.builtin.set_fact:
+            ansible_controller_collection_installed: "{{ lookup('ansible.builtin.pipe', 'ansible-galaxy collection list | grep -i ansible.controller || echo NOTINSTALLED') }}"
+          failed_when: ansible_controller_collection_installed is match('NOTINSTALLED')
+      rescue:
+        - name: "Check if the collection awx.awx is installed"
+          ansible.builtin.set_fact:
+            awx_awx_collection_installed: "{{ lookup('ansible.builtin.pipe', 'ansible-galaxy collection list | grep -i awx.awx || echo NOTINSTALLED') }}"
+          failed_when: awx_awx_collection_installed is match('NOTINSTALLED')
+      always:
+        - name: "Set the collection providing the controller_api lookup plugin"
+          ansible.builtin.set_fact:
+            controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api' if awx_awx_collection_installed is defined) | default('NONE') }}"
+        - name: "Fail if no collection is detected"
+          ansible.builtin.fail:
+            msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."
+          when: controller_api_plugin is match('NONE')
+        - name: "Show the plugin we are using"
+          ansible.builtin.debug:
+            msg: "Using the 'controller_api' plugin from: {{ controller_api_plugin }}"
+  tags:
+    - always
+
 - name: "Setup authentication (block)"
   block:
     - name: "Get the Authentication Token for the future requests"
@@ -15,10 +42,10 @@
 
     - name: "Set the oauth token to be used since now"
       ansible.builtin.set_fact:
-        oauthtoken: "{{ authtoken_res.json.token }}"
+        controller_oauthtoken: "{{ authtoken_res.json.token }}"
         oauthtoken_url: "{{ authtoken_res.json.url }}"
-      no_log: true
-
+  no_log: "{{ controller_configuration_object_diff_secure_logging }}"
+  when: controller_oauthtoken is not defined
   tags:
     - always
 
@@ -32,4 +59,14 @@
   loop_control:
     loop_var: __task_diff
 
+- name: "Delete the Authentication Token used"
+  ansible.builtin.uri:
+    url: "https://{{ controller_hostname }}{{ oauthtoken_url }}"
+    user: "{{ controller_username }}"
+    password: "{{ controller_password }}"
+    method: DELETE
+    force_basic_auth: true
+    validate_certs: "{{ controller_validate_certs }}"
+    status_code: 204
+  when: oauthtoken_url is defined
 ...

--- a/roles/object_diff/tasks/organizations.yml
+++ b/roles/object_diff/tasks/organizations.yml
@@ -2,7 +2,7 @@
 - name: "Gets current Organizations configured"
   ansible.builtin.set_fact:
     __controller_api_organizations: "{{ query(controller_api_plugin, 'organizations',
-      host=controller_hostname, oauth_token=oauthtoken, verify_ssl=controller_validate_certs) }}"
+      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) }}"
 
 - name: "OBJECT DIFF: Find the difference of Organizations between what is on the Controller versus curated list."
   ansible.builtin.set_fact:

--- a/roles/object_diff/tasks/projects.yml
+++ b/roles/object_diff/tasks/projects.yml
@@ -3,14 +3,14 @@
   ansible.builtin.set_fact:
     __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                               query_params={'name': orgs},
-                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                    }}"
 
 - name: "OBJECT DIFF: Get the API list of all Projects {{ orgs }} Organization"
   ansible.builtin.set_fact:
     __controller_api_projects: "{{ query(controller_api_plugin, 'projects',
                                           query_params={'organization': __controller_organization_id.id},
-                                          host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                 }}"
 
 - name: "OBJECT DIFF: Find the difference of Project between what is on the Controller versus CasC on SCM"

--- a/roles/object_diff/tasks/roles.yml
+++ b/roles/object_diff/tasks/roles.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
                                                               query_params={'username': controller_username},
-                                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                                    }}"
 
 - name: "Role differences (block)"

--- a/roles/object_diff/tasks/teams.yml
+++ b/roles/object_diff/tasks/teams.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
                                                               query_params={'username': controller_username},
-                                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                                    }}"
 
 - name: "Team differences (block)"
@@ -12,14 +12,14 @@
       ansible.builtin.set_fact:
         __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                                   query_params={'name': orgs},
-                                                  host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                        }}"
 
     - name: "OBJECT DIFF: Get the API list of all teams {{ orgs }} Organization"
       ansible.builtin.set_fact:
         __controller_api_teams: "{{ query(controller_api_plugin, 'teams',
                                           query_params={'organization': __controller_organization_id.id},
-                                          host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                  }}"
 
     - name: "OBJECT DIFF: Find the difference of Teams between what is on the Controller versus CasC on SCM"

--- a/roles/object_diff/tasks/user_accounts.yml
+++ b/roles/object_diff/tasks/user_accounts.yml
@@ -4,13 +4,13 @@
   ansible.builtin.set_fact:
     __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
                                                               query_params={'username': controller_username},
-                                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                                    }}"
 
 - name: "OBJECT DIFF: Sets the current controller user to determine if it is super-admin"
   ansible.builtin.set_fact:
     __controller_api_user_accounts: "{{ query(controller_api_plugin, 'users',
-                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                      }}"
 
 - name: "Populate user accounts (block)"
@@ -24,7 +24,7 @@
         __controller_api_user_accounts: "{{ populate_controller_api_user_accounts_without_external_accounts }}"
       when: populate_controller_api_user_accounts_without_external_accounts is defined
 
-  ansible.builtin.when:
+  when:
     - drop_user_external_accounts is defined
     - drop_user_external_accounts
 

--- a/roles/object_diff/tasks/workflow_job_templates.yml
+++ b/roles/object_diff/tasks/workflow_job_templates.yml
@@ -3,14 +3,14 @@
   ansible.builtin.set_fact:
     __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                               query_params={'name': orgs},
-                                              host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                    }}"
 
 - name: "OBJECT DIFF: Get the API list of all Workflow Job Templates"
   ansible.builtin.set_fact:
     __controller_api_workflow_job_templates: "{{ query(controller_api_plugin, 'workflow_job_templates',
                                                         query_params={'organization': __controller_organization_id.id},
-                                                        host=controller_hostname, oauth_token=oauthtoken, verify_ssl=false)
+                                                        host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
                                               }}"
 
 - name: "OBJECT DIFF: Find the difference of Workflow Job Templates between what is on the Controller versus CasC on SCM"

--- a/roles/object_diff/tests/object_diff.yml
+++ b/roles/object_diff/tests/object_diff.yml
@@ -3,5 +3,6 @@
   connection: local
   gather_facts: false
   roles:
+    - redhat_cop.controller_configuration.filetree_read
     - redhat_cop.controller_configuration.object_diff
 ...


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?
This PR try to improve the managment of oauthtoken for filetree_create, filetree_read and object_diff roles and some other fixes which they were seen during tests:

1. oauthtoken var is renamed because follow naming of the rest of roles: oauthtoken -> controller_oauthtoken
2. Control if controller_oauthtoken is given, the roles will not create the oauth token
3. If oauth token is created, it will be deleted at the end.
4. Remove generate token in filetree_read because this role only is to read variable definitions.
5. Add check what collection ansible.controller or ansible.awx is installed for object_diff role
6. fix controller_object_diff.py: it was I was handling credential_type as it would have organization.

### How should this be tested?

Launch test playbooks for filetree_create, filetree_read and object_diff roles.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc
I think that, after this PR will be merged, I should generate a new release version because we have a lot of new features and fixes and we already have customers testing CasC using these roles.