### PR TITLE
Update ansible-lint version and fix lint errors

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -13,7 +13,10 @@ use_default_rules: true
 # https://github.com/ansible/ansible-lint/issues/808
 # with verbosity set to 1, its dumping 'unknown file type messages'
 # verbosity: 1
-skip_list: []
+skip_list:
+  # Skipping fqcn[action] because this collection supports using either the awx.awx or ansible.controller collection
+  #   so a FQCN cannot be used in module names
+  - fqcn[action]
 kinds:
   - playbooks: "**/examples/templates/*.{yml,yaml}"
   - playbooks: "**/examples/*.{yml,yaml}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   #       types:
   #         - yaml
   - repo: 'https://github.com/ansible-community/ansible-lint.git'
-    rev: v6.6.1
+    rev: v6.8.2
     hooks:
       # see discussions here about what arguments are used, and behavior
       # https://github.com/ansible/ansible-lint/issues/649

--- a/examples/tasks/differential.yml
+++ b/examples/tasks/differential.yml
@@ -1,9 +1,9 @@
 ---
-- name: "Get the API list of all {{ differential_item.name }} in the Default Organization"
+- name: "Get the API list in the Default Organization of all {{ differential_item.name }}"
   ansible.builtin.set_fact:
     controller_api_results: "{{ lookup('awx.awx.controller_object_diff', differential_item.name, query_params={'organization': controller_organization_id.id}, host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=false) }}"
 
-- name: "Find the difference of {{ differential_item.name }} between what is on the Controller versus curated list."
+- name: "Find the difference between what is on the Controller versus curated list of {{ differential_item.name }}"
   ansible.builtin.set_fact:
     set_absent_diff: "{{ lookup('awx.awx.controller_object_diff', api_list=controller_api_results, compare_list=differential_item.differential_test_items, with_present=differential_item.with_present) }}"
 
@@ -11,7 +11,7 @@
   ansible.builtin.debug:
     var: set_absent_diff
 
-- name: "Assert that the expected {{ differential_item.name }} results match."
+- name: "Assert that the expected results match for {{ differential_item.name }}"
   ansible.builtin.assert:
     that:
       - set_absent_diff ==  differential_item.expected_test_result

--- a/roles/dispatch/tasks/main.yml
+++ b/roles/dispatch/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: "Run redhat_cop.controller_configuration.{{ __role.role }} role"
+- name: "Run redhat_cop.controller_configuration.{{ __role.role }}"
   ansible.builtin.include_role:
     name: "{{ __role.role }}"
     apply:

--- a/roles/filetree_create/tasks/all.yml
+++ b/roles/filetree_create/tasks/all.yml
@@ -4,6 +4,7 @@
     is_aap: "{{ lookup(controller_api_plugin, 'ping', host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs).version is version('4.0.0', '>=') }}"
 
 - name: Include tasks (block)
+  when: "['all', 'inventory', 'credentials', 'credential_types', 'notification_templates', 'users', 'teams', 'organizations', 'projects', 'execution_environments', 'job_templates', 'workflow_job_templates', 'workflow_job_template_nodes'] | intersect(input_tag) | length > 0"
   block:
     - name: "Export Inventories and related Groups and Hosts"
       ansible.builtin.include_tasks: "inventory.yml"
@@ -38,5 +39,4 @@
     - name: "Export Workflow Job Templates"
       ansible.builtin.include_tasks: "workflow_job_templates.yml"
       when: "'workflow_job_templates' in input_tag or 'all' in input_tag"
-  when: "['all', 'inventory', 'credentials', 'credential_types', 'notification_templates', 'users', 'teams', 'organizations', 'projects', 'execution_environments', 'job_templates', 'workflow_job_templates', 'workflow_job_template_nodes'] | intersect(input_tag) | length > 0"
 ...

--- a/roles/filetree_create/tasks/credential_types.yml
+++ b/roles/filetree_create/tasks/credential_types.yml
@@ -23,7 +23,7 @@
     state: directory
     mode: '0755'
 
-- name: "Add current credential types to the output yaml file: {{ output_path }}/current_credential_types.yaml"
+- name: "Add current credential types to the current_credential_types.yaml output file in {{ output_path }}"
   ansible.builtin.template:
     src: "templates/current_credential_types.j2"
     dest: "{{ output_path }}/current_credential_types.yaml"

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -7,7 +7,7 @@
                                    return_all=true, max_objects=query_controller_api_max_objects)
                           }}"
 
