### PR TITLE
Object diff variable verifyssl and some fixes

### DIFF
--- a/roles/filetree_create/templates/current_projects.j2
+++ b/roles/filetree_create/templates/current_projects.j2
@@ -6,7 +6,9 @@ controller_projects:
 {% if current_projects_asset_value.scm_type %}
     scm_type: "{{ current_projects_asset_value.scm_type }}"
     scm_url: "{{ current_projects_asset_value.scm_url }}"
-    scm_credential: "{{ current_projects_asset_value.summary_fields.credential.name | default('ToDo: The project \'' + current_projects_asset_value.name + '\' is missing the SCM credential') }}"
+{% if current_projects_asset_value.summary_fields.credential is defined %}
+    scm_credential: "{{ current_projects_asset_value.summary_fields.credential.name }}"
+{% endif %}
     scm_branch: "{{ current_projects_asset_value.scm_branch }}"
     scm_clean: "{{ current_projects_asset_value.scm_clean }}"
     scm_delete_on_update: "{{ current_projects_asset_value.scm_delete_on_update }}"

--- a/roles/filetree_create/templates/current_roles.j2
+++ b/roles/filetree_create/templates/current_roles.j2
@@ -18,7 +18,7 @@ controller_roles:
     target_teams:
       - "{{ role.content_object.name }}"
 {% endif %}
-    roles:
+    role:
       - "{{ role.name }}"
 {% endif %}
 {% endfor %}

--- a/roles/filetree_read/README.md
+++ b/roles/filetree_read/README.md
@@ -280,17 +280,22 @@ The role is designed to be used with tags, each tags correspond to an AWX or Aut
   vars:
     controller_configuration_projects_async_retries: 60
     controller_configuration_projects_async_delay: 2
+    controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
+    controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
+    controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
+    controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
+
   pre_tasks:
     - name: "Setup authentication (block)"
       block:
         - name: "Get the Authentication Token for the future requests"
           ansible.builtin.uri:
-            url: "https://{{ vault_controller_hostname }}/api/v2/tokens/"
-            user: "{{ vault_controller_username }}"
-            password: "{{ vault_controller_password }}"
+            url: "https://{{ controller_hostname }}/api/v2/tokens/"
+            user: "{{ controller_username }}"
+            password: "{{ controller_password }}"
             method: POST
             force_basic_auth: true
-            validate_certs: "{{ vault_controller_validate_certs }}"
+            validate_certs: "{{ controller_validate_certs }}"
             status_code: 201
           register: authtoken_res
 
@@ -332,12 +337,12 @@ The role is designed to be used with tags, each tags correspond to an AWX or Aut
   post_tasks:
     - name: "Delete the Authentication Token used"
       ansible.builtin.uri:
-        url: "https://{{ vault_controller_hostname }}{{ controller_oauthtoken_url }}"
-        user: "{{ vault_controller_username }}"
-        password: "{{ vault_controller_password }}"
+        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
+        user: "{{ controller_username }}"
+        password: "{{ controller_password }}"
         method: DELETE
         force_basic_auth: true
-        validate_certs: "{{ vault_controller_validate_certs }}"
+        validate_certs: "{{ controller_validate_certs }}"
         status_code: 204
       when: controller_oauthtoken_url is defined
 ...

--- a/roles/filetree_read/README.md
+++ b/roles/filetree_read/README.md
@@ -8,21 +8,6 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 
 ## Role Variables
 
