### PR TITLE
Fixed chicken-egg issue galaxy credentials and orgs

### DIFF
--- a/roles/filetree_read/tests/config-controller-filetree.yml
+++ b/roles/filetree_read/tests/config-controller-filetree.yml
@@ -3,13 +3,12 @@
   connection: local
   gather_facts: false
   vars:
-    controller_configuration_projects_async_retries: 60
+    controller_configuration_projects_async_retries: 120
     controller_configuration_projects_async_delay: 2
     controller_username: "{{ vault_controller_username | default(lookup('env', 'CONTROLLER_USERNAME')) }}"
     controller_password: "{{ vault_controller_password | default(lookup('env', 'CONTROLLER_PASSWORD')) }}"
     controller_hostname: "{{ vault_controller_hostname | default(lookup('env', 'CONTROLLER_HOST')) }}"
     controller_validate_certs: "{{ vault_controller_validate_certs | default(lookup('env', 'CONTROLLER_VERIFY_SSL')) }}"
-
   pre_tasks:
     - name: "Setup authentication (block)"
       block:
@@ -32,17 +31,16 @@
       when: controller_oauthtoken is not defined
       tags:
         - always
+  roles:
+    - {role: redhat_cop.controller_configuration.filetree_read, assign_galaxy_credentials_to_org: false}
+    - {role: redhat_cop.controller_configuration.dispatch, assign_galaxy_credentials_to_org: false}
 
+  post_tasks:
     - block:
         - name: Include Tasks to load Galaxy credentials to be added to Organizations
           ansible.builtin.include_role:
             name: redhat_cop.controller_configuration.filetree_read
-            tasks_from: "{{ create_orgs_credentials }}"
-          loop:
-            - organizations.yml
-            - credentials.yml
-          loop_control:
-            loop_var: create_orgs_credentials
+            tasks_from: organizations.yml
 
         - name: Include Tasks to add Galaxy credentials to Organizations
           ansible.builtin.include_role:
@@ -50,18 +48,12 @@
             apply:
               tags:
                 - organizations
-                - credentials
           vars:
-            assign_galaxy_credentials_to_org: false
             controller_configuration_dispatcher_roles:
               - {role: organizations, var: controller_organizations, tags: organizations}
-              - {role: credentials, var: controller_credentials, tags: credentials}
+      tags:
+        - organizations
 
-  roles:
-    - {role: redhat_cop.controller_configuration.filetree_read}
-    - {role: redhat_cop.controller_configuration.dispatch}
-
-  post_tasks:
     - name: "Delete the Authentication Token used"
       ansible.builtin.uri:
         url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"


### PR DESCRIPTION
### What does this PR do?

Fixed chicken-egg issue with galaxy credentials and organizations in the example playbook in test directory of the filetree_read role. 

### How should this be tested?
Tested manually ->

 ansible-playbook config-controller-filetree.yml -i inventory -l demo-dev -e '{orgs: test-org, dir_orgs_vars: orgs_vars, env: demo-dev}' --tags organizations,credentials