-- name: "Create the output directory for credentials: {{ output_path }}/<ORGANIZATION_NAME>/credentials"
+- name: "Create the <ORGANIZATION_NAME>/credentials output directory for credentials in {{ output_path }}"
   ansible.builtin.file:
     path: "{{ __path }}"
     state: directory
@@ -21,7 +21,7 @@
     loop_var: needed_path
     label: "{{ __path }}"
 
-- name: "Add current credentials to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/credentials"
+- name: "Add current credentials to the <ORGANIZATION_NAME>/credentials output yaml file in {{ output_path }}"
   ansible.builtin.template:
     src: "templates/current_credentials.j2"
     dest: "{{ __dest }}"

--- a/roles/filetree_create/tasks/execution_environments.yml
+++ b/roles/filetree_create/tasks/execution_environments.yml
@@ -12,7 +12,7 @@
     state: directory
     mode: '0755'
 
-- name: "Add current execution environments to the output yaml file: {{ output_path }}/current_execution_environments.yaml"
+- name: "Add current execution environments to the current_execution_environments.yaml output file in {{ output_path }}"
   ansible.builtin.template:
     src: "templates/current_execution_environments.j2"
     dest: "{{ output_path }}/current_execution_environments.yaml"

--- a/roles/filetree_create/tasks/groups.yml
+++ b/roles/filetree_create/tasks/groups.yml
@@ -5,7 +5,7 @@
     state: directory
     mode: '0755'
 
-- name: "Add current groups to the output yaml file: {{ groups_output_path }}/current_groups.yaml"
+- name: "Add current groups to the current_groups.yaml output file in {{ groups_output_path }}"
   ansible.builtin.template:
     src: "templates/current_groups.j2"
     dest: "{{ groups_output_path }}/current_groups.yaml"

--- a/roles/filetree_create/tasks/hosts.yml
+++ b/roles/filetree_create/tasks/hosts.yml
@@ -5,7 +5,7 @@
     state: directory
     mode: '0755'
 
-- name: "Add current hosts to the output yaml file: {{ hosts_output_path }}/current_hosts.yaml"
+- name: "Add current hosts to the current_hosts.yaml output file in {{ hosts_output_path }}"
   ansible.builtin.template:
     src: "templates/current_hosts.j2"
     dest: "{{ hosts_output_path }}/current_hosts.yaml"

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -7,7 +7,7 @@
                                  return_all=true, max_objects=query_controller_api_max_objects)
                         }}"
 
-- name: "Create the <ORGANIZATION_NAME>/inventories output directory for inventories in {{ output_path | regex_replace('/', '_') }}"
+- name: "Create the <ORGANIZATION_NAME>/inventories output directory for inventories in {{ output_path }}"
   ansible.builtin.file:
     path: "{{ __path }}"
     state: directory
@@ -21,7 +21,7 @@
     loop_var: needed_path
     label: "{{ __path }}"
 
-- name: "Add current inventories to the <ORGANIZATION_NAME>/inventories output yaml file in {{ output_path | regex_replace('/', '_') }}"
+- name: "Add current inventories to the <ORGANIZATION_NAME>/inventories output yaml file in {{ output_path }}"
   ansible.builtin.template:
     src: "templates/current_inventories.j2"
     dest: "{{ __dest }}"

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -7,7 +7,7 @@
                                  return_all=true, max_objects=query_controller_api_max_objects)
                         }}"
 
-- name: "Create the output directory for inventories: {{ output_path }}/<ORGANIZATION_NAME>/inventories"
+- name: "Create the <ORGANIZATION_NAME>/inventories output directory for inventories in {{ output_path | regex_replace('/', '_') }}"
   ansible.builtin.file:
     path: "{{ __path }}"
     state: directory
@@ -21,7 +21,7 @@
     loop_var: needed_path
     label: "{{ __path }}"
 
-- name: "Add current inventories to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/inventories"
+- name: "Add current inventories to the <ORGANIZATION_NAME>/inventories output yaml file in {{ output_path | regex_replace('/', '_') }}"
   ansible.builtin.template:
     src: "templates/current_inventories.j2"
     dest: "{{ __dest }}"
@@ -39,12 +39,12 @@
   ansible.builtin.include_tasks: "inventory_sources.yml"
   vars:
     inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
-    inventory_name: "{{ current_inventory_sources.name | regex_replace('/','_') }}"
+    inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
     inventory_sources_output_path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
     current_inventory_sources_asset_value: "{{ query(controller_api_plugin, current_inventory_sources.related.inventory_sources,
                                                           host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                                                          return_all=true, max_objects=query_controller_api_max_objects
