### PR TITLE
Multiple fixes

### DIFF
--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -117,7 +117,7 @@ class LookupModule(LookupBase):
             return [api_list]
 
         # Set Keys to keep for each list. Depending on type
-        if api_list[0]["type"] == "organization":
+        if api_list[0]["type"] == "organization" or api_list[0]["type"] == "credential_type":
             keys_to_keep = ["name"]
             api_keys_to_keep = ["name"]
         elif api_list[0]["type"] == "user":
@@ -159,6 +159,11 @@ class LookupModule(LookupBase):
         if api_list[0]["type"] == "group" or api_list[0]["type"] == "host":
             for item in api_list_reduced:
                 item.update({"inventory": item["summary_fields"]["inventory"]["name"]})
+                item.pop("summary_fields")
+        elif api_list[0]["type"] == "inventory_source":
+            for item in api_list_reduced:
+                item.update({"inventory": item["summary_fields"]["inventory"]["name"]})
+                item.update({"organization": item["summary_fields"]["organization"]["name"]})
                 item.pop("summary_fields")
         elif api_list[0]["type"] == "credential":
             for item in api_list_reduced:

--- a/roles/credentials/tasks/main.yml
+++ b/roles/credentials/tasks/main.yml
@@ -23,6 +23,7 @@
   loop: "{{ controller_credentials }}"
   loop_control:
     loop_var: __controller_credentials_item
+    label: "{{ __controller_credentials_item.name | mandatory }}"
   no_log: "{{ controller_configuration_credentials_secure_logging }}"
   async: 1000
   poll: 0
@@ -41,6 +42,7 @@
   loop: "{{ __credentials_job_async.results }}"
   loop_control:
     loop_var: __credentials_job_async_results_item
+    label: "{{ __credentials_job_async_results_item.__controller_credentials_item.name }}"
   when: __credentials_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_credentials_secure_logging }}"
   vars:

--- a/roles/dispatch/defaults/main.yml
+++ b/roles/dispatch/defaults/main.yml
@@ -10,13 +10,13 @@ controller_configuration_dispatcher_roles:
   - {role: credential_input_sources, var: controller_credential_input_sources, tags: credential_input_sources}
   - {role: notification_templates, var: controller_notifications, tags: notification_templates}
   - {role: projects, var: controller_projects, tags: projects}
-  - {role: execution_environments, var: controller_execution_environments, tags: execution_environments}
-  - {role: applications, var: controller_applications, tags: applications}
   - {role: inventories, var: controller_inventories, tags: inventories}
-  - {role: instance_groups, var: controller_instance_groups, tags: instance_groups}
-  - {role: project_update, var: controller_projects, tags: projects}
   - {role: inventory_sources, var: controller_inventory_sources, tags: inventory_sources}
   - {role: inventory_source_update, var: controller_inventory_sources, tags: inventory_sources}
+  - {role: execution_environments, var: controller_execution_environments, tags: execution_environments}
+  - {role: applications, var: controller_applications, tags: applications}
+  - {role: instance_groups, var: controller_instance_groups, tags: instance_groups}
+  - {role: project_update, var: controller_projects, tags: projects}
   - {role: hosts, var: controller_hosts, tags: hosts}
   - {role: groups, var: controller_groups, tags: inventories}
   - {role: job_templates, var: controller_templates, tags: job_templates}

--- a/roles/object_diff/tasks/credential_types.yml
+++ b/roles/object_diff/tasks/credential_types.yml
@@ -3,6 +3,7 @@
 - name: "OBJECT DIFF: Get the API list of all Credential Types"
   ansible.builtin.set_fact:
     __controller_api_credential_types: "{{ query(controller_api_plugin, 'credential_types',
+      query_params={'managed': false},
       host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=false) }}"
 
 - name: "OBJECT DIFF: Find the difference of Credential Types between what is on the Controller versus CasC on SCM"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

- Fixes object diffing for `credential_type` and `inventory_source` objects
- Add labels to `credentials` to avoid exposing sensible information
- Object creation order has been improved at `dispatch` role
- The role `filetree_read` was searching the inventories in the wrong path
- The role `object_diff` was managing the `credential_type`s managed by the Controller

### How should this be tested?

Launch test playbooks for filetree_read and object_diff roles.

### Is there a relevant Issue open for this?

No issue has been opened for this PR

### Other Relevant info, PRs, etc

N/A