-### Authentication
-
-|Variable Name|Default Value|Required|Description|Example|
-|:---:|:---:|:---:|:---:|:---:|
-|`controller_hostname`|""|yes|URL to the Ansible Controller Server.|127.0.0.1|
-|`controller_validate_certs`|`True`|no|Whether or not to validate the Ansible Controller Server's SSL certificate.||
-|`controller_username`|""|yes|Admin User on the Ansible Controller Server.||
-|`controller_password`|""|yes|Controller Admin User's password on the Ansible Controller Server. This should be stored in an Ansible Vault at vars/controller-secrets.yml or elsewhere and called from a parent playbook.||
-|`controller_oauthtoken`|""|yes|Controller Admin User's token on the Ansible Controller Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||
-|`vault_controller_hostname`|""|optional|URL to the Ansible Controller Server.|127.0.0.1|
-|`vault_controller_validate_certs`|`True`|optional|Whether or not to validate the Ansible Controller Server's SSL certificate.||
-|`vault_controller_username`|""|optional|Admin User on the Ansible Controller Server.||
-|`vault_controller_password`|""|optional|Controller Admin User's password on the Ansible Controller Server. This should be stored in an Ansible Vault at vars/controller-secrets.yml or elsewhere and called from a parent playbook.||
-|`vault_controller_oauthtoken`|""|optional|Controller Admin User's token on the Ansible Controller Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||
-
 ### Organization and Environment Variables
 
 The following Variables set the organization where should be applied the configuration, the absolute or relative of the directory structure where the variables will be stored and the life-cycle environment to use.
@@ -300,12 +285,12 @@ The role is designed to be used with tags, each tags correspond to an AWX or Aut
       block:
         - name: "Get the Authentication Token for the future requests"
           ansible.builtin.uri:
-            url: "https://{{ controller_hostname }}/api/v2/tokens/"
-            user: "{{ controller_username }}"
-            password: "{{ controller_password }}"
+            url: "https://{{ vault_controller_hostname }}/api/v2/tokens/"
+            user: "{{ vault_controller_username }}"
+            password: "{{ vault_controller_password }}"
             method: POST
             force_basic_auth: true
-            validate_certs: "{{ controller_validate_certs }}"
+            validate_certs: "{{ vault_controller_validate_certs }}"
             status_code: 201
           register: authtoken_res
 
@@ -347,12 +332,12 @@ The role is designed to be used with tags, each tags correspond to an AWX or Aut
   post_tasks:
     - name: "Delete the Authentication Token used"
       ansible.builtin.uri:
-        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
-        user: "{{ controller_username }}"
-        password: "{{ controller_password }}"
+        url: "https://{{ vault_controller_hostname }}{{ controller_oauthtoken_url }}"
+        user: "{{ vault_controller_username }}"
+        password: "{{ vault_controller_password }}"
         method: DELETE
         force_basic_auth: true
-        validate_certs: "{{ controller_validate_certs }}"
+        validate_certs: "{{ vault_controller_validate_certs }}"
         status_code: 204
       when: controller_oauthtoken_url is defined
 ...

--- a/roles/filetree_read/defaults/main.yml
+++ b/roles/filetree_read/defaults/main.yml
@@ -6,12 +6,6 @@ orgs: "Acme"
 dir_orgs_vars: orgs_vars
 env: dev
 
-# Authentication
-controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
-controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
-controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
-controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
-
 # Controller lists
 
 controller_settings: []

--- a/roles/filetree_read/tests/config-controller-filetree.yml
+++ b/roles/filetree_read/tests/config-controller-filetree.yml
@@ -10,12 +10,12 @@
       block:
         - name: "Get the Authentication Token for the future requests"
           ansible.builtin.uri:
-            url: "https://{{ controller_hostname }}/api/v2/tokens/"
-            user: "{{ controller_username }}"
-            password: "{{ controller_password }}"
+            url: "https://{{ vault_controller_hostname }}/api/v2/tokens/"
+            user: "{{ vault_controller_username }}"
+            password: "{{ vault_controller_password }}"
             method: POST
             force_basic_auth: true
-            validate_certs: "{{ controller_validate_certs }}"
+            validate_certs: "{{ vault_controller_validate_certs }}"
             status_code: 201
           register: authtoken_res
 
@@ -57,12 +57,12 @@
   post_tasks:
     - name: "Delete the Authentication Token used"
       ansible.builtin.uri:
-        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
-        user: "{{ controller_username }}"
-        password: "{{ controller_password }}"
+        url: "https://{{ vault_controller_hostname }}{{ controller_oauthtoken_url }}"
+        user: "{{ vault_controller_username }}"
+        password: "{{ vault_controller_password }}"
         method: DELETE
         force_basic_auth: true
-        validate_certs: "{{ controller_validate_certs }}"
+        validate_certs: "{{ vault_controller_validate_certs }}"
         status_code: 204
       when: controller_oauthtoken_url is defined
 ...

--- a/roles/filetree_read/tests/config-controller-filetree.yml
+++ b/roles/filetree_read/tests/config-controller-filetree.yml
@@ -5,17 +5,22 @@
   vars:
     controller_configuration_projects_async_retries: 60
     controller_configuration_projects_async_delay: 2
+    controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
+    controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
+    controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
+    controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
+
   pre_tasks:
     - name: "Setup authentication (block)"
       block:
         - name: "Get the Authentication Token for the future requests"
           ansible.builtin.uri:
-            url: "https://{{ vault_controller_hostname }}/api/v2/tokens/"
-            user: "{{ vault_controller_username }}"
-            password: "{{ vault_controller_password }}"
+            url: "https://{{ controller_hostname }}/api/v2/tokens/"
+            user: "{{ controller_username }}"
+            password: "{{ controller_password }}"
             method: POST
             force_basic_auth: true
-            validate_certs: "{{ vault_controller_validate_certs }}"
+            validate_certs: "{{ controller_validate_certs }}"
             status_code: 201
           register: authtoken_res
 
@@ -57,12 +62,12 @@
   post_tasks:
     - name: "Delete the Authentication Token used"
       ansible.builtin.uri:
-        url: "https://{{ vault_controller_hostname }}{{ controller_oauthtoken_url }}"
-        user: "{{ vault_controller_username }}"
-        password: "{{ vault_controller_password }}"
+        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
+        user: "{{ controller_username }}"
+        password: "{{ controller_password }}"
         method: DELETE
         force_basic_auth: true
-        validate_certs: "{{ vault_controller_validate_certs }}"
+        validate_certs: "{{ controller_validate_certs }}"
         status_code: 204
       when: controller_oauthtoken_url is defined
 ...

--- a/roles/object_diff/tasks/credential_types.yml
+++ b/roles/object_diff/tasks/credential_types.yml
@@ -4,7 +4,7 @@
   ansible.builtin.set_fact:
     __controller_api_credential_types: "{{ query(controller_api_plugin, 'credential_types',
       query_params={'managed': false},
-      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) }}"      
+      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) }}"
 
 - name: "OBJECT DIFF: Find the difference of Credential Types between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:

--- a/roles/object_diff/tasks/credential_types.yml
+++ b/roles/object_diff/tasks/credential_types.yml
@@ -3,7 +3,7 @@
 - name: "OBJECT DIFF: Get the API list of all Credential Types"
   ansible.builtin.set_fact:
     __controller_api_credential_types: "{{ query(controller_api_plugin, 'credential_types',
-      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false) }}"
+      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) }}"
 
 - name: "OBJECT DIFF: Find the difference of Credential Types between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:

--- a/roles/object_diff/tasks/credentials.yml
+++ b/roles/object_diff/tasks/credentials.yml
@@ -4,14 +4,14 @@
   ansible.builtin.set_fact:
     __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                               query_params={'name': orgs},
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
 - name: "OBJECT DIFF: Get the API list of all Credentials {{ orgs }} Organization"
   ansible.builtin.set_fact:
     __controller_api_credentials: "{{ query(controller_api_plugin, 'credentials',
                                             query_params={'organization': __controller_organization_id.id},
-                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
 - name: "OBJECT DIFF: Find the difference of Credentials between what is on the Controller versus CasC on SCM"

--- a/roles/object_diff/tasks/groups.yml
+++ b/roles/object_diff/tasks/groups.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                             query_params={'name': orgs},
-                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                  }}"
 
 - name: "OBJECT DIFF: Get the API list of all inventories"
