### PR TITLE
Fix type job_temaplates - role-job_templates

### DIFF
--- a/roles/job_templates/tasks/main.yml
+++ b/roles/job_templates/tasks/main.yml
@@ -64,22 +64,22 @@
   no_log: "{{ controller_configuration_job_templates_secure_logging }}"
   async: 1000
   poll: 0
-  register: __job_temaplates_job_async
-  changed_when: not __job_temaplates_job_async.changed
+  register: __job_templates_job_async
+  changed_when: not __job_templates_job_async.changed
   vars:
     ansible_async_dir: '/tmp/.ansible_async'
 
 - name: "Configure Controller Job Templates | Wait for finish the job templates creation"
   ansible.builtin.async_status:
-    jid: "{{ __job_temaplates_job_async_result_item.ansible_job_id }}"
-  register: __job_temaplates_job_async_result
-  until: __job_temaplates_job_async_result.finished
+    jid: "{{ __job_templates_job_async_result_item.ansible_job_id }}"
+  register: __job_templates_job_async_result
+  until: __job_templates_job_async_result.finished
   retries: "{{ controller_configuration_job_templates_async_retries }}"
   delay: "{{ controller_configuration_job_templates_async_delay }}"
-  loop: "{{ __job_temaplates_job_async.results }}"
+  loop: "{{ __job_templates_job_async.results }}"
   loop_control:
-    loop_var: __job_temaplates_job_async_result_item
-  when: __job_temaplates_job_async_result_item.ansible_job_id is defined
+    loop_var: __job_templates_job_async_result_item
+  when: __job_templates_job_async_result_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_job_templates_secure_logging }}"
   vars:
     ansible_async_dir: '/tmp/.ansible_async'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

Fix typo in the variable "__job_temaplates_job_async" to __job_templates_job_async.

roles/job_templates/tasks/main.yml:  register: __job_temaplates_job_async
roles/job_templates/tasks/main.yml:  changed_when: not __job_temaplates_job_async.changed
roles/job_templates/tasks/main.yml:    jid: "{{ __job_temaplates_job_async_result_item.ansible_job_id }}"
roles/job_templates/tasks/main.yml:  register: __job_temaplates_job_async_result
roles/job_templates/tasks/main.yml:  until: __job_temaplates_job_async_result.finished
roles/job_templates/tasks/main.yml:  loop: "{{ __job_temaplates_job_async.results }}"
roles/job_templates/tasks/main.yml:    loop_var: __job_temaplates_job_async_result_item
roles/job_templates/tasks/main.yml:  when: __job_temaplates_job_async_result_item.ansible_job_id is defined

### How should this be tested?

Tested manually.