### PR TITLE
Fixing issues encountered during import of production objects.

### DIFF
--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -40,6 +40,4 @@ GPLv3+
 
 ## Author Information
 
-- Ivan Aragonés:
-  - email: <iaragone@redhat.com>
-  - github: <https://github.com/ivarmu>
+- [Ivan Aragonés](https://github.com/ivarmu)

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -9,27 +9,30 @@
 
 - name: "Create the output directory for credentials: {{ output_path }}/<ORGANIZATION_NAME>/credentials"
   ansible.builtin.file:
-    path: "{{ output_path }}/{{ needed_path }}/credentials"
+    path: "{{ __path }}"
     state: directory
     mode: '0755'
+  vars:
+    __path: "{{ output_path }}/{{ needed_path }}/credentials"
   loop: "{{ (credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}/credentials"
+    label: "{{ __path }}"
 
 - name: "Add current credentials to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/credentials"
   ansible.builtin.template:
     src: "templates/current_credentials.j2"
-    dest: "{{ output_path }}/{{ credentials_organization }}/credentials/{{ credentials_id }}_{{ credentials_name }}.yaml"
+    dest: "{{ __dest }}"
     mode: '0644'
   vars:
     credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
     credentials_id: "{{ current_credentials_asset_value.id }}"
     credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"
+    __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/credentials/{{ credentials_id }}_{{ credentials_name | regex_replace('/', '_') }}.yaml"
   loop: "{{ credentials_lookvar }}"
   loop_control:
     loop_var: current_credentials_asset_value
-    label: "{{ output_path }}/{{ credentials_organization }}/credentials/{{ credentials_id }}_{{ credentials_name }}.yaml"
+    label: "{{ __dest }}"
 ...

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -7,38 +7,40 @@
                                  return_all=true, max_objects=query_controller_api_max_objects)
                         }}"
 
-- name: "Create the output directory for inventories: {{ output_path }}/<ORGANIZATION_NAME>/inventories"
+- name: "Create the output directory for inventories: {{ output_path | regex_replace('/', '_') }}/<ORGANIZATION_NAME>/inventories"
   ansible.builtin.file:
-    path: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
+    path: "{{ __path }}"
     state: directory
     mode: '0755'
   vars:
     inventory_organization: "{{ needed_path.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
     inventory_name: "{{ needed_path.name | regex_replace('/', '_') }}"
+    __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
+    label: "{{ __path }}"
 
-- name: "Add current inventories to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/inventories"
+- name: "Add current inventories to the output yaml file: {{ output_path | regex_replace('/', '_') }}/<ORGANIZATION_NAME>/inventories"
   ansible.builtin.template:
     src: "templates/current_inventories.j2"
-    dest: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}/{{ current_inventories_asset_value.id }}_{{ inventory_name }}.yaml"
+    dest: "{{ __dest }}"
     mode: '0644'
   vars:
     inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
     inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
+    __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ current_inventories_asset_value.id }}_{{ inventory_name | regex_replace('/', '_') }}.yaml"
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: current_inventories_asset_value
-    label: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}/{{ current_inventories_asset_value.id }}_{{ inventory_name }}.yaml"
+    label: "{{ __dest }}"
 
 - name: "Set the inventory's inventory sources"
   ansible.builtin.include_tasks: "inventory_sources.yml"
   vars:
     inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
     inventory_name: "{{ current_inventory_sources.name | regex_replace('/','_') }}"
-    inventory_sources_output_path: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
+    inventory_sources_output_path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
     current_inventory_sources_asset_value: "{{ query(controller_api_plugin, current_inventory_sources.related.inventory_sources,
                                                           host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                                           return_all=true, max_objects=query_controller_api_max_objects
@@ -54,7 +56,7 @@
   vars:
     inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
     inventory_name: "{{ current_inventory_hosts.name | regex_replace('/','_') }}"
-    hosts_output_path: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
+    hosts_output_path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
     current_hosts_asset_value: "{{ query(controller_api_plugin, current_inventory_hosts.related.hosts,
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                               return_all=true, max_objects=query_controller_api_max_objects
@@ -70,7 +72,7 @@
   vars:
     inventory_organization: "{{ current_inventory_groups.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
     inventory_name: "{{ current_inventory_groups.name | regex_replace('/','_') }}"