@@ -14,7 +14,7 @@
                                               'not__total_groups': '0',
                                               'not__kind': 'smart'},
                                             host=controller_hostname, username=controller_username,
-                                            password=controller_password, verify_ssl=false)
+                                            password=controller_password, verify_ssl=controller_validate_certs)
                                    }}"
 
 - name: "OBJECT DIFF: Get the API list of all groups in the inventories at organization {{ orgs }}"
@@ -22,7 +22,7 @@
     __controller_api_groups: "{{ (__controller_api_groups | default([])) + query(controller_api_plugin, 'groups',
                                           query_params={'inventory': current_inventory.id},
                                           host=controller_hostname, username=controller_username,
-                                          password=controller_password, verify_ssl=false)
+                                          password=controller_password, verify_ssl=controller_validate_certs)
                               }}"
   loop: "{{ __controller_api_inventories }}"
   loop_control:

--- a/roles/object_diff/tasks/hosts.yml
+++ b/roles/object_diff/tasks/hosts.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                             query_params={'name': orgs},
-                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                  }}"
 
 - name: "OBJECT DIFF: Get the API list of all inventories"
@@ -14,7 +14,7 @@
                                               'not__total_hosts': '0',
                                               'not__kind': 'smart'},
                                             host=controller_hostname, username=controller_username,
-                                            password=controller_password, verify_ssl=false)
+                                            password=controller_password, verify_ssl=controller_validate_certs)
                                    }}"
 
 - name: "OBJECT DIFF: Get the API list of all hosts in the inventories at organization {{ orgs }}"
@@ -22,7 +22,7 @@
     __controller_api_hosts: "{{ (__controller_api_hosts | default([])) + query(controller_api_plugin, 'hosts',
                                     query_params={'inventory': current_inventory.id},
                                     host=controller_hostname, username=controller_username,
-                                    password=controller_password, verify_ssl=false)
+                                    password=controller_password, verify_ssl=controller_validate_certs)
                              }}"
   loop: "{{ __controller_api_inventories }}"
   loop_control:

--- a/roles/object_diff/tasks/inventories.yml
+++ b/roles/object_diff/tasks/inventories.yml
@@ -3,14 +3,14 @@
   ansible.builtin.set_fact:
     __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                              query_params={'name': orgs},
-                                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
 - name: "OBJECT DIFF: Get the API list of all Inventories"
   ansible.builtin.set_fact:
     __controller_api_inventories: "{{ query(controller_api_plugin, 'inventories',
                                             query_params={'organization': __controller_organization_id.id},
-                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
 - name: "OBJECT DIFF: Find the difference of Inventories between what is on the Controller versus CasC on SCM"

--- a/roles/object_diff/tasks/inventory_sources.yml
+++ b/roles/object_diff/tasks/inventory_sources.yml
@@ -3,14 +3,14 @@
   ansible.builtin.set_fact:
     __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                              query_params={'name': orgs},
-                                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
 - name: "OBJECT DIFF: Get the API list of all Inventory Sources"
   ansible.builtin.set_fact:
     __controller_api_inventory_sources: "{{ query(controller_api_plugin, 'inventory_sources',
                                                   query_params={'organization': __controller_organization_id.id},
-                                                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                          }}"
 
 - name: "OBJECT DIFF: Find the difference of Inventory Sources between what is on the Controller versus CasC on SCM"

--- a/roles/object_diff/tasks/job_templates.yml
+++ b/roles/object_diff/tasks/job_templates.yml
@@ -3,14 +3,14 @@
   ansible.builtin.set_fact:
     __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                               query_params={'name': orgs},
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
 - name: "OBJECT DIFF: Get the API list of all Job Templates {{ orgs }} Organization"
   ansible.builtin.set_fact:
     __controller_api_job_templates: "{{ query(controller_api_plugin, 'job_templates',
                                               query_params={'organization': __controller_organization_id.id},
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                      }}"
 
 - name: "OBJECT DIFF: Find the difference of Job Templates between what is on the Controller versus CasC on SCM"

--- a/roles/object_diff/tasks/projects.yml
+++ b/roles/object_diff/tasks/projects.yml
@@ -3,14 +3,14 @@
   ansible.builtin.set_fact:
     __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                               query_params={'name': orgs},
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
 - name: "OBJECT DIFF: Get the API list of all Projects {{ orgs }} Organization"
   ansible.builtin.set_fact:
     __controller_api_projects: "{{ query(controller_api_plugin, 'projects',
                                           query_params={'organization': __controller_organization_id.id},
-                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                 }}"
 
 - name: "OBJECT DIFF: Find the difference of Project between what is on the Controller versus CasC on SCM"

--- a/roles/object_diff/tasks/roles.yml
+++ b/roles/object_diff/tasks/roles.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
                                                               query_params={'username': controller_username},
-                                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                                    }}"
 
 - name: "Role differences (block)"
@@ -13,7 +13,7 @@
       ansible.builtin.set_fact:
         __controller_api_roles: "{{ query(controller_api_plugin, 'roles',
                                           host=controller_hostname, username=controller_username,
-                                          password=controller_password, verify_ssl=false)
+                                          password=controller_password, verify_ssl=controller_validate_certs)
                                  }}"
 
     - name: "OBJECT DIFF: Find the difference of Roles between what is on the Controller versus CasC on SCM"

--- a/roles/object_diff/tasks/teams.yml
+++ b/roles/object_diff/tasks/teams.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
                                                               query_params={'username': controller_username},
-                                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                                    }}"
 
 - name: "Team differences (block)"
@@ -12,14 +12,14 @@
       ansible.builtin.set_fact:
         __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                                   query_params={'name': orgs},
-                                                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                        }}"
 
     - name: "OBJECT DIFF: Get the API list of all teams {{ orgs }} Organization"
       ansible.builtin.set_fact:
         __controller_api_teams: "{{ query(controller_api_plugin, 'teams',
                                           query_params={'organization': __controller_organization_id.id},
-                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                  }}"
 
     - name: "OBJECT DIFF: Find the difference of Teams between what is on the Controller versus CasC on SCM"

--- a/roles/object_diff/tasks/user_accounts.yml
+++ b/roles/object_diff/tasks/user_accounts.yml
@@ -4,13 +4,13 @@
   ansible.builtin.set_fact:
     __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
                                                               query_params={'username': controller_username},
-                                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                                    }}"
 
 - name: "OBJECT DIFF: Sets the current controller user to determine if it is super-admin"
   ansible.builtin.set_fact:
     __controller_api_user_accounts: "{{ query(controller_api_plugin, 'users',
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                      }}"
 
 - name: "Populate user accounts (block)"

--- a/roles/object_diff/tasks/workflow_job_templates.yml
+++ b/roles/object_diff/tasks/workflow_job_templates.yml
@@ -3,14 +3,14 @@
   ansible.builtin.set_fact:
     __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
                                               query_params={'name': orgs},
-                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
 - name: "OBJECT DIFF: Get the API list of all Workflow Job Templates"
   ansible.builtin.set_fact:
     __controller_api_workflow_job_templates: "{{ query(controller_api_plugin, 'workflow_job_templates',
                                                         query_params={'organization': __controller_organization_id.id},
-                                                        host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false)
+                                                        host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                               }}"
 
 - name: "OBJECT DIFF: Find the difference of Workflow Job Templates between what is on the Controller versus CasC on SCM"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

1.- Add verify_ssl as a variable in object_diff role
2.- Remove auth info in the filetree_read role because this role itself will not connect to controller/tower
3.- Add auth example variables in playbooks which use filetree_read and dispatch roles.
4.- Fixes in some templates of filetree_create role

### How should this be tested?

Launch test playbooks for filetree_create, filetree_read and object_diff roles.

### Is there a relevant Issue open for this?

N/A

### Other Relevant info, PRs, etc

