### PR TITLE
Update CI to release infra collection

### DIFF
--- a/.github/workflow-config/release_tarball.yml
+++ b/.github/workflow-config/release_tarball.yml
@@ -18,13 +18,6 @@
         dest: "{{ repo_base_dir }}/galaxy.yml"
         mode: '0644'
 
-    - name: Update changelog
-      command:
-        cmd: antsibull-changelog release --verbose --version {{ collection_version }}
-        chdir: "{{ repo_base_dir }}"
-      register: update_changelog
-      changed_when: "update_changelog.rc != 2"
-
     - name: build collection
       command:
         cmd: ansible-galaxy collection build
@@ -41,18 +34,4 @@
       register: install_result
       changed_when: "install_result.rc != 2"
       tags: install
-
-    - name: publish collection
-      command:
-        cmd: "ansible-galaxy collection publish --api-key={{ api_key }} {{ collection_namespace }}-{{ collection_name }}-{{ collection_version }}.tar.gz"
-        chdir: "{{ repo_base_dir }}"
-      register: publish_result
-      changed_when: "publish_result.rc != 2"
-      tags: publish
-
-    - name: remove galaxy.yml
-      file:
-        path: "{{ repo_base_dir }}/galaxy.yml"
-        state: absent
-      tags: cleanup
 ...

--- a/.github/workflows/galaxy-release.yml
+++ b/.github/workflows/galaxy-release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Publish to galaxy
         run: ansible-playbook .github/workflow-config/release.yml
           -e namespace=${{ github.repository_owner }}
-          -e github_tag=${{ github.ref }}
+          -e github_tag=${{ github.ref_name }}
           -e api_key=${{ secrets.ANSIBLE_GALAXY_APIKEY }}
           -e collection_repo=https://github.com/${{ github.repository }}
           --verbose --skip-tags=install,cleanup

--- a/.github/workflows/infra-release.yml
+++ b/.github/workflows/infra-release.yml
@@ -1,0 +1,69 @@
+---
+name: tarball-release
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      ANSIBLE_FORCE_COLOR: 1
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: redhat_cop tarball creation
+        run: ansible-playbook .github/workflow-config/release_tarball.yml
+          -e namespace=${{ github.repository_owner }}
+          -e github_tag=${{ github.ref_name }}
+          -e collection_repo=https://github.com/${{ github.repository }}
+          --verbose --skip-tags=install,cleanup
+
+      - name: infra tarball creation
+        run: ansible-playbook .github/workflow-config/release_tarball.yml
+          -e namespace=infra
+          -e github_tag=${{ github.ref_name }}
+          -e collection_repo=https://github.com/${{ github.repository }}
+          --verbose --skip-tags=install,cleanup
+
+      - name: run ls
+        run: ls
+
+      - name: Set namespace
+        run: |
+          echo "NAMESPACE=$(sed 's/-/_/g' <<< ${{ github.repository_owner }})" >> $GITHUB_OUTPUT
+        id: namespace
+
+      - name: Display namespace
+        run: echo "namespace is ${{ steps.namespace.outputs.NAMESPACE }}"
+
+      - name: run ls
+        run: ls
+
+      - name: Upload files to tag
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: infra-controller_configuration-${{ github.ref_name }}.tar.gz
+          tag: ${{ github.ref }}
+          overwrite: true
+
+      - name: Upload files to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.namespace.outputs.NAMESPACE }}-controller_configuration-${{ github.ref_name }}.tar.gz
+          tag: ${{ github.ref }}
+          overwrite: true
+
+...

--- a/galaxy.yml.j2
+++ b/galaxy.yml.j2
@@ -10,6 +10,7 @@ authors:
     - Kedar Kulkarni @kedark3
     - Tom Page @Tompage1994
     - Sean Sullivan @sean-m-sullivan
+    - David Danielsson @djdanielsson
 repository: {{ collection_repo }}
 issues: {{ collection_repo }}/issues
 build_ignore:
@@ -18,6 +19,7 @@ build_ignore:
     - .github
     - .ansiblelint.yml
     - .yamllint.yml
+    - '*.tar.gz'
 license:
     - GPL-3.0-or-later
 tags:


### PR DESCRIPTION
### What does this PR do?
When we do a new release this uploads collection builds to the release. This will require all new releases to be numbered as in 2.3.0 not v2.3.0, unless someone has a better sed, but that should be our standard practice anyway.

### How should this be tested?

Automated tests

In action: https://github.com/sean-m-sullivan/controller_configuration/releases/tag/1.3.1