### PR TITLE
remove auth from roles

### DIFF
--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -28,9 +28,48 @@ A list of other roles hosted on Galaxy should go here, plus any details in regar
 - hosts: localhost
   connection: local
   gather_facts: false
+  vars:
+    controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
+    controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
+    controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
+    controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
+
+  pre_tasks:
+    - name: "Setup authentication (block)"
+      block:
+        - name: "Get the Authentication Token for the future requests"
+          ansible.builtin.uri:
+            url: "https://{{ controller_hostname }}/api/v2/tokens/"
+            user: "{{ controller_username }}"
+            password: "{{ controller_password }}"
+            method: POST
+            force_basic_auth: true
+            validate_certs: "{{ controller_validate_certs }}"
+            status_code: 201
+          register: authtoken_res
+
+        - name: "Set the oauth token to be used since now"
+          ansible.builtin.set_fact:
+            controller_oauthtoken: "{{ authtoken_res.json.token }}"
+            controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
+      no_log: "{{ controller_configuration_filetree_create_secure_logging | default('false') }}"
+      when: controller_oauthtoken is not defined
+
 
   roles:
     - redhat_cop.controller_configuration.filetree_create
+
+  post_tasks:
+    - name: "Delete the Authentication Token used"
+      ansible.builtin.uri:
+        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
+        user: "{{ controller_username }}"
+        password: "{{ controller_password }}"
+        method: DELETE
+        force_basic_auth: true
+        validate_certs: "{{ controller_validate_certs }}"
+        status_code: 204
+      when: controller_oauthtoken_url is defined
 ...
 ```
 

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -1,12 +1,6 @@
 ---
 # defaults file for filetree_create
 
-#  Authentication variables
-controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
-controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
-controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
-controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
-
 # Controller object lists
 controller_credentials: []
 controller_execution_environments: []

--- a/roles/filetree_create/tasks/all.yml
+++ b/roles/filetree_create/tasks/all.yml
@@ -1,24 +1,4 @@
 ---
-- name: Generate oauth otken (block)
-  block:
-    - name: "Get the Authentication Token for the future requests"
-      ansible.builtin.uri:
-        url: "https://{{ controller_hostname }}/api/v2/tokens/"
-        user: "{{ controller_username }}"
-        password: "{{ controller_password }}"
-        method: POST
-        force_basic_auth: true
-        validate_certs: "{{ controller_validate_certs }}"
-        status_code: 201
-      register: authtoken_res
-
-    - name: "Set the oauth token to be used since now"
-      ansible.builtin.set_fact:
-        controller_oauthtoken: "{{ authtoken_res.json.token }}"
-        controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
-  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
-  when: controller_oauthtoken is not defined
-
 - name: "Check if the connection is to an Ansible Tower or to Automation Platform"
   ansible.builtin.set_fact:
     is_aap: "{{ lookup(controller_api_plugin, 'ping', host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs).version is version('4.0.0', '>=') }}"
@@ -59,15 +39,4 @@
       ansible.builtin.include_tasks: "workflow_job_templates.yml"
       when: "'workflow_job_templates' in input_tag or 'all' in input_tag"
   when: "['all', 'inventory', 'credentials', 'credential_types', 'notification_templates', 'users', 'teams', 'organizations', 'projects', 'execution_environments', 'job_templates', 'workflow_job_templates', 'workflow_job_template_nodes'] | intersect(input_tag) | length > 0"
-
-- name: "Delete the Authentication Token used"
-  ansible.builtin.uri:
-    url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
-    user: "{{ controller_username }}"
-    password: "{{ controller_password }}"
-    method: DELETE
-    force_basic_auth: true
-    validate_certs: "{{ controller_validate_certs }}"
-    status_code: 204
-  when: controller_oauthtoken_url is defined
 ...

--- a/roles/filetree_create/tests/filetree_create.yml
+++ b/roles/filetree_create/tests/filetree_create.yml
@@ -2,7 +2,45 @@
 - hosts: localhost
   connection: local
   gather_facts: false
+  vars:
+    controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
+    controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
+    controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
+    controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
+
+  pre_tasks:
+    - name: "Setup authentication (block)"
+      block:
+        - name: "Get the Authentication Token for the future requests"
+          ansible.builtin.uri:
+            url: "https://{{ controller_hostname }}/api/v2/tokens/"
+            user: "{{ controller_username }}"
+            password: "{{ controller_password }}"
+            method: POST
+            force_basic_auth: true
+            validate_certs: "{{ controller_validate_certs }}"
+            status_code: 201
+          register: authtoken_res
+
+        - name: "Set the oauth token to be used since now"
+          ansible.builtin.set_fact:
+            controller_oauthtoken: "{{ authtoken_res.json.token }}"
+            controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
+      no_log: "{{ controller_configuration_filetree_create_secure_logging | default('false') }}"
+      when: controller_oauthtoken is not defined
 
   roles:
     - redhat_cop.controller_configuration.filetree_create
+
+  post_tasks:
+    - name: "Delete the Authentication Token used"
+      ansible.builtin.uri:
+        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
+        user: "{{ controller_username }}"
+        password: "{{ controller_password }}"
+        method: DELETE
+        force_basic_auth: true
+        validate_certs: "{{ controller_validate_certs }}"
+        status_code: 204
+      when: controller_oauthtoken_url is defined
 ...

--- a/roles/object_diff/README.md
+++ b/roles/object_diff/README.md
@@ -37,6 +37,33 @@ $ ansible-playbook object_diff.yml --list-tags
 - hosts: localhost
   connection: local
   gather_facts: false
+  vars:
+    controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
+    controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
+    controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
+    controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
+
+  pre_tasks:
+    - name: "Setup authentication (block)"
+      block:
+        - name: "Get the Authentication Token for the future requests"
+          ansible.builtin.uri:
+            url: "https://{{ controller_hostname }}/api/v2/tokens/"
+            user: "{{ controller_username }}"
+            password: "{{ controller_password }}"
+            method: POST
+            force_basic_auth: true
+            validate_certs: "{{ controller_validate_certs }}"
+            status_code: 201
+          register: authtoken_res
+
+        - name: "Set the oauth token to be used since now"
+          ansible.builtin.set_fact:
+            controller_oauthtoken: "{{ authtoken_res.json.token }}"
+            controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
+      no_log: "{{ controller_configuration_object_diff_secure_logging }}"
+      when: controller_oauthtoken is not defined
+
   roles:
     - role: redhat_cop.controller_configuration.filetree_read
     - role: redhat_cop.controller_configuration.object_diff
@@ -55,6 +82,18 @@ $ ansible-playbook object_diff.yml --list-tags
           - {role: credentials, var: controller_credentials, tags: credentials}
           - {role: credential_types, var: controller_credential_types, tags: credential_types}
           - {role: organizations, var: controller_organizations, tags: organizations}
+
+  post_tasks:
+    - name: "Delete the Authentication Token used"
+      ansible.builtin.uri:
+        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
+        user: "{{ controller_username }}"
+        password: "{{ controller_password }}"
+        method: DELETE
+        force_basic_auth: true
+        validate_certs: "{{ controller_validate_certs }}"
+        status_code: 204
+      when: controller_oauthtoken_url is defined
 
 $ ansible-playbook drop_diff.yml --tags ${CONTROLLER_OBJECT} -e "{orgs: ${ORGANIZATION}, dir_orgs_vars: orgs_vars, env: ${ENVIRONMENT} }" --vault-password-file ./.vault_pass.txt -e @orgs_vars/env/${ENVIRONMENT}/configure_connection_controller_credentials.yml ${OTHER}
 ```

--- a/roles/object_diff/defaults/main.yml
+++ b/roles/object_diff/defaults/main.yml
@@ -1,12 +1,6 @@
 ---
 # defaults file for object_diff
 
-# Authentication
-controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
-controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
-controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
-controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
-
 # populate_controller_api_user_accounts_without_external_accounts
 drop_user_external_accounts: true
 

--- a/roles/object_diff/tasks/main.yml
+++ b/roles/object_diff/tasks/main.yml
@@ -27,28 +27,6 @@
   tags:
     - always
 
-- name: "Setup authentication (block)"
-  block:
-    - name: "Get the Authentication Token for the future requests"
-      ansible.builtin.uri:
-        url: "https://{{ controller_hostname }}/api/v2/tokens/"
-        user: "{{ controller_username }}"
-        password: "{{ controller_password }}"
-        method: POST
-        force_basic_auth: true
-        validate_certs: "{{ controller_validate_certs }}"
-        status_code: 201
-      register: authtoken_res
-
-    - name: "Set the oauth token to be used since now"
-      ansible.builtin.set_fact:
-        controller_oauthtoken: "{{ authtoken_res.json.token }}"
-        controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
-  no_log: "{{ controller_configuration_object_diff_secure_logging }}"
-  when: controller_oauthtoken is not defined
-  tags:
-    - always
-
 - name: "Include Tasks to get OBJECT DIFF {{  __task_diff.name }}"
   ansible.builtin.include_tasks: "{{  __task_diff.name }}.yml"
   args:
@@ -58,15 +36,4 @@
   loop: "{{ controller_configuration_object_diff_tasks }}"
   loop_control:
     loop_var: __task_diff
-
-- name: "Delete the Authentication Token used"
-  ansible.builtin.uri:
-    url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
-    user: "{{ controller_username }}"
-    password: "{{ controller_password }}"
-    method: DELETE
-    force_basic_auth: true
-    validate_certs: "{{ controller_validate_certs }}"
-    status_code: 204
-  when: controller_oauthtoken_url is defined
 ...

--- a/roles/object_diff/tests/drop_diff.yml
+++ b/roles/object_diff/tests/drop_diff.yml
@@ -3,6 +3,33 @@
   hosts: localhost
   connection: local
   gather_facts: false
+  vars:
+    controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
+    controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
+    controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
+    controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
+
+  pre_tasks:
+    - name: "Setup authentication (block)"
+      block:
+        - name: "Get the Authentication Token for the future requests"
+          ansible.builtin.uri:
+            url: "https://{{ controller_hostname }}/api/v2/tokens/"
+            user: "{{ controller_username }}"
+            password: "{{ controller_password }}"
+            method: POST
+            force_basic_auth: true
+            validate_certs: "{{ controller_validate_certs }}"
+            status_code: 201
+          register: authtoken_res
+
+        - name: "Set the oauth token to be used since now"
+          ansible.builtin.set_fact:
+            controller_oauthtoken: "{{ authtoken_res.json.token }}"
+            controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
+      no_log: "{{ controller_configuration_object_diff_secure_logging }}"
+      when: controller_oauthtoken is not defined
+
   roles:
     - role: redhat_cop.controller_configuration.filetree_read
     - role: redhat_cop.controller_configuration.object_diff
@@ -21,4 +48,16 @@
           - {role: credentials, var: controller_credentials, tags: credentials}
           - {role: credential_types, var: controller_credential_types, tags: credential_types}
           - {role: organizations, var: controller_organizations, tags: organizations}
+
+  post_tasks:
+    - name: "Delete the Authentication Token used"
+      ansible.builtin.uri:
+        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
+        user: "{{ controller_username }}"
+        password: "{{ controller_password }}"
+        method: DELETE
+        force_basic_auth: true
+        validate_certs: "{{ controller_validate_certs }}"
+        status_code: 204
+      when: controller_oauthtoken_url is defined
 ...

--- a/roles/object_diff/tests/object_diff.yml
+++ b/roles/object_diff/tests/object_diff.yml
@@ -3,7 +3,46 @@
   hosts: localhost
   connection: local
   gather_facts: false
+  vars:
+    controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
+    controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
+    controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
+    controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
+
+  pre_tasks:
+    - name: "Setup authentication (block)"
+      block:
+        - name: "Get the Authentication Token for the future requests"
+          ansible.builtin.uri:
+            url: "https://{{ controller_hostname }}/api/v2/tokens/"
+            user: "{{ controller_username }}"
+            password: "{{ controller_password }}"
+            method: POST
+            force_basic_auth: true
+            validate_certs: "{{ controller_validate_certs }}"
+            status_code: 201
+          register: authtoken_res
+
+        - name: "Set the oauth token to be used since now"
+          ansible.builtin.set_fact:
+            controller_oauthtoken: "{{ authtoken_res.json.token }}"
+            controller_oauthtoken_url: "{{ authtoken_res.json.url }}"
+      no_log: "{{ controller_configuration_object_diff_secure_logging }}"
+      when: controller_oauthtoken is not defined
+
   roles:
     - redhat_cop.controller_configuration.filetree_read
     - redhat_cop.controller_configuration.object_diff
+
+  post_tasks:
+    - name: "Delete the Authentication Token used"
+      ansible.builtin.uri:
+        url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"
+        user: "{{ controller_username }}"
+        password: "{{ controller_password }}"
+        method: DELETE
+        force_basic_auth: true
+        validate_certs: "{{ controller_validate_certs }}"
+        status_code: 204
+      when: controller_oauthtoken_url is defined
 ...


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

We remove from roles the authentication tasks because roles themselves shouldn't do it. Authentication should be done by the playbook which use the roles or by the user sending the oauth token as a extra var.

We found problems with auth in roles because we need to use more than one role in the same playbook and authentication in roles broke our workflow.

### How should this be tested?

Launch test playbooks for filetree_create, filetree_read and object_diff roles.