-    groups_output_path: "{{ output_path }}/{{ inventory_organization }}/inventories/{{ inventory_name }}"
+    groups_output_path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
     current_groups_asset_value: "{{ query(controller_api_plugin, current_inventory_groups.related.groups,
                                                host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                                return_all=true, max_objects=query_controller_api_max_objects

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -9,27 +9,30 @@
 
 - name: "Create the output directories for job templates: {{ output_path }}/<ORGANIZATION_NAME>"
   ansible.builtin.file:
-    path: "{{ output_path }}/{{ needed_path }}/job_templates"
+    path: "{{ __path }}"
     state: directory
     mode: '0755'
+  vars:
+    __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/job_templates"
   loop: "{{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}/job_templates"
+    label: "{{ __path }}"
 
 - name: "Add current job_templates to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/job_templates"
   ansible.builtin.template:
     src: "templates/current_job_templates.j2"
-    dest: "{{ output_path }}/{{ job_template_organization }}/job_templates/{{ job_template_id }}_{{ job_template_name }}.yaml"
+    dest: "{{ __dest }}"
     mode: '0644'
   vars:
     job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
     job_template_id: "{{ current_job_templates_asset_value.id }}"
     job_template_name: "{{ current_job_templates_asset_value.name | regex_replace('/', '_') }}"
+    __dest: "{{ output_path }}/{{ job_template_organization | regex_replace('/', '_') }}/job_templates/{{ job_template_id }}_{{ job_template_name | regex_replace('/', '_') }}.yaml"
   loop: "{{ job_templates_lookvar }}"
   loop_control:
     loop_var: current_job_templates_asset_value
-    label: "{{ output_path }}/{{ job_template_organization }}/job_templates/{{ job_template_id }}_{{ job_template_name }}.yaml"
+    label: "{{ __dest }}"
 ...

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -8,23 +8,27 @@
 
 - name: "Create the output directory for notification templates: {{ output_path }}/<ORGANIZATION_NAME>/notification_templates"
   ansible.builtin.file:
-    path: "{{ output_path }}/{{ needed_path }}/notification_templates"
+    path: "{{ __path }}"
     state: directory
     mode: '0755'
+  vars:
+    __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/notification_templates"
   loop: "{{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}/notification_templates"
+    label: "{{ __path }}"
 
 - name: "Add current notification templates to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/current_notification_templates.yaml"
   ansible.builtin.template:
     src: "templates/current_notification_templates.j2"
-    dest: "{{ output_path }}/{{ current_notification_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/notification_templates/{{ current_notification_templates_asset_value.name | regex_replace('/', '_') }}.yaml"
+    dest: "{{ __dest }}"
     mode: '0644'
+  vars:
+    __dest: "{{ output_path }}/{{ (current_notification_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}/notification_templates/{{ current_notification_templates_asset_value.name | regex_replace('/', '_') }}.yaml"
   loop: "{{ notification_templates_lookvar }}"
   loop_control:
     loop_var: current_notification_templates_asset_value
-    label: "{{ output_path }}/{{ current_notification_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}/notification_templates/{{ current_notification_templates_asset_value.name | regex_replace('/', '_') }}.yaml"
+    label: "{{ __dest }}"
 ...

--- a/roles/filetree_create/tasks/organizations.yml
+++ b/roles/filetree_create/tasks/organizations.yml
@@ -9,21 +9,25 @@
 
 - name: "Create the output directory for organizations: {{ output_path }}/{{ current_organization_dir.name }}"
   ansible.builtin.file:
-    path: "{{ output_path }}/{{ current_organization_dir.name }}"
+    path: "{{ __path }}"
     state: directory
     mode: '0755'
+  vars:
+    __path: "{{ output_path }}/{{ current_organization_dir.name | regex_replace('/', '_') }}"
   loop: "{{ orgs_lookvar }}"
   loop_control:
     loop_var: current_organization_dir
-    label: "{{ output_path }}/{{ current_organization_dir.name }}"
+    label: "{{ __path }}"
 
 - name: "Add current organizations to the output yaml file"
   ansible.builtin.template:
     src: "templates/current_organizations.j2"
-    dest: "{{ output_path }}/{{ current_organization.name }}/current_organization.yaml"
+    dest: "{{ __dest }}"
     mode: '0644'
+  vars:
+    __dest: "{{ output_path }}/{{ current_organization.name | regex_replace('/', '_') }}/current_organization.yaml"
   loop: "{{ orgs_lookvar }}"
   loop_control:
     loop_var: current_organization
-    label: "{{ output_path }}/{{ current_organization.name }}/current_organization.yaml"
+    label: "{{ __dest }}"
 ...

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -9,27 +9,30 @@
 
 - name: "Create the output directory for projects: {{ output_path }}/<ORGANIZATION_NAME>/projects"
   ansible.builtin.file:
-    path: "{{ output_path }}/{{ needed_path }}/projects"
+    path: "{{ __path }}"
     state: directory
     mode: '0755'
+  vars:
+    __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/projects"
   loop: "{{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}/projects"
+    label: "{{ __path }}"
 
 - name: "Add current projects to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/projects"
   ansible.builtin.template:
     src: "templates/current_projects.j2"
-    dest: "{{ output_path }}/{{ project_organization }}/projects/{{ project_id }}_{{ project_name }}.yaml"
+    dest: "{{ __dest }}"
     mode: '0644'
   vars:
     project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
     project_id: "{{ current_projects_asset_value.id }}"
     project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"
+    __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/projects/{{ project_id }}_{{ project_name | regex_replace('/', '_') }}.yaml"
   loop: "{{ projects_lookvar }}"
   loop_control:
     loop_var: current_projects_asset_value
-    label: "{{ output_path }}/{{ project_organization }}/projects/{{ project_id }}_{{ project_name }}.yaml"
+    label: "{{ __dest }}"
 ...

--- a/roles/filetree_create/tasks/roles.yml
+++ b/roles/filetree_create/tasks/roles.yml
@@ -8,12 +8,13 @@
 - name: "Add current roles to the output yaml file"
   ansible.builtin.template:
     src: "templates/current_roles.j2"
-    dest: "{{ output_path }}/current_roles_{{ current_user_roles.key }}.yaml"
+    dest: "{{ __dest }}"
     mode: '0644'
+  vars:
+    main_object_type: "{{ object_type }}"
+    __dest: "{{ output_path }}/current_roles_{{ current_user_roles.key | regex_replace('/', '_') }}.yaml"
   loop: "{{ current_asset_value | dict2items }}"
   loop_control:
     loop_var: current_user_roles
-    label: "{{ current_user_roles.key }} at file {{ output_path }}/current_roles_{{ current_user_roles.key }}.yaml"
-  vars:
-    main_object_type: "{{ object_type }}"
+    label: "{{ current_user_roles.key }} at file {{ __dest }}"
 ...

--- a/roles/filetree_create/tasks/team_roles.yml
+++ b/roles/filetree_create/tasks/team_roles.yml
@@ -15,7 +15,7 @@
 - name: "Add current roles to the output yaml file"
   ansible.builtin.template:
     src: "templates/current_team_roles.j2"
-    dest: "{{ output_path }}/current_roles_{{ teamname }}.yaml"
+    dest: "{{ output_path }}/current_roles_{{ teamname | regex_replace('/', '_') }}.yaml"
     mode: '0644'
   vars:
     current_team_roles_asset_value: "{{ team_roles_lookvar }}"

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -9,29 +9,32 @@
 
 - name: "Create the output directory for teams: {{ output_path }}/<ORGANIZATION_NAME>/teams"
   ansible.builtin.file:
-    path: "{{ output_path }}/{{ needed_path }}/teams"
+    path: "{{ __path }}"
     state: directory
     mode: '0755'
+  vars:
+    __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/teams"
   loop: "{{ (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}/teams"
+    label: "{{ __path }}"
 
 - name: "Add current teams to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/teams"
   ansible.builtin.template:
     src: "templates/current_teams.j2"
-    dest: "{{ output_path }}/{{ team_organization }}/teams/{{ team_id }}_{{ team_name }}.yaml"
+    dest: "{{ __dest }}"
     mode: '0644'
   vars:
-    team_organization: "{{ current_teams_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
+    team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
     team_id: "{{ current_teams_asset_value.id }}"
     team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"
+    __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/teams/{{ team_id }}_{{ team_name | regex_replace('/', '_') }}.yaml"
   loop: "{{ teams_lookvar }}"
   loop_control:
     loop_var: current_teams_asset_value
-    label: "{{ output_path }}/{{ team_organization }}/teams/{{ team_id }}_{{ team_name }}.yaml"
+    label: "{{ __dest }}"
 
 - name: "Set the team's roles"
   ansible.builtin.include_tasks: "team_roles.yml"

--- a/roles/filetree_create/tasks/user_roles.yml
+++ b/roles/filetree_create/tasks/user_roles.yml
@@ -15,7 +15,7 @@
 - name: "Add current roles to the output yaml file"
   ansible.builtin.template:
     src: "templates/current_user_roles.j2"
-    dest: "{{ output_path }}/current_roles_{{ username }}.yaml"
+    dest: "{{ output_path }}/current_roles_{{ username | regex_replace('/', '_') }}.yaml"
     mode: '0644'
   vars:
     current_user_roles_asset_value: "{{ user_roles_lookvar }}"

--- a/roles/filetree_create/tasks/users.yml
+++ b/roles/filetree_create/tasks/users.yml
@@ -18,25 +18,28 @@
 
 - name: "Create the output directory for users: {{ output_path }}/<ORGANIZATION_NAME>"
   ansible.builtin.file:
-    path: "{{ output_path }}/{{ current_user_dir }}"
+    path: "{{ __path }}"
     state: directory
     mode: '0755'
+  vars:
+    __path: "{{ output_path }}/{{ current_user_dir | regex_replace('/', '_') }}"
   loop: "{{ current_users | selectattr('organizations', 'defined') | map(attribute='organizations') | flatten | unique }}"
   loop_control:
     loop_var: current_user_dir
-    label: "{{ output_path }}/{{ current_user_dir }}"
+    label: "{{ __path }}"
 
 - name: "Add current users to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/current_users_<USERNAME>.yaml"
   ansible.builtin.template:
     src: "templates/current_users.j2"
-    dest: "{{ output_path }}/{{ current_user_dir.1 }}/current_users_{{ current_user_dir.0.username }}.yaml"
+    dest: "{{ __dest }}"
     mode: '0644'
   vars:
     current_users_asset_value: "{{ current_user_dir.0 }}"
+    __dest: "{{ output_path }}/{{ current_user_dir.1 | regex_replace('/', '_') }}/current_users_{{ current_user_dir.0.username | regex_replace('/', '_') }}.yaml"
   loop: "{{ current_users | subelements('organizations') }}"
   loop_control:
     loop_var: current_user_dir
-    label: "{{ output_path }}/{{ current_user_dir.1 }}/current_users_{{ current_user_dir.0.username }}.yaml"
+    label: "{{ __dest }}"
 
 - name: "Set the user's roles"
   ansible.builtin.include_tasks: "user_roles.yml"

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -9,27 +9,30 @@
 
 - name: "Create the output directory for workflow job templates: {{ output_path }}/<ORGANIZATION_NAME>/workflow_job_templates"
   ansible.builtin.file:
-    path: "{{ output_path }}/{{ needed_path }}/workflow_job_templates/"
+    path: "{{ __path }}"
     state: directory
     mode: '0755'
+  vars:
+    __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/workflow_job_templates/"
   loop: "{{ (workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
   loop_control:
     loop_var: needed_path
-    label: "{{ output_path }}/{{ needed_path }}/workflow_job_templates/"
+    label: "{{ __path }}"
 
 - name: "Add current workflow job templates to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/workflow_job_templates"
   ansible.builtin.template:
     src: "templates/current_workflow_job_templates.j2"
-    dest: "{{ output_path }}/{{ workflow_job_template_organization }}/workflow_job_templates/{{ workflow_job_template_id }}_{{ workflow_job_template_name }}.yaml"
+    dest: "{{ __dest }}"
     mode: '0644'
   vars:
     workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
     workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
     workflow_job_template_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/', '_') }}"
+    __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/workflow_job_templates/{{ workflow_job_template_id }}_{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"
   loop: "{{ workflow_job_templates_lookvar }}"
   loop_control:
     loop_var: current_workflow_job_templates_asset_value
-    label: "{{ output_path }}/{{ workflow_job_template_organization }}/workflow_job_templates/{{ workflow_job_template_id }}_{{ workflow_job_template_name }}.yaml"
+    label: "{{ __dest }}"
 ...

--- a/roles/filetree_create/templates/current_credential_types.j2
+++ b/roles/filetree_create/templates/current_credential_types.j2
@@ -8,7 +8,6 @@ controller_credential_types:
 {{ credential_type.inputs | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
     injectors:
 {# https://docs.ansible.com/ansible/latest/user_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings #}
-{{ credential_type.injectors | to_nice_yaml(indent=2) | indent(width=6, first=True) | replace("'{{", "unsafe! \'{{") }}
-
+{{ credential_type.injectors | to_nice_yaml(indent=2) | indent(width=6, first=True) | replace("'{{", "!unsafe \'{{") }}
 {% endfor %}
 ...

--- a/roles/filetree_create/templates/current_credentials.j2
+++ b/roles/filetree_create/templates/current_credentials.j2
@@ -7,5 +7,5 @@ controller_credentials:
     organization: "{{ current_credentials_asset_value.summary_fields.organization.name }}"
 {% endif %}
     inputs:
-{{ current_credentials_asset_value.inputs | to_nice_yaml(indent=2) | indent(width=6, first=True) | replace("$encrypted$", "\'\'")  }}
+{{ current_credentials_asset_value.inputs | to_nice_yaml(indent=2) | indent(width=6, first=True) | replace("$encrypted$", "\'\'") }}
 ...

--- a/roles/filetree_create/templates/current_inventory_sources.j2
+++ b/roles/filetree_create/templates/current_inventory_sources.j2
@@ -10,6 +10,9 @@ controller_inventory_sources:
 {% if inventory_source.source_path %}
     source_path: "{{ inventory_source.source_path }}"
 {% endif %}
+{% if inventory_source.source_vars %}
+    source_vars: "{{ inventory_source.source_vars | replace("'{{", "!unsafe \'{{") }}"
+{% endif %}
     inventory: "{{ inventory_source.summary_fields.inventory.name }}"
     update_on_launch: "{{ inventory_source.update_on_launch }}"
     overwrite: "{{ inventory_source.overwrite }}"

--- a/roles/filetree_create/templates/current_notification_templates.j2
+++ b/roles/filetree_create/templates/current_notification_templates.j2
@@ -9,6 +9,6 @@ controller_notification_templates:
 {{ current_notification_templates_asset_value.notification_configuration | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
 {% if current_notification_templates_asset_value.messages is defined and current_notification_templates_asset_value.messages %}
     messages:
-{{ current_notification_templates_asset_value.messages | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
+{{ current_notification_templates_asset_value.messages | to_nice_yaml(indent=2) | indent(width=6, first=True) | replace("'{{", "!unsafe \'{{") }}
 {% endif %}
 ...

--- a/roles/filetree_create/templates/current_organizations.j2
+++ b/roles/filetree_create/templates/current_organizations.j2
@@ -2,13 +2,4 @@
 controller_organizations:
   - name: "{{ current_organization.name }}"
     description: "{{ current_organization.description }}"
-{%- raw %}
-    galaxy_credentials: "{{ common_galaxy_credentials }}"
-
-common_galaxy_credentials:
-  - "Ansible Galaxy"
-  - "{{ orgs }} {{ env }} Automation Hub Community Repository"
-  - "{{ orgs }} {{ env }} Automation Hub Published Repository"
-  - "{{ orgs }} {{ env }} Automation Hub RH Certified Repository"
-{% endraw %}
 ...

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -1,4 +1,4 @@
---
+---
 controller_workflows:
   - name: "{{ current_workflow_job_templates_asset_value.name }}"
     description: "{{ current_workflow_job_templates_asset_value.description }}"

--- a/roles/filetree_read/README.md
+++ b/roles/filetree_read/README.md
@@ -370,6 +370,4 @@ GPLv3+
 
 ## Author Information
 
-- silvinux
-  - email: <silvio@redhat.com>
-  - github: <https://github.com/silvinux>
+- [Silvio Perez](https://github.com/silvinux)

--- a/roles/object_diff/README.md
+++ b/roles/object_diff/README.md
@@ -65,13 +65,9 @@ GPLv3+
 
 ## Author Information
 
-- silvinux
-  - email: <silvio@redhat.com>
-  - github: <https://github.com/silvinux>
+- [Silvio Perez](https://github.com/silvinux)
 
-- Ivan Aragonés:
-  - email: <iaragone@redhat.com>
-  - github: <https://github.com/ivarmu>
+- [Ivan Aragonés](https://github.com/ivarmu)
 
 ## Important things to take into account
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

- FIX: WFJT template starts with `--`.
- FIX: Orgs are exported with non-existing credentials.
- FIX: `'{{` is now extracted as `!unsafe '{{` (was `unsafe!`).
- FIX: Assure that the paths doesn't contain the character '/' when generating files.

### How should this be tested?

```
$ cat filetree_create.yml
---
- hosts: localhost
  connection: local
  gather_facts: false

  roles:
    - redhat_cop.controller_configuration.filetree_create
...
$ time ansible-playbook filetree_create.yml --ask-vault-pass -e @.vaultfile -e '{input_tag: [all], output_path: /home/user/iam/filetree_create_output}'
```

### Is there a relevant Issue open for this?

No issue has been opened for this PR

### Other Relevant info, PRs, etc

N/A
 