-                                                    ) if current_inventory_sources.has_inventory_sources else []
+                                                          return_all=true, max_objects=query_controller_api_max_objects)
+                                                    if current_inventory_sources.has_inventory_sources else []
                                             }}"
   loop: "{{ inventory_lookvar }}"
   loop_control:
@@ -55,12 +55,12 @@
   ansible.builtin.include_tasks: "hosts.yml"
   vars:
     inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
-    inventory_name: "{{ current_inventory_hosts.name | regex_replace('/','_') }}"
+    inventory_name: "{{ current_inventory_hosts.name | regex_replace('/', '_') }}"
     hosts_output_path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
     current_hosts_asset_value: "{{ query(controller_api_plugin, current_inventory_hosts.related.hosts,
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                                              return_all=true, max_objects=query_controller_api_max_objects
-                                        ) if not current_inventory_hosts.has_inventory_sources else []
+                                              return_all=true, max_objects=query_controller_api_max_objects)
+                                        if not current_inventory_hosts.has_inventory_sources else []
                                 }}"
   loop: "{{ inventory_lookvar }}"
   loop_control:
@@ -71,12 +71,12 @@
   ansible.builtin.include_tasks: "groups.yml"
   vars:
     inventory_organization: "{{ current_inventory_groups.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
-    inventory_name: "{{ current_inventory_groups.name | regex_replace('/','_') }}"
+    inventory_name: "{{ current_inventory_groups.name | regex_replace('/', '_') }}"
     groups_output_path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
     current_groups_asset_value: "{{ query(controller_api_plugin, current_inventory_groups.related.groups,
                                                host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                                               return_all=true, max_objects=query_controller_api_max_objects
-                                         ) if not current_inventory_groups.has_inventory_sources else []
+                                               return_all=true, max_objects=query_controller_api_max_objects)
+                                         if not current_inventory_groups.has_inventory_sources else []
                                  }}"
   loop: "{{ inventory_lookvar }}"
   loop_control:

--- a/roles/filetree_create/tasks/inventory_sources.yml
+++ b/roles/filetree_create/tasks/inventory_sources.yml
@@ -5,7 +5,7 @@
     state: directory
     mode: '0755'
 
-- name: "Add current inventory source to the output yaml file: {{ inventory_sources_output_path }}/current_inventory_sources.yaml"
+- name: "Add current inventory source to the current_inventory_sources.yaml output file in {{ inventory_sources_output_path }}"
   ansible.builtin.template:
     src: "templates/current_inventory_sources.j2"
     dest: "{{ inventory_sources_output_path }}/current_inventory_sources.yaml"

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -7,7 +7,7 @@
                                      return_all=true, max_objects=query_controller_api_max_objects)
                             }}"
 
-- name: "Create the output directories for job templates: {{ output_path }}/<ORGANIZATION_NAME>"
+- name: "Create the <ORGANIZATION_NAME> output directories for job templates in {{ output_path }}"
   ansible.builtin.file:
     path: "{{ __path }}"
     state: directory
@@ -21,7 +21,7 @@
     loop_var: needed_path
     label: "{{ __path }}"
 
-- name: "Add current job_templates to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/job_templates"
+- name: "Add current job_templates to the <ORGANIZATION_NAME>/job_templates output file in {{ output_path }}"
   ansible.builtin.template:
     src: "templates/current_job_templates.j2"
     dest: "{{ __dest }}"

--- a/roles/filetree_create/tasks/main.yml
+++ b/roles/filetree_create/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 # tasks file for filetree_create
 - name: "Check requirements (block)"
+  tags:
+    - always
   block:
     - name: "Check installed collections (block)"
       block:
@@ -42,9 +44,6 @@
       loop: "{{ input_tag }}"
       loop_control:
         loop_var: tag_item
-
-  tags:
-    - always
 
 - name: "Include Tasks to get all objects of type {{ input_tag }}"
   ansible.builtin.include_tasks: all.yml

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -6,7 +6,7 @@
                                               return_all=true, max_objects=query_controller_api_max_objects)
                                      }}"
 
-- name: "Create the output directory for notification templates: {{ output_path }}/<ORGANIZATION_NAME>/notification_templates"
+- name: "Create the <ORGANIZATION_NAME>/notification_templates output directory for notification templates in {{ output_path }}"
   ansible.builtin.file:
     path: "{{ __path }}"
     state: directory
@@ -20,7 +20,7 @@
     loop_var: needed_path
     label: "{{ __path }}"
 
-- name: "Add current notification templates to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/current_notification_templates.yaml"
+- name: "Add current notification templates to the <ORGANIZATION_NAME>/current_notification_templates.yaml output file in {{ output_path }}"
   ansible.builtin.template:
     src: "templates/current_notification_templates.j2"
     dest: "{{ __dest }}"

--- a/roles/filetree_create/tasks/organizations.yml
+++ b/roles/filetree_create/tasks/organizations.yml
@@ -7,7 +7,7 @@
                             return_all=true, max_objects=query_controller_api_max_objects)
                    }}"
 
-- name: "Create the output directory for organizations: {{ output_path }}/{{ current_organization_dir.name }}"
+- name: "Create the output directory for organizations: {{ output_path + '/' + current_organization_dir.name }}"
   ansible.builtin.file:
     path: "{{ __path }}"
     state: directory

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -7,7 +7,7 @@
                                 return_all=true, max_objects=query_controller_api_max_objects)
                        }}"
 
-- name: "Create the output directory for projects: {{ output_path }}/<ORGANIZATION_NAME>/projects"
+- name: "Create the <ORGANIZATION_NAME>/projects output directory for projects in {{ output_path }}"
   ansible.builtin.file:
     path: "{{ __path }}"
     state: directory
@@ -21,7 +21,7 @@
     loop_var: needed_path
     label: "{{ __path }}"
 
-- name: "Add current projects to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/projects"
+- name: "Add current projects to the <ORGANIZATION_NAME>/projects output file in {{ output_path }}"
   ansible.builtin.template:
     src: "templates/current_projects.j2"
     dest: "{{ __dest }}"

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -7,7 +7,7 @@
                              return_all=true, max_objects=query_controller_api_max_objects)
                     }}"
 
-- name: "Create the output directory for teams: {{ output_path }}/<ORGANIZATION_NAME>/teams"
+- name: "Create the <ORGANIZATION_NAME>/teams output directory for teams in {{ output_path }}"
   ansible.builtin.file:
     path: "{{ __path }}"
     state: directory
@@ -21,7 +21,7 @@
     loop_var: needed_path
     label: "{{ __path }}"
 
-- name: "Add current teams to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/teams"
+- name: "Add current teams to the <ORGANIZATION_NAME>/teams output file in {{ output_path }}"
   ansible.builtin.template:
     src: "templates/current_teams.j2"
     dest: "{{ __dest }}"

--- a/roles/filetree_create/tasks/users.yml
+++ b/roles/filetree_create/tasks/users.yml
@@ -16,7 +16,7 @@
     loop_var: user_lookvar_item
     label: "User {{ user_lookvar_item.username }}"
 
-- name: "Create the output directory for users: {{ output_path }}/<ORGANIZATION_NAME>"
+- name: "Create the <ORGANIZATION_NAME> output directory for users in {{ output_path }}"
   ansible.builtin.file:
     path: "{{ __path }}"
     state: directory
@@ -28,7 +28,7 @@
     loop_var: current_user_dir
     label: "{{ __path }}"
 
-- name: "Add current users to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/current_users_<USERNAME>.yaml"
+- name: "Add current users to the <ORGANIZATION_NAME>/current_users_<USERNAME>.yaml output file in {{ output_path }}"
   ansible.builtin.template:
     src: "templates/current_users.j2"
     dest: "{{ __dest }}"

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -7,7 +7,7 @@
                                               return_all=true, max_objects=query_controller_api_max_objects)
                                      }}"
 
-- name: "Create the output directory for workflow job templates: {{ output_path }}/<ORGANIZATION_NAME>/workflow_job_templates"
+- name: "Create the <ORGANIZATION_NAME>/workflow_job_templates output directory for workflow job templates in {{ output_path }}"
   ansible.builtin.file:
     path: "{{ __path }}"
     state: directory
@@ -21,7 +21,7 @@
     loop_var: needed_path
     label: "{{ __path }}"
 
-- name: "Add current workflow job templates to the output yaml file: {{ output_path }}/<ORGANIZATION_NAME>/workflow_job_templates"
+- name: "Add current workflow job templates to the <ORGANIZATION_NAME>/workflow_job_templates output file in {{ output_path }}"
   ansible.builtin.template:
     src: "templates/current_workflow_job_templates.j2"
     dest: "{{ __dest }}"

--- a/roles/filetree_read/tasks/main.yml
+++ b/roles/filetree_read/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 # tasks file for filetree_read
-- name: "Include Tasks to config {{  __task_filetree_read.name }}"
-  ansible.builtin.include_tasks: "{{  __task_filetree_read.name }}.yml"
+- name: "Include Tasks to config {{ __task_filetree_read.name }}"
+  ansible.builtin.include_tasks: "{{ __task_filetree_read.name }}.yml"
   args:
     apply:
-      tags: "{{  __task_filetree_read.tags }}"
+      tags: "{{ __task_filetree_read.tags }}"
   tags: always
   loop: "{{ controller_configuration_filetree_read_tasks }}"
   loop_control:

--- a/roles/groups/tasks/main.yml
+++ b/roles/groups/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # The group module is also an ansible.builtin module, but due to supporting both the awx.awx and automation.controller collections
 # the FQCN cannot be used here.
-- name: Add controller group  # noqa fqcn-builtins
+- name: Add controller group  # noqa fqcn[action-core]
   group:
     name:                           "{{ controller_groups_item.name | mandatory }}"
     new_name:                       "{{ controller_groups_item.new_name | default(omit, true) }}"

--- a/roles/object_diff/tasks/credentials.yml
+++ b/roles/object_diff/tasks/credentials.yml
@@ -7,7 +7,7 @@
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all Credentials {{ orgs }} Organization"
+- name: "OBJECT DIFF: Get the API list of all Credentials in Organization {{ orgs }}"
   ansible.builtin.set_fact:
     __controller_api_credentials: "{{ query(controller_api_plugin, 'credentials',
                                             query_params={'organization': __controller_organization_id.id},

--- a/roles/object_diff/tasks/groups.yml
+++ b/roles/object_diff/tasks/groups.yml
@@ -29,6 +29,7 @@
     loop_var: current_inventory
 
 - name: "Group differences (block)"
+  when: __controller_api_groups is defined
   block:
     - name: "OBJECT DIFF: Find the difference of Groups between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
@@ -41,6 +42,4 @@
     - name: "OBJECT DIFF: Set the inventory key at the correct place"
       ansible.builtin.set_fact:
         controller_groups: "{{ __groups_difference }}"
-
-  when: __controller_api_groups is defined
 ...

--- a/roles/object_diff/tasks/hosts.yml
+++ b/roles/object_diff/tasks/hosts.yml
@@ -29,6 +29,7 @@
     loop_var: current_inventory
 
 - name: "Host differences (block)"
+  when: __controller_api_hosts is defined
   block:
     - name: "OBJECT DIFF: Find the difference of Hosts between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
@@ -41,6 +42,4 @@
     - name: "OBJECT DIFF: Set the inventory key at the correct place"
       ansible.builtin.set_fact:
         controller_hosts: "{{ __hosts_difference }}"
-
-  when: __controller_api_hosts is defined
 ...

--- a/roles/object_diff/tasks/job_templates.yml
+++ b/roles/object_diff/tasks/job_templates.yml
@@ -6,7 +6,7 @@
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all Job Templates {{ orgs }} Organization"
+- name: "OBJECT DIFF: Get the API list of all Job Templates in Organization {{ orgs }}"
   ansible.builtin.set_fact:
     __controller_api_job_templates: "{{ query(controller_api_plugin, 'job_templates',
                                               query_params={'organization': __controller_organization_id.id},

--- a/roles/object_diff/tasks/main.yml
+++ b/roles/object_diff/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 # tasks file for object_diff
 - name: "Check requirements (block)"
+  tags:
+    - always
   block:
     - name: "Check installed collections (block)"
       block:
@@ -24,14 +26,12 @@
         - name: "Show the plugin we are using"
           ansible.builtin.debug:
             msg: "Using the 'controller_api' plugin from: {{ controller_api_plugin }}"
-  tags:
-    - always
 
-- name: "Include Tasks to get OBJECT DIFF {{  __task_diff.name }}"
-  ansible.builtin.include_tasks: "{{  __task_diff.name }}.yml"
+- name: "Include Tasks to get OBJECT DIFF {{ __task_diff.name }}"
+  ansible.builtin.include_tasks: "{{ __task_diff.name }}.yml"
   args:
     apply:
-      tags: "{{  __task_diff.tags }}"
+      tags: "{{ __task_diff.tags }}"
   tags: always
   loop: "{{ controller_configuration_object_diff_tasks }}"
   loop_control:

--- a/roles/object_diff/tasks/projects.yml
+++ b/roles/object_diff/tasks/projects.yml
@@ -6,7 +6,7 @@
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all Projects {{ orgs }} Organization"
+- name: "OBJECT DIFF: Get the API list of all Projects in Organization {{ orgs }}"
   ansible.builtin.set_fact:
     __controller_api_projects: "{{ query(controller_api_plugin, 'projects',
                                           query_params={'organization': __controller_organization_id.id},

--- a/roles/object_diff/tasks/roles.yml
+++ b/roles/object_diff/tasks/roles.yml
@@ -7,6 +7,8 @@
                                                    }}"
 
 - name: "Role differences (block)"
+  when:
+    - __controller_api_current_user_check_is_admin.is_superuser
   block:
 
     - name: "OBJECT DIFF: Get the API list of all roles"
@@ -26,7 +28,4 @@
     - name: "OBJECT DIFF: Sets differences between Roles what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         controller_roles: "{{ __roles_difference }}"
-
-  when:
-    - __controller_api_current_user_check_is_admin.is_superuser
 ...

--- a/roles/object_diff/tasks/teams.yml
+++ b/roles/object_diff/tasks/teams.yml
@@ -7,6 +7,8 @@
                                                    }}"
 
 - name: "Team differences (block)"
+  when:
+    - __controller_api_current_user_check_is_admin.is_superuser
   block:
     - name: Get the organization ID
       ansible.builtin.set_fact:
@@ -15,7 +17,7 @@
                                                   host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                        }}"
 
-    - name: "OBJECT DIFF: Get the API list of all teams {{ orgs }} Organization"
+    - name: "OBJECT DIFF: Get the API list of all teams in Organization {{ orgs }}"
       ansible.builtin.set_fact:
         __controller_api_teams: "{{ query(controller_api_plugin, 'teams',
                                           query_params={'organization': __controller_organization_id.id},
@@ -34,6 +36,4 @@
     - name: "OBJECT DIFF: Sets the difference of Teams between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         controller_teams: "{{ __teams_difference }}"
-  when:
-    - __controller_api_current_user_check_is_admin.is_superuser
 ...

--- a/roles/object_diff/tasks/user_accounts.yml
+++ b/roles/object_diff/tasks/user_accounts.yml
@@ -14,6 +14,7 @@
                                      }}"
 
 - name: "Populate user accounts (block)"
+  when: not drop_user_external_accounts
   block:
     - name: "Populate User Accounts list"
       ansible.builtin.set_fact:
@@ -24,9 +25,9 @@
         __controller_api_user_accounts: "{{ populate_controller_api_user_accounts_without_external_accounts }}"
       when: populate_controller_api_user_accounts_without_external_accounts is defined
 
-  when: not drop_user_external_accounts
-
 - name: "User account differences (block)"
+  when:
+    - __controller_api_current_user_check_is_admin.is_superuser
   block:
     - name: "OBJECT DIFF: Find the difference of User Accounts between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
@@ -38,7 +39,4 @@
     - name: "OBJECT DIFF: Sets the difference of User Accounts between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         controller_user_accounts: "{{ __user_accounts_difference }}"
-  when:
-    - __controller_api_current_user_check_is_admin.is_superuser
-
 ...

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # The user module is also an ansible.builtin module, but due to supporting both the awx.awx and automation.controller collections
 # the FQCN cannot be used here.
-- name: Add controller user  # noqa fqcn-builtins
+- name: Add controller user  # noqa fqcn[action-core]
   user:
     username:                 "{{ __controller_user_accounts_item.user | default(__controller_user_accounts_item.username) | mandatory }}"
     # the 'true' in the second default leads to no password being set if the default password is empty

--- a/roles/workflow_job_templates/tasks/main.yml
+++ b/roles/workflow_job_templates/tasks/main.yml
@@ -63,7 +63,7 @@
     ansible_async_dir: '/tmp/.ansible_async'
 
 # Create links between workflow node
-- name: loop over nodes in schema to add to workflow templates
+- name: Loop over nodes in schema to add to workflow templates
   ansible.builtin.include_tasks: "add_workflows_schema.yml"
   loop: "{{ controller_workflows }}"
   loop_control:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

Updates ansible-lint to version 6.8.2 and fixes new found linting errors.

The `fqcn[action]` check has also been disabled as the collection depends on either the `awx.awx` or `ansible.controller` collection so the FQCN of the modules cannot be specified.

### How should this be tested?

Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

### Is there a relevant Issue open for this?

No

### Other Relevant info, PRs, etc

Nnoe