### PR TITLE
[filetree_read role] - Added controller_location variable to handle multiple sites and loop…

### DIFF
--- a/roles/filetree_read/README.md
+++ b/roles/filetree_read/README.md
@@ -17,6 +17,7 @@ The following Variables set the organization where should be applied the configu
 |`orgs:`|Acme|yes|This variable sets the organization where should be applied the configuration.|
 |`dir_orgs_vars:`|orgs_vars|yes|This variable sets the directory path where the variables will be store.|
 |`env:`|dev|yes|This variable sets the life-cycle environment to use.|
+|`controller_location:`|''|no|This variable sets object localtion. It is useful when the configuration need to be replicated in an active/passive sites architecture|
 |`filetree_controller_settings`|{{ dir_orgs_vars }}/{{ orgs }}/env/{{ env }}/controller_settings.d/|yes|Directory path to load controller object variables|
 |`filetree_controller_organizations`|{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_organizations.d/|yes|Directory path to load controller object variables|
 |`filetree_controller_labels`|{{ dir_orgs_vars }}/{{ orgs }}/env/common/controller_labels.d/|yes|Directory path to load controller object variables|

--- a/roles/filetree_read/tasks/applications.yml
+++ b/roles/filetree_read/tasks/applications.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Applications definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_applications_definitions_item.path }}"
   loop: "{{ __list_files_controller_applications.files }}"
+  loop_control:
+    loop_var: __read_applications_definitions_item
   register: __contents_filetree_controller_applications
 
 - name: "Populate Applications list"
   ansible.builtin.set_fact:
-    __populate_controller_applications: "{{ (__populate_controller_applications | default([])) + item.ansible_facts.controller_applications }}"
+    __populate_controller_applications: "{{ (__populate_controller_applications | default([])) + __populate_applications_list_item.ansible_facts.controller_applications }}"
   loop: "{{ __contents_filetree_controller_applications.results }}"
-  when: __contents_filetree_controller_applications.results is defined and item.ansible_facts.controller_applications is defined
+  loop_control:
+    loop_var: __populate_applications_list_item
+  when: __contents_filetree_controller_applications.results is defined and __populate_applications_list_item.ansible_facts.controller_applications is defined
 
 - name: "Set Applications Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/credential_input_sources.yml
+++ b/roles/filetree_read/tasks/credential_input_sources.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Credential Input Sources definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_input_sources_definitions_item.path }}"
   loop: "{{ __list_files_controller_credential_input_sources.files }}"
+  loop_control:
+    loop_var: __read_input_sources_definitions_item
   register: __contents_filetree_controller_credential_input_sources
 
 - name: "Populate Credential Input Sources list"
   ansible.builtin.set_fact:
-    __populate_controller_credential_input_sources: "{{ (__populate_controller_credential_input_sources | default([])) + item.ansible_facts.controller_credential_input_sources }}"
+    __populate_controller_credential_input_sources: "{{ (__populate_controller_credential_input_sources | default([])) + __populate_input_sources_list_item.ansible_facts.controller_credential_input_sources }}"
   loop: "{{ __contents_filetree_controller_credential_input_sources.results }}"
-  when: __contents_filetree_controller_credential_input_sources.results is defined and item.ansible_facts.controller_credential_input_sources is defined
+  loop_control:
+    loop_var: __populate_input_sources_list_item
+  when: __contents_filetree_controller_credential_input_sources.results is defined and __populate_input_sources_list_item.ansible_facts.controller_credential_input_sources is defined
 
 - name: "Set Credential Input Sources Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/credential_types.yml
+++ b/roles/filetree_read/tasks/credential_types.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Credential_Types definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_credentials_definitions_item.path }}"
   loop: "{{ __list_files_controller_credential_types.files }}"
+  loop_control:
+    loop_var: __read_credentials_definitions_item
   register: __contents_filetree_controller_credential_types
 
 - name: "Populate Credential_Types list"
   ansible.builtin.set_fact:
-    __populate_controller_credential_types: "{{ (__populate_controller_credential_types | default([])) + item.ansible_facts.controller_credential_types }}"
+    __populate_controller_credential_types: "{{ (__populate_controller_credential_types | default([])) + __populate_credentials_list_item.ansible_facts.controller_credential_types }}"
   loop: "{{ __contents_filetree_controller_credential_types.results }}"
-  when: __contents_filetree_controller_credential_types.results is defined and item.ansible_facts.controller_credential_types is defined
+  loop_control:
+    loop_var: __populate_credentials_list_item
+  when: __contents_filetree_controller_credential_types.results is defined and __populate_credentials_list_item.ansible_facts.controller_credential_types is defined
 
 - name: "Set Projects Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/credentials.yml
+++ b/roles/filetree_read/tasks/credentials.yml
@@ -24,32 +24,31 @@
 
 - name: "Segrated Credentials list when controller_location is defined"
   block:
-  - name: "Populate Credentials list by _common objects"
-    ansible.builtin.set_fact:
-      __populate_controller_credentials_common: "{{ (__populate_controller_credentials_common | default([])) + [__populate_credentials_list_common_item] }}"
-    loop: "{{ __populate_controller_credentials }}"
-    loop_control:
-      loop_var: __populate_credentials_list_common_item
-    when: "__populate_credentials_list_common_item.controller_location is not defined"
+    - name: "Populate Credentials list by _common objects"
+      ansible.builtin.set_fact:
+        __populate_controller_credentials_common: "{{ (__populate_controller_credentials_common | default([])) + [__populate_credentials_list_common_item] }}"
+      loop: "{{ __populate_controller_credentials }}"
+      loop_control:
+        loop_var: __populate_credentials_list_common_item
+      when: "__populate_credentials_list_common_item.controller_location is not defined"
 
-  - name: "Populate Credentials list by __site objects"
-    ansible.builtin.set_fact:
-      __populate_controller_credentials_site: "{{ (__populate_controller_credentials_site | default([])) + [__populate_credentials_list_site_item] }}"
-    loop: "{{ __populate_controller_credentials }}"
-    loop_control:
-      loop_var: __populate_credentials_list_site_item
-    when: "__populate_credentials_list_site_item.controller_location is defined and __populate_credentials_list_site_item.controller_location == controller_location"
+    - name: "Populate Credentials list by __site objects"
+      ansible.builtin.set_fact:
+        __populate_controller_credentials_site: "{{ (__populate_controller_credentials_site | default([])) + [__populate_credentials_list_site_item] }}"
+      loop: "{{ __populate_controller_credentials }}"
+      loop_control:
+        loop_var: __populate_credentials_list_site_item
+      when: "__populate_credentials_list_site_item.controller_location is defined and __populate_credentials_list_site_item.controller_location == controller_location"
 
-  - name: "Concatenate Credentials list common + site"
-    ansible.builtin.set_fact:
-      __populate_controller_credentials_total: "{{ __populate_controller_credentials_common | default([]) + __populate_controller_credentials_site }}"
-    when: __populate_controller_credentials_site is defined
+    - name: "Concatenate Credentials list common + site"
+      ansible.builtin.set_fact:
+        __populate_controller_credentials_total: "{{ __populate_controller_credentials_common | default([]) + __populate_controller_credentials_site }}"
+      when: __populate_controller_credentials_site is defined
 
-  - name: "Set Credentials Data Structure common + site concatenated"
-    ansible.builtin.set_fact:
-      __populate_controller_credentials: "{{ __populate_controller_credentials_total }}"
-    when: __populate_controller_credentials_total is defined
-
+    - name: "Set Credentials Data Structure common + site concatenated"
+      ansible.builtin.set_fact:
+        __populate_controller_credentials: "{{ __populate_controller_credentials_total }}"
+      when: __populate_controller_credentials_total is defined
   when: controller_location is defined and __populate_controller_credentials is defined
 
 - name: "Set Credentials Data Structure"

--- a/roles/filetree_read/tasks/credentials.yml
+++ b/roles/filetree_read/tasks/credentials.yml
@@ -23,6 +23,7 @@
   when: __contents_filetree_controller_credentials.results is defined and __populate_credentials_list_item.ansible_facts.controller_credentials is defined
 
 - name: "Segregated Credentials list when controller_location is defined"
+  when: controller_location is defined and __populate_controller_credentials is defined
   block:
     - name: "Populate Credentials list by _common objects"
       ansible.builtin.set_fact:
@@ -49,7 +50,6 @@
       ansible.builtin.set_fact:
         __populate_controller_credentials: "{{ __populate_controller_credentials_total }}"
       when: __populate_controller_credentials_total is defined
-  when: controller_location is defined and __populate_controller_credentials is defined
 
 - name: "Set Credentials Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/credentials.yml
+++ b/roles/filetree_read/tasks/credentials.yml
@@ -8,15 +8,49 @@
 
 - name: "Read Credentials definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_credentials_definitions_item.path }}"
   loop: "{{ __list_files_controller_credentials.files }}"
+  loop_control:
+    loop_var: __read_credentials_definitions_item
   register: __contents_filetree_controller_credentials
 
 - name: "Populate Credentials list"
   ansible.builtin.set_fact:
-    __populate_controller_credentials: "{{ (__populate_controller_credentials | default([])) + item.ansible_facts.controller_credentials }}"
+    __populate_controller_credentials: "{{ (__populate_controller_credentials | default([])) + __populate_credentials_list_item.ansible_facts.controller_credentials }}"
   loop: "{{ __contents_filetree_controller_credentials.results }}"
-  when: __contents_filetree_controller_credentials.results is defined and item.ansible_facts.controller_credentials is defined
+  loop_control:
+    loop_var: __populate_credentials_list_item
+  when: __contents_filetree_controller_credentials.results is defined and __populate_credentials_list_item.ansible_facts.controller_credentials is defined
+
+- name: "Segrated Credentials list when controller_location is defined"
+  block:
+  - name: "Populate Credentials list by _common objects"
+    ansible.builtin.set_fact:
+      __populate_controller_credentials_common: "{{ (__populate_controller_credentials_common | default([])) + [__populate_credentials_list_common_item] }}"
+    loop: "{{ __populate_controller_credentials }}"
+    loop_control:
+      loop_var: __populate_credentials_list_common_item
+    when: "__populate_credentials_list_common_item.controller_location is not defined"
+
+  - name: "Populate Credentials list by __site objects"
+    ansible.builtin.set_fact:
+      __populate_controller_credentials_site: "{{ (__populate_controller_credentials_site | default([])) + [__populate_credentials_list_site_item] }}"
+    loop: "{{ __populate_controller_credentials }}"
+    loop_control:
+      loop_var: __populate_credentials_list_site_item
+    when: "__populate_credentials_list_site_item.controller_location is defined and __populate_credentials_list_site_item.controller_location == controller_location"
+
+  - name: "Concatenate Credentials list common + site"
+    ansible.builtin.set_fact:
+      __populate_controller_credentials_total: "{{ __populate_controller_credentials_common | default([]) + __populate_controller_credentials_site }}"
+    when: __populate_controller_credentials_site is defined
+
+  - name: "Set Credentials Data Structure common + site concatenated"
+    ansible.builtin.set_fact:
+      __populate_controller_credentials: "{{ __populate_controller_credentials_total }}"
+    when: __populate_controller_credentials_total is defined
+
+  when: controller_location is defined and __populate_controller_credentials is defined
 
 - name: "Set Credentials Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/credentials.yml
+++ b/roles/filetree_read/tasks/credentials.yml
@@ -22,7 +22,7 @@
     loop_var: __populate_credentials_list_item
   when: __contents_filetree_controller_credentials.results is defined and __populate_credentials_list_item.ansible_facts.controller_credentials is defined
 
-- name: "Segrated Credentials list when controller_location is defined"
+- name: "Segregated Credentials list when controller_location is defined"
   block:
     - name: "Populate Credentials list by _common objects"
       ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/execution_environments.yml
+++ b/roles/filetree_read/tasks/execution_environments.yml
@@ -23,6 +23,7 @@
   when: __contents_filetree_controller_execution_environments.results is defined and __populate_execution_environments_list_item.ansible_facts.controller_execution_environments is defined
 
 - name: "Segregated Execution Environments list when controller_location is defined"
+  when: controller_location is defined and __populate_controller_execution_environments is defined
   block:
     - name: "Populate Execution Environments list by _common objects"
       ansible.builtin.set_fact:
@@ -49,7 +50,6 @@
       ansible.builtin.set_fact:
         __populate_controller_execution_environments: "{{ __populate_controller_execution_environments_total }}"
       when: __populate_controller_execution_environments_total is defined
-  when: controller_location is defined and __populate_controller_execution_environments is defined
 
 - name: "Set Execution Environments Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/execution_environments.yml
+++ b/roles/filetree_read/tasks/execution_environments.yml
@@ -24,32 +24,31 @@
 
 - name: "Segrated Execution Environments list when controller_location is defined"
   block:
-  - name: "Populate Execution Environments list by _common objects"
-    ansible.builtin.set_fact:
-      __populate_controller_execution_environments_common: "{{ (__populate_controller_execution_environments_common | default([])) + [__populate_execution_environments_list_common_item] }}"
-    loop: "{{ __populate_controller_execution_environments }}"
-    loop_control:
-      loop_var: __populate_execution_environments_list_common_item
-    when: "__populate_execution_environments_list_common_item.controller_location is not defined"
+    - name: "Populate Execution Environments list by _common objects"
+      ansible.builtin.set_fact:
+        __populate_controller_execution_environments_common: "{{ (__populate_controller_execution_environments_common | default([])) + [__populate_execution_environments_list_common_item] }}"
+      loop: "{{ __populate_controller_execution_environments }}"
+      loop_control:
+        loop_var: __populate_execution_environments_list_common_item
+      when: "__populate_execution_environments_list_common_item.controller_location is not defined"
 
-  - name: "Populate Execution Environments list by __site objects"
-    ansible.builtin.set_fact:
-      __populate_controller_execution_environments_site: "{{ (__populate_controller_execution_environments_site | default([])) + [__populate_execution_environments_list_site_item] }}"
-    loop: "{{ __populate_controller_execution_environments }}"
-    loop_control:
-      loop_var: __populate_execution_environments_list_site_item
-    when: "__populate_execution_environments_list_site_item.controller_location is defined and __populate_execution_environments_list_site_item.controller_location == controller_location"
+    - name: "Populate Execution Environments list by __site objects"
+      ansible.builtin.set_fact:
+        __populate_controller_execution_environments_site: "{{ (__populate_controller_execution_environments_site | default([])) + [__populate_execution_environments_list_site_item] }}"
+      loop: "{{ __populate_controller_execution_environments }}"
+      loop_control:
+        loop_var: __populate_execution_environments_list_site_item
+      when: "__populate_execution_environments_list_site_item.controller_location is defined and __populate_execution_environments_list_site_item.controller_location == controller_location"
 
-  - name: "Concatenate Execution Environments list common + site"
-    ansible.builtin.set_fact:
-      __populate_controller_execution_environments_total: "{{ __populate_controller_execution_environments_common | default([]) + __populate_controller_execution_environments_site }}"
-    when: __populate_controller_execution_environments_site is defined
+    - name: "Concatenate Execution Environments list common + site"
+      ansible.builtin.set_fact:
+        __populate_controller_execution_environments_total: "{{ __populate_controller_execution_environments_common | default([]) + __populate_controller_execution_environments_site }}"
+      when: __populate_controller_execution_environments_site is defined
 
-  - name: "Set Execution Environments Data Structure common + site concatenated"
-    ansible.builtin.set_fact:
-      __populate_controller_execution_environments: "{{ __populate_controller_execution_environments_total }}"
-    when: __populate_controller_execution_environments_total is defined
-
+    - name: "Set Execution Environments Data Structure common + site concatenated"
+      ansible.builtin.set_fact:
+        __populate_controller_execution_environments: "{{ __populate_controller_execution_environments_total }}"
+      when: __populate_controller_execution_environments_total is defined
   when: controller_location is defined and __populate_controller_execution_environments is defined
 
 - name: "Set Execution Environments Data Structure"

--- a/roles/filetree_read/tasks/execution_environments.yml
+++ b/roles/filetree_read/tasks/execution_environments.yml
@@ -22,7 +22,7 @@
     loop_var: __populate_execution_environments_list_item
   when: __contents_filetree_controller_execution_environments.results is defined and __populate_execution_environments_list_item.ansible_facts.controller_execution_environments is defined
 
-- name: "Segrated Execution Environments list when controller_location is defined"
+- name: "Segregated Execution Environments list when controller_location is defined"
   block:
     - name: "Populate Execution Environments list by _common objects"
       ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/execution_environments.yml
+++ b/roles/filetree_read/tasks/execution_environments.yml
@@ -8,17 +8,51 @@
 
 - name: "Read Execution Environments definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_execution_environments_definitions_item.path }}"
   loop: "{{ __list_files_controller_execution_environments.files }}"
+  loop_control:
+    loop_var: __read_execution_environments_definitions_item
   register: __contents_filetree_controller_execution_environments
 
 - name: "Populate Execution Environments list"
   ansible.builtin.set_fact:
-    __populate_controller_execution_environments: "{{ (__populate_controller_execution_environments | default([])) + item.ansible_facts.controller_execution_environments }}"
+    __populate_controller_execution_environments: "{{ (__populate_controller_execution_environments | default([])) + __populate_execution_environments_list_item.ansible_facts.controller_execution_environments }}"
   loop: "{{ __contents_filetree_controller_execution_environments.results }}"
-  when: __contents_filetree_controller_execution_environments.results is defined and item.ansible_facts.controller_execution_environments is defined
+  loop_control:
+    loop_var: __populate_execution_environments_list_item
+  when: __contents_filetree_controller_execution_environments.results is defined and __populate_execution_environments_list_item.ansible_facts.controller_execution_environments is defined
 
-- name: "Set Projects Data Structure"
+- name: "Segrated Execution Environments list when controller_location is defined"
+  block:
+  - name: "Populate Execution Environments list by _common objects"
+    ansible.builtin.set_fact:
+      __populate_controller_execution_environments_common: "{{ (__populate_controller_execution_environments_common | default([])) + [__populate_execution_environments_list_common_item] }}"
+    loop: "{{ __populate_controller_execution_environments }}"
+    loop_control:
+      loop_var: __populate_execution_environments_list_common_item
+    when: "__populate_execution_environments_list_common_item.controller_location is not defined"
+
+  - name: "Populate Execution Environments list by __site objects"
+    ansible.builtin.set_fact:
+      __populate_controller_execution_environments_site: "{{ (__populate_controller_execution_environments_site | default([])) + [__populate_execution_environments_list_site_item] }}"
+    loop: "{{ __populate_controller_execution_environments }}"
+    loop_control:
+      loop_var: __populate_execution_environments_list_site_item
+    when: "__populate_execution_environments_list_site_item.controller_location is defined and __populate_execution_environments_list_site_item.controller_location == controller_location"
+
+  - name: "Concatenate Execution Environments list common + site"
+    ansible.builtin.set_fact:
+      __populate_controller_execution_environments_total: "{{ __populate_controller_execution_environments_common | default([]) + __populate_controller_execution_environments_site }}"
+    when: __populate_controller_execution_environments_site is defined
+
+  - name: "Set Execution Environments Data Structure common + site concatenated"
+    ansible.builtin.set_fact:
+      __populate_controller_execution_environments: "{{ __populate_controller_execution_environments_total }}"
+    when: __populate_controller_execution_environments_total is defined
+
+  when: controller_location is defined and __populate_controller_execution_environments is defined
+
+- name: "Set Execution Environments Data Structure"
   ansible.builtin.set_fact:
     controller_execution_environments: "{{ __populate_controller_execution_environments }}"
   when: __populate_controller_execution_environments is defined

--- a/roles/filetree_read/tasks/groups.yml
+++ b/roles/filetree_read/tasks/groups.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Groups definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_groups_definitions_item.path }}"
   loop: "{{ __list_files_controller_groups.files }}"
+  loop_control:
+    loop_var: __read_groups_definitions_item
   register: __contents_filetree_controller_groups
 
 - name: "Populate Groups list"
   ansible.builtin.set_fact:
-    __populate_controller_groups: "{{ (__populate_controller_groups | default([])) + item.ansible_facts.controller_groups }}"
+    __populate_controller_groups: "{{ (__populate_controller_groups | default([])) + __populate_groups_list_item.ansible_facts.controller_groups }}"
   loop: "{{ __contents_filetree_controller_groups.results }}"
-  when: __contents_filetree_controller_groups.results is defined and item.ansible_facts.controller_groups is defined
+  loop_control:
+    loop_var: __populate_groups_list_item
+  when: __contents_filetree_controller_groups.results is defined and __populate_groups_list_item.ansible_facts.controller_groups is defined
 
 - name: "Set Groups Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/hosts.yml
+++ b/roles/filetree_read/tasks/hosts.yml
@@ -23,6 +23,7 @@
   when: __contents_filetree_controller_hosts.results is defined and __populate_hosts_list_item.ansible_facts.controller_hosts is defined
 
 - name: "Segregated Hosts list when controller_location is defined"
+  when: controller_location is defined and __populate_controller_hosts is defined
   block:
     - name: "Populate Hosts list by _common objects"
       ansible.builtin.set_fact:
@@ -49,7 +50,6 @@
       ansible.builtin.set_fact:
         __populate_controller_hosts: "{{ __populate_controller_hosts_total }}"
       when: __populate_controller_hosts_total is defined
-  when: controller_location is defined and __populate_controller_hosts is defined
 
 - name: "Set Hosts Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/hosts.yml
+++ b/roles/filetree_read/tasks/hosts.yml
@@ -22,7 +22,7 @@
     loop_var: __populate_hosts_list_item
   when: __contents_filetree_controller_hosts.results is defined and __populate_hosts_list_item.ansible_facts.controller_hosts is defined
 
-- name: "Segrated Hosts list when controller_location is defined"
+- name: "Segregated Hosts list when controller_location is defined"
   block:
     - name: "Populate Hosts list by _common objects"
       ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/hosts.yml
+++ b/roles/filetree_read/tasks/hosts.yml
@@ -8,17 +8,51 @@
 
 - name: "Read Hosts definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_hosts_definitions_item.path }}"
   loop: "{{ __list_files_controller_hosts.files }}"
+  loop_control:
+    loop_var: __read_hosts_definitions_item
   register: __contents_filetree_controller_hosts
 
 - name: "Populate Hosts list"
   ansible.builtin.set_fact:
-    __populate_controller_hosts: "{{ (__populate_controller_hosts | default([])) + item.ansible_facts.controller_hosts }}"
+    __populate_controller_hosts: "{{ (__populate_controller_hosts | default([])) + __populate_hosts_list_item.ansible_facts.controller_hosts }}"
   loop: "{{ __contents_filetree_controller_hosts.results }}"
-  when: __contents_filetree_controller_hosts.results is defined and item.ansible_facts.controller_hosts is defined
+  loop_control:
+    loop_var: __populate_hosts_list_item
+  when: __contents_filetree_controller_hosts.results is defined and __populate_hosts_list_item.ansible_facts.controller_hosts is defined
 
-- name: "Set Projects Data Structure"
+- name: "Segrated Hosts list when controller_location is defined"
+  block:
+  - name: "Populate Hosts list by _common objects"
+    ansible.builtin.set_fact:
+      __populate_controller_hosts_common: "{{ (__populate_controller_hosts_common | default([])) + [__populate_hosts_list_common_item] }}"
+    loop: "{{ __populate_controller_hosts }}"
+    loop_control:
+      loop_var: __populate_hosts_list_common_item
+    when: "__populate_hosts_list_common_item.controller_location is not defined"
+
+  - name: "Populate Hosts list by __site objects"
+    ansible.builtin.set_fact:
+      __populate_controller_hosts_site: "{{ (__populate_controller_hosts_site | default([])) + [__populate_hosts_list_site_item] }}"
+    loop: "{{ __populate_controller_hosts }}"
+    loop_control:
+      loop_var: __populate_hosts_list_site_item
+    when: "__populate_hosts_list_site_item.controller_location is defined and __populate_hosts_list_site_item.controller_location == controller_location"
+
+  - name: "Concatenate Hosts list common + site"
+    ansible.builtin.set_fact:
+      __populate_controller_hosts_total: "{{ __populate_controller_hosts_common | default([]) + __populate_controller_hosts_site }}"
+    when: __populate_controller_hosts_site is defined
+
+  - name: "Set Hosts Data Structure common + site concatenated"
+    ansible.builtin.set_fact:
+      __populate_controller_hosts: "{{ __populate_controller_hosts_total }}"
+    when: __populate_controller_hosts_total is defined
+
+  when: controller_location is defined and __populate_controller_hosts is defined
+
+- name: "Set Hosts Data Structure"
   ansible.builtin.set_fact:
     controller_hosts: "{{ __populate_controller_hosts }}"
   when: __populate_controller_hosts is defined

--- a/roles/filetree_read/tasks/hosts.yml
+++ b/roles/filetree_read/tasks/hosts.yml
@@ -24,32 +24,31 @@
 
 - name: "Segrated Hosts list when controller_location is defined"
   block:
-  - name: "Populate Hosts list by _common objects"
-    ansible.builtin.set_fact:
-      __populate_controller_hosts_common: "{{ (__populate_controller_hosts_common | default([])) + [__populate_hosts_list_common_item] }}"
-    loop: "{{ __populate_controller_hosts }}"
-    loop_control:
-      loop_var: __populate_hosts_list_common_item
-    when: "__populate_hosts_list_common_item.controller_location is not defined"
+    - name: "Populate Hosts list by _common objects"
+      ansible.builtin.set_fact:
+        __populate_controller_hosts_common: "{{ (__populate_controller_hosts_common | default([])) + [__populate_hosts_list_common_item] }}"
+      loop: "{{ __populate_controller_hosts }}"
+      loop_control:
+        loop_var: __populate_hosts_list_common_item
+      when: "__populate_hosts_list_common_item.controller_location is not defined"
 
-  - name: "Populate Hosts list by __site objects"
-    ansible.builtin.set_fact:
-      __populate_controller_hosts_site: "{{ (__populate_controller_hosts_site | default([])) + [__populate_hosts_list_site_item] }}"
-    loop: "{{ __populate_controller_hosts }}"
-    loop_control:
-      loop_var: __populate_hosts_list_site_item
-    when: "__populate_hosts_list_site_item.controller_location is defined and __populate_hosts_list_site_item.controller_location == controller_location"
+    - name: "Populate Hosts list by __site objects"
+      ansible.builtin.set_fact:
+        __populate_controller_hosts_site: "{{ (__populate_controller_hosts_site | default([])) + [__populate_hosts_list_site_item] }}"
+      loop: "{{ __populate_controller_hosts }}"
+      loop_control:
+        loop_var: __populate_hosts_list_site_item
+      when: "__populate_hosts_list_site_item.controller_location is defined and __populate_hosts_list_site_item.controller_location == controller_location"
 
-  - name: "Concatenate Hosts list common + site"
-    ansible.builtin.set_fact:
-      __populate_controller_hosts_total: "{{ __populate_controller_hosts_common | default([]) + __populate_controller_hosts_site }}"
-    when: __populate_controller_hosts_site is defined
+    - name: "Concatenate Hosts list common + site"
+      ansible.builtin.set_fact:
+        __populate_controller_hosts_total: "{{ __populate_controller_hosts_common | default([]) + __populate_controller_hosts_site }}"
+      when: __populate_controller_hosts_site is defined
 
-  - name: "Set Hosts Data Structure common + site concatenated"
-    ansible.builtin.set_fact:
-      __populate_controller_hosts: "{{ __populate_controller_hosts_total }}"
-    when: __populate_controller_hosts_total is defined
-
+    - name: "Set Hosts Data Structure common + site concatenated"
+      ansible.builtin.set_fact:
+        __populate_controller_hosts: "{{ __populate_controller_hosts_total }}"
+      when: __populate_controller_hosts_total is defined
   when: controller_location is defined and __populate_controller_hosts is defined
 
 - name: "Set Hosts Data Structure"

--- a/roles/filetree_read/tasks/instance_groups.yml
+++ b/roles/filetree_read/tasks/instance_groups.yml
@@ -24,7 +24,6 @@
 
 - name: "Segregated Instance Groups list when controller_location is defined"
   block:
-  when: controller_location is defined and __populate_controller_instance_groups is defined
     - name: "Populate Instance Groups list by _common objects"
       ansible.builtin.set_fact:
         __populate_controller_instance_groups_common: "{{ (__populate_controller_instance_groups_common | default([])) + [__populate_instance_groups_list_common_item] }}"
@@ -50,6 +49,7 @@
       ansible.builtin.set_fact:
         __populate_controller_instance_groups: "{{ __populate_controller_instance_groups_total }}"
       when: __populate_controller_instance_groups_total is defined
+  when: controller_location is defined and __populate_controller_instance_groups is defined
 
 - name: "Set Instance Groups Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/instance_groups.yml
+++ b/roles/filetree_read/tasks/instance_groups.yml
@@ -8,15 +8,49 @@
 
 - name: "Read Instance Groups definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_instance_groups_definitions_item.path }}"
   loop: "{{ __list_files_controller_instance_groups.files }}"
+  loop_control:
+    loop_var: __read_instance_groups_definitions_item
   register: __contents_filetree_controller_instance_groups
 
 - name: "Populate Instance Groups list"
   ansible.builtin.set_fact:
-    __populate_controller_instance_groups: "{{ (__populate_controller_instance_groups | default([])) + item.ansible_facts.controller_instance_groups }}"
+    __populate_controller_instance_groups: "{{ (__populate_controller_instance_groups | default([])) + __populate_instance_groups_list_item.ansible_facts.controller_instance_groups }}"
   loop: "{{ __contents_filetree_controller_instance_groups.results }}"
-  when: __contents_filetree_controller_instance_groups.results is defined and item.ansible_facts.controller_instance_groups is defined
+  loop_control:
+    loop_var: __populate_instance_groups_list_item
+  when: __contents_filetree_controller_instance_groups.results is defined and __populate_instance_groups_list_item.ansible_facts.controller_instance_groups is defined
+
+- name: "Segrated Instance Groups list when controller_location is defined"
+  block:
+  - name: "Populate Instance Groups list by _common objects"
+    ansible.builtin.set_fact:
+      __populate_controller_instance_groups_common: "{{ (__populate_controller_instance_groups_common | default([])) + [__populate_instance_groups_list_common_item] }}"
+    loop: "{{ __populate_controller_instance_groups }}"
+    loop_control:
+      loop_var: __populate_instance_groups_list_common_item
+    when: "__populate_instance_groups_list_common_item.controller_location is not defined"
+
+  - name: "Populate Instance Groups list by __site objects"
+    ansible.builtin.set_fact:
+      __populate_controller_instance_groups_site: "{{ (__populate_controller_instance_groups_site | default([])) + [__populate_instance_groups_list_site_item] }}"
+    loop: "{{ __populate_controller_instance_groups }}"
+    loop_control:
+      loop_var: __populate_instance_groups_list_site_item
+    when: "__populate_instance_groups_list_site_item.controller_location is defined and __populate_instance_groups_list_site_item.controller_location == controller_location"
+
+  - name: "Concatenate Instance Groups list common + site"
+    ansible.builtin.set_fact:
+      __populate_controller_instance_groups_total: "{{ __populate_controller_instance_groups_common | default([]) + __populate_controller_instance_groups_site }}"
+    when: __populate_controller_instance_groups_site is defined
+
+  - name: "Set Instance Groups Data Structure common + site concatenated"
+    ansible.builtin.set_fact:
+      __populate_controller_instance_groups: "{{ __populate_controller_instance_groups_total }}"
+    when: __populate_controller_instance_groups_total is defined
+
+  when: controller_location is defined and __populate_controller_instance_groups is defined
 
 - name: "Set Instance Groups Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/instance_groups.yml
+++ b/roles/filetree_read/tasks/instance_groups.yml
@@ -23,6 +23,7 @@
   when: __contents_filetree_controller_instance_groups.results is defined and __populate_instance_groups_list_item.ansible_facts.controller_instance_groups is defined
 
 - name: "Segregated Instance Groups list when controller_location is defined"
+  when: controller_location is defined and __populate_controller_instance_groups is defined
   block:
     - name: "Populate Instance Groups list by _common objects"
       ansible.builtin.set_fact:
@@ -49,7 +50,6 @@
       ansible.builtin.set_fact:
         __populate_controller_instance_groups: "{{ __populate_controller_instance_groups_total }}"
       when: __populate_controller_instance_groups_total is defined
-  when: controller_location is defined and __populate_controller_instance_groups is defined
 
 - name: "Set Instance Groups Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/instance_groups.yml
+++ b/roles/filetree_read/tasks/instance_groups.yml
@@ -22,7 +22,7 @@
     loop_var: __populate_instance_groups_list_item
   when: __contents_filetree_controller_instance_groups.results is defined and __populate_instance_groups_list_item.ansible_facts.controller_instance_groups is defined
 
-- name: "Segrated Instance Groups list when controller_location is defined"
+- name: "Segregated Instance Groups list when controller_location is defined"
   block:
   when: controller_location is defined and __populate_controller_instance_groups is defined
     - name: "Populate Instance Groups list by _common objects"

--- a/roles/filetree_read/tasks/instance_groups.yml
+++ b/roles/filetree_read/tasks/instance_groups.yml
@@ -24,33 +24,32 @@
 
 - name: "Segrated Instance Groups list when controller_location is defined"
   block:
-  - name: "Populate Instance Groups list by _common objects"
-    ansible.builtin.set_fact:
-      __populate_controller_instance_groups_common: "{{ (__populate_controller_instance_groups_common | default([])) + [__populate_instance_groups_list_common_item] }}"
-    loop: "{{ __populate_controller_instance_groups }}"
-    loop_control:
-      loop_var: __populate_instance_groups_list_common_item
-    when: "__populate_instance_groups_list_common_item.controller_location is not defined"
-
-  - name: "Populate Instance Groups list by __site objects"
-    ansible.builtin.set_fact:
-      __populate_controller_instance_groups_site: "{{ (__populate_controller_instance_groups_site | default([])) + [__populate_instance_groups_list_site_item] }}"
-    loop: "{{ __populate_controller_instance_groups }}"
-    loop_control:
-      loop_var: __populate_instance_groups_list_site_item
-    when: "__populate_instance_groups_list_site_item.controller_location is defined and __populate_instance_groups_list_site_item.controller_location == controller_location"
-
-  - name: "Concatenate Instance Groups list common + site"
-    ansible.builtin.set_fact:
-      __populate_controller_instance_groups_total: "{{ __populate_controller_instance_groups_common | default([]) + __populate_controller_instance_groups_site }}"
-    when: __populate_controller_instance_groups_site is defined
-
-  - name: "Set Instance Groups Data Structure common + site concatenated"
-    ansible.builtin.set_fact:
-      __populate_controller_instance_groups: "{{ __populate_controller_instance_groups_total }}"
-    when: __populate_controller_instance_groups_total is defined
-
   when: controller_location is defined and __populate_controller_instance_groups is defined
+    - name: "Populate Instance Groups list by _common objects"
+      ansible.builtin.set_fact:
+        __populate_controller_instance_groups_common: "{{ (__populate_controller_instance_groups_common | default([])) + [__populate_instance_groups_list_common_item] }}"
+      loop: "{{ __populate_controller_instance_groups }}"
+      loop_control:
+        loop_var: __populate_instance_groups_list_common_item
+      when: "__populate_instance_groups_list_common_item.controller_location is not defined"
+
+    - name: "Populate Instance Groups list by __site objects"
+      ansible.builtin.set_fact:
+        __populate_controller_instance_groups_site: "{{ (__populate_controller_instance_groups_site | default([])) + [__populate_instance_groups_list_site_item] }}"
+      loop: "{{ __populate_controller_instance_groups }}"
+      loop_control:
+        loop_var: __populate_instance_groups_list_site_item
+      when: "__populate_instance_groups_list_site_item.controller_location is defined and __populate_instance_groups_list_site_item.controller_location == controller_location"
+
+    - name: "Concatenate Instance Groups list common + site"
+      ansible.builtin.set_fact:
+        __populate_controller_instance_groups_total: "{{ __populate_controller_instance_groups_common | default([]) + __populate_controller_instance_groups_site }}"
+      when: __populate_controller_instance_groups_site is defined
+
+    - name: "Set Instance Groups Data Structure common + site concatenated"
+      ansible.builtin.set_fact:
+        __populate_controller_instance_groups: "{{ __populate_controller_instance_groups_total }}"
+      when: __populate_controller_instance_groups_total is defined
 
 - name: "Set Instance Groups Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/inventories.yml
+++ b/roles/filetree_read/tasks/inventories.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Inventories definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_inventories_definitions_item.path }}"
   loop: "{{ __list_files_controller_inventories.files }}"
+  loop_control:
+    loop_var: __read_inventories_definitions_item
   register: __contents_filetree_controller_inventories
 
 - name: "Populate Inventories list"
   ansible.builtin.set_fact:
-    __populate_controller_inventories: "{{ (__populate_controller_inventories | default([])) + item.ansible_facts.controller_inventories }}"
+    __populate_controller_inventories: "{{ (__populate_controller_inventories | default([])) + __populate_inventories_list_item.ansible_facts.controller_inventories }}"
   loop: "{{ __contents_filetree_controller_inventories.results }}"
-  when: __contents_filetree_controller_inventories.results is defined and item.ansible_facts.controller_inventories is defined
+  loop_control:
+    loop_var: __populate_inventories_list_item
+  when: __contents_filetree_controller_inventories.results is defined and __populate_inventories_list_item.ansible_facts.controller_inventories is defined
 
 - name: "Set Inventories Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/inventory_sources.yml
+++ b/roles/filetree_read/tasks/inventory_sources.yml
@@ -24,32 +24,31 @@
 
 - name: "Segrated Inventory Sources list when controller_location is defined"
   block:
-  - name: "Populate Inventory Sources list by _common objects"
-    ansible.builtin.set_fact:
-      __populate_controller_inventory_sources_common: "{{ (__populate_controller_inventory_sources_common | default([])) + [__populate_inventory_sources_list_common_item] }}"
-    loop: "{{ __populate_controller_inventory_sources }}"
-    loop_control:
-      loop_var: __populate_inventory_sources_list_common_item
-    when: "__populate_inventory_sources_list_common_item.controller_location is not defined"
+    - name: "Populate Inventory Sources list by _common objects"
+      ansible.builtin.set_fact:
+        __populate_controller_inventory_sources_common: "{{ (__populate_controller_inventory_sources_common | default([])) + [__populate_inventory_sources_list_common_item] }}"
+      loop: "{{ __populate_controller_inventory_sources }}"
+      loop_control:
+        loop_var: __populate_inventory_sources_list_common_item
+      when: "__populate_inventory_sources_list_common_item.controller_location is not defined"
 
-  - name: "Populate Inventory Sources list by __site objects"
-    ansible.builtin.set_fact:
-      __populate_controller_inventory_sources_site: "{{ (__populate_controller_inventory_sources_site | default([])) + [__populate_inventory_sources_list_site_item] }}"
-    loop: "{{ __populate_controller_inventory_sources }}"
-    loop_control:
-      loop_var: __populate_inventory_sources_list_site_item
-    when: "__populate_inventory_sources_list_site_item.controller_location is defined and __populate_inventory_sources_list_site_item.controller_location == controller_location"
+    - name: "Populate Inventory Sources list by __site objects"
+      ansible.builtin.set_fact:
+        __populate_controller_inventory_sources_site: "{{ (__populate_controller_inventory_sources_site | default([])) + [__populate_inventory_sources_list_site_item] }}"
+      loop: "{{ __populate_controller_inventory_sources }}"
+      loop_control:
+        loop_var: __populate_inventory_sources_list_site_item
+      when: "__populate_inventory_sources_list_site_item.controller_location is defined and __populate_inventory_sources_list_site_item.controller_location == controller_location"
 
-  - name: "Concatenate Inventory Sources list common + site"
-    ansible.builtin.set_fact:
-      __populate_controller_inventory_sources_total: "{{ __populate_controller_inventory_sources_common | default([]) + __populate_controller_inventory_sources_site }}"
-    when: __populate_controller_inventory_sources_site is defined
+    - name: "Concatenate Inventory Sources list common + site"
+      ansible.builtin.set_fact:
+        __populate_controller_inventory_sources_total: "{{ __populate_controller_inventory_sources_common | default([]) + __populate_controller_inventory_sources_site }}"
+      when: __populate_controller_inventory_sources_site is defined
 
-  - name: "Set Inventory Sources Data Structure common + site concatenated"
-    ansible.builtin.set_fact:
-      __populate_controller_inventory_sources: "{{ __populate_controller_inventory_sources_total }}"
-    when: __populate_controller_inventory_sources_total is defined
-
+    - name: "Set Inventory Sources Data Structure common + site concatenated"
+      ansible.builtin.set_fact:
+        __populate_controller_inventory_sources: "{{ __populate_controller_inventory_sources_total }}"
+      when: __populate_controller_inventory_sources_total is defined
   when: controller_location is defined and __populate_controller_inventory_sources is defined
 
 - name: "Set Inventory Sources Data Structure"

--- a/roles/filetree_read/tasks/inventory_sources.yml
+++ b/roles/filetree_read/tasks/inventory_sources.yml
@@ -23,6 +23,7 @@
   when: __contents_filetree_controller_inventory_sources.results is defined and __populate_inventory_sources_list_item.ansible_facts.controller_inventory_sources is defined
 
 - name: "Segregated Inventory Sources list when controller_location is defined"
+  when: controller_location is defined and __populate_controller_inventory_sources is defined
   block:
     - name: "Populate Inventory Sources list by _common objects"
       ansible.builtin.set_fact:
@@ -49,7 +50,6 @@
       ansible.builtin.set_fact:
         __populate_controller_inventory_sources: "{{ __populate_controller_inventory_sources_total }}"
       when: __populate_controller_inventory_sources_total is defined
-  when: controller_location is defined and __populate_controller_inventory_sources is defined
 
 - name: "Set Inventory Sources Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/inventory_sources.yml
+++ b/roles/filetree_read/tasks/inventory_sources.yml
@@ -6,19 +6,53 @@
     recurse: true
   register: __list_files_controller_inventory_sources
 
-- name: "Read Inventory Source definitions"
+- name: "Read Inventory Sources definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_inventory_sources_definitions_item.path }}"
   loop: "{{ __list_files_controller_inventory_sources.files }}"
+  loop_control:
+    loop_var: __read_inventory_sources_definitions_item
   register: __contents_filetree_controller_inventory_sources
 
-- name: "Populate Inventory Source list"
+- name: "Populate Inventory Sources list"
   ansible.builtin.set_fact:
-    __populate_controller_inventory_sources: "{{ (__populate_controller_inventory_sources | default([])) + item.ansible_facts.controller_inventory_sources }}"
+    __populate_controller_inventory_sources: "{{ (__populate_controller_inventory_sources | default([])) + __populate_inventory_sources_list_item.ansible_facts.controller_inventory_sources }}"
   loop: "{{ __contents_filetree_controller_inventory_sources.results }}"
-  when: __contents_filetree_controller_inventory_sources.results is defined and item.ansible_facts.controller_inventory_sources is defined
+  loop_control:
+    loop_var: __populate_inventory_sources_list_item
+  when: __contents_filetree_controller_inventory_sources.results is defined and __populate_inventory_sources_list_item.ansible_facts.controller_inventory_sources is defined
 
-- name: "Set Inventory Source Data Structure"
+- name: "Segrated Inventory Sources list when controller_location is defined"
+  block:
+  - name: "Populate Inventory Sources list by _common objects"
+    ansible.builtin.set_fact:
+      __populate_controller_inventory_sources_common: "{{ (__populate_controller_inventory_sources_common | default([])) + [__populate_inventory_sources_list_common_item] }}"
+    loop: "{{ __populate_controller_inventory_sources }}"
+    loop_control:
+      loop_var: __populate_inventory_sources_list_common_item
+    when: "__populate_inventory_sources_list_common_item.controller_location is not defined"
+
+  - name: "Populate Inventory Sources list by __site objects"
+    ansible.builtin.set_fact:
+      __populate_controller_inventory_sources_site: "{{ (__populate_controller_inventory_sources_site | default([])) + [__populate_inventory_sources_list_site_item] }}"
+    loop: "{{ __populate_controller_inventory_sources }}"
+    loop_control:
+      loop_var: __populate_inventory_sources_list_site_item
+    when: "__populate_inventory_sources_list_site_item.controller_location is defined and __populate_inventory_sources_list_site_item.controller_location == controller_location"
+
+  - name: "Concatenate Inventory Sources list common + site"
+    ansible.builtin.set_fact:
+      __populate_controller_inventory_sources_total: "{{ __populate_controller_inventory_sources_common | default([]) + __populate_controller_inventory_sources_site }}"
+    when: __populate_controller_inventory_sources_site is defined
+
+  - name: "Set Inventory Sources Data Structure common + site concatenated"
+    ansible.builtin.set_fact:
+      __populate_controller_inventory_sources: "{{ __populate_controller_inventory_sources_total }}"
+    when: __populate_controller_inventory_sources_total is defined
+
+  when: controller_location is defined and __populate_controller_inventory_sources is defined
+
+- name: "Set Inventory Sources Data Structure"
   ansible.builtin.set_fact:
     controller_inventory_sources: "{{ __populate_controller_inventory_sources }}"
   when: __populate_controller_inventory_sources is defined

--- a/roles/filetree_read/tasks/inventory_sources.yml
+++ b/roles/filetree_read/tasks/inventory_sources.yml
@@ -22,7 +22,7 @@
     loop_var: __populate_inventory_sources_list_item
   when: __contents_filetree_controller_inventory_sources.results is defined and __populate_inventory_sources_list_item.ansible_facts.controller_inventory_sources is defined
 
-- name: "Segrated Inventory Sources list when controller_location is defined"
+- name: "Segregated Inventory Sources list when controller_location is defined"
   block:
     - name: "Populate Inventory Sources list by _common objects"
       ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/job_templates.yml
+++ b/roles/filetree_read/tasks/job_templates.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Job Templates definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_job_templates_definitions_item.path }}"
   loop: "{{ __list_files_controller_templates.files }}"
+  loop_control:
+    loop_var: __read_job_templates_definitions_item
   register: __contents_filetree_controller_templates
 
 - name: "Populate Job Templates list"
   ansible.builtin.set_fact:
-    __populate_controller_job_templates: "{{ (__populate_controller_job_templates | default([])) + item.ansible_facts.controller_templates }}"
+    __populate_controller_job_templates: "{{ (__populate_controller_job_templates | default([])) + __populate_job_templates_list_item.ansible_facts.controller_templates }}"
   loop: "{{ __contents_filetree_controller_templates.results }}"
-  when: __contents_filetree_controller_templates.results is defined and item.ansible_facts.controller_templates is defined
+  loop_control:
+    loop_var: __populate_job_templates_list_item
+  when: __contents_filetree_controller_templates.results is defined and __populate_job_templates_list_item.ansible_facts.controller_templates is defined
 
 - name: "Set Job Templates Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/labels.yml
+++ b/roles/filetree_read/tasks/labels.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Labels definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_labels_definitions_item.path }}"
   loop: "{{ __list_files_controller_labels.files }}"
+  loop_control:
+    loop_var: __read_labels_definitions_item
   register: __contents_filetree_controller_labels
 
 - name: "Populate Labels list"
   ansible.builtin.set_fact:
-    __populate_controller_labels: "{{ (__populate_controller_labels | default([])) + item.ansible_facts.controller_labels }}"
+    __populate_controller_labels: "{{ (__populate_controller_labels | default([])) + __populate_labels_list_item.ansible_facts.controller_labels }}"
   loop: "{{ __contents_filetree_controller_labels.results }}"
-  when: __contents_filetree_controller_labels.results is defined and item.ansible_facts.controller_labels is defined
+  loop_control:
+    loop_var: __populate_labels_list_item
+  when: __contents_filetree_controller_labels.results is defined and __populate_labels_list_item.ansible_facts.controller_labels is defined
 
 - name: "Set Labels Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/notifications.yml
+++ b/roles/filetree_read/tasks/notifications.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Notifications definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_notifications_definitions_item.path }}"
   loop: "{{ __list_files_controller_notifications.files }}"
+  loop_control:
+    loop_var: __read_notifications_definitions_item
   register: __contents_filetree_controller_notifications
 
 - name: "Populate Notifications list"
   ansible.builtin.set_fact:
-    __populate_controller_notifications: "{{ (__populate_controller_notifications | default([])) + item.ansible_facts.controller_notifications }}"
+    __populate_controller_notifications: "{{ (__populate_controller_notifications | default([])) + __populate_notifications_list_item.ansible_facts.controller_notifications }}"
   loop: "{{ __contents_filetree_controller_notifications.results }}"
-  when: __contents_filetree_controller_notifications.results is defined and item.ansible_facts.controller_notifications is defined
+  loop_control:
+    loop_var: __populate_notifications_list_item
+  when: __contents_filetree_controller_notifications.results is defined and __populate_notifications_list_item.ansible_facts.controller_notifications is defined
 
 - name: "Set Notifications Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/organizations.yml
+++ b/roles/filetree_read/tasks/organizations.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Organization definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_organizations_definitions_item.path }}"
   loop: "{{ __list_files_controller_organizations.files }}"
+  loop_control:
+    loop_var: __read_organizations_definitions_item
   register: __contents_filetree_controller_organizations
 
 - name: "Populate Organizations list"
   ansible.builtin.set_fact:
-    __populate_controller_organizations: "{{ (__populate_controller_organizations | default([])) + item.ansible_facts.controller_organizations }}"
+    __populate_controller_organizations: "{{ (__populate_controller_organizations | default([])) + __populate_organizations_list_item.ansible_facts.controller_organizations }}"
   loop: "{{ __contents_filetree_controller_organizations.results }}"
-  when: __contents_filetree_controller_organizations.results is defined and item.ansible_facts.controller_organizations is defined
+  loop_control:
+    loop_var: __populate_organizations_list_item
+  when: __contents_filetree_controller_organizations.results is defined and __populate_organizations_list_item.ansible_facts.controller_organizations is defined
 
 - name: "Set Organization Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/projects.yml
+++ b/roles/filetree_read/tasks/projects.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Projects definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_projects_definitions_item.path }}"
   loop: "{{ __list_files_controller_projects.files }}"
+  loop_control:
+    loop_var: __read_projects_definitions_item
   register: __contents_filetree_controller_projects
 
 - name: "Populate Projects list"
   ansible.builtin.set_fact:
-    __populate_controller_projects: "{{ (__populate_controller_projects | default([])) + item.ansible_facts.controller_projects }}"
+    __populate_controller_projects: "{{ (__populate_controller_projects | default([])) + __populate_projects_list_item.ansible_facts.controller_projects }}"
   loop: "{{ __contents_filetree_controller_projects.results }}"
-  when: __contents_filetree_controller_projects.results is defined and item.ansible_facts.controller_projects is defined
+  loop_control:
+    loop_var: __populate_projects_list_item
+  when: __contents_filetree_controller_projects.results is defined and __populate_projects_list_item.ansible_facts.controller_projects is defined
 
 - name: "Set Projects Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/roles.yml
+++ b/roles/filetree_read/tasks/roles.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Roles definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_roles_definitions_item.path }}"
   loop: "{{ __list_files_controller_roles.files }}"
+  loop_control:
+    loop_var: __read_roles_definitions_item
   register: __contents_filetree_controller_roles
 
 - name: "Populate Roles list"
   ansible.builtin.set_fact:
-    __populate_controller_roles: "{{ (__populate_controller_roles | default([])) + item.ansible_facts.controller_roles }}"
+    __populate_controller_roles: "{{ (__populate_controller_roles | default([])) + __populate_roles_list_item.ansible_facts.controller_roles }}"
   loop: "{{ __contents_filetree_controller_roles.results }}"
-  when: __contents_filetree_controller_roles.results is defined and item.ansible_facts.controller_roles is defined
+  loop_control:
+    loop_var: __populate_roles_list_item
+  when: __contents_filetree_controller_roles.results is defined and __populate_roles_list_item.ansible_facts.controller_roles is defined
 
 - name: "Set Roles Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/schedules.yml
+++ b/roles/filetree_read/tasks/schedules.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Schedules definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_schedules_definitions_item.path }}"
   loop: "{{ __list_files_controller_schedules.files }}"
+  loop_control:
+    loop_var: __read_schedules_definitions_item
   register: __contents_filetree_controller_schedules
 
 - name: "Populate Schedules list"
   ansible.builtin.set_fact:
-    __populate_controller_schedules: "{{ (__populate_controller_schedules | default([])) + item.ansible_facts.controller_schedules }}"
+    __populate_controller_schedules: "{{ (__populate_controller_schedules | default([])) + __populate_schedules_list_item.ansible_facts.controller_schedules }}"
   loop: "{{ __contents_filetree_controller_schedules.results }}"
-  when: __contents_filetree_controller_schedules.results is defined and item.ansible_facts.controller_schedules is defined
+  loop_control:
+    loop_var: __populate_schedules_list_item
+  when: __contents_filetree_controller_schedules.results is defined and __populate_schedules_list_item.ansible_facts.controller_schedules is defined
 
 - name: "Set Schedules Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/settings.yml
+++ b/roles/filetree_read/tasks/settings.yml
@@ -8,15 +8,49 @@
 
 - name: "Read Settings definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_settings_definitions_item.path }}"
   loop: "{{ __list_files_controller_settings.files }}"
+  loop_control:
+    loop_var: __read_settings_definitions_item
   register: __contents_filetree_controller_settings
 
 - name: "Populate Settings list"
   ansible.builtin.set_fact:
-    __populate_controller_settings: "{{ (__populate_controller_settings | default([])) + item.ansible_facts.controller_settings }}"
+    __populate_controller_settings: "{{ (__populate_controller_settings | default([])) + __populate_settings_list_item.ansible_facts.controller_settings }}"
   loop: "{{ __contents_filetree_controller_settings.results }}"
-  when: __contents_filetree_controller_settings.results is defined and item.ansible_facts.controller_settings is defined
+  loop_control:
+    loop_var: __populate_settings_list_item
+  when: __contents_filetree_controller_settings.results is defined and __populate_settings_list_item.ansible_facts.controller_settings is defined
+
+- name: "Segrated Settings list when controller_location is defined"
+  block:
+  - name: "Populate Settings list by _common objects"
+    ansible.builtin.set_fact:
+      __populate_controller_settings_common: "{{ (__populate_controller_settings_common | default([])) + [__populate_settings_list_common_item] }}"
+    loop: "{{ __populate_controller_settings }}"
+    loop_control:
+      loop_var: __populate_settings_list_common_item
+    when: "__populate_settings_list_common_item.controller_location is not defined"
+
+  - name: "Populate Settings list by __site objects"
+    ansible.builtin.set_fact:
+      __populate_controller_settings_site: "{{ (__populate_controller_settings_site | default([])) + [__populate_settings_list_site_item] }}"
+    loop: "{{ __populate_controller_settings }}"
+    loop_control:
+      loop_var: __populate_settings_list_site_item
+    when: "__populate_settings_list_site_item.controller_location is defined and __populate_settings_list_site_item.controller_location == controller_location"
+
+  - name: "Concatenate Settings list common + site"
+    ansible.builtin.set_fact:
+      __populate_controller_settings_total: "{{ __populate_controller_settings_common | default([]) + __populate_controller_settings_site }}"
+    when: __populate_controller_settings_site is defined
+
+  - name: "Set Settings Data Structure common + site concatenated"
+    ansible.builtin.set_fact:
+      __populate_controller_settings: "{{ __populate_controller_settings_total }}"
+    when: __populate_controller_settings_total is defined
+
+  when: controller_location is defined and __populate_controller_settings is defined
 
 - name: "Set Settings Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/settings.yml
+++ b/roles/filetree_read/tasks/settings.yml
@@ -24,32 +24,31 @@
 
 - name: "Segrated Settings list when controller_location is defined"
   block:
-  - name: "Populate Settings list by _common objects"
-    ansible.builtin.set_fact:
-      __populate_controller_settings_common: "{{ (__populate_controller_settings_common | default([])) + [__populate_settings_list_common_item] }}"
-    loop: "{{ __populate_controller_settings }}"
-    loop_control:
-      loop_var: __populate_settings_list_common_item
-    when: "__populate_settings_list_common_item.controller_location is not defined"
+    - name: "Populate Settings list by _common objects"
+      ansible.builtin.set_fact:
+        __populate_controller_settings_common: "{{ (__populate_controller_settings_common | default([])) + [__populate_settings_list_common_item] }}"
+      loop: "{{ __populate_controller_settings }}"
+      loop_control:
+        loop_var: __populate_settings_list_common_item
+      when: "__populate_settings_list_common_item.controller_location is not defined"
 
-  - name: "Populate Settings list by __site objects"
-    ansible.builtin.set_fact:
-      __populate_controller_settings_site: "{{ (__populate_controller_settings_site | default([])) + [__populate_settings_list_site_item] }}"
-    loop: "{{ __populate_controller_settings }}"
-    loop_control:
-      loop_var: __populate_settings_list_site_item
-    when: "__populate_settings_list_site_item.controller_location is defined and __populate_settings_list_site_item.controller_location == controller_location"
+    - name: "Populate Settings list by __site objects"
+      ansible.builtin.set_fact:
+        __populate_controller_settings_site: "{{ (__populate_controller_settings_site | default([])) + [__populate_settings_list_site_item] }}"
+      loop: "{{ __populate_controller_settings }}"
+      loop_control:
+        loop_var: __populate_settings_list_site_item
+      when: "__populate_settings_list_site_item.controller_location is defined and __populate_settings_list_site_item.controller_location == controller_location"
 
-  - name: "Concatenate Settings list common + site"
-    ansible.builtin.set_fact:
-      __populate_controller_settings_total: "{{ __populate_controller_settings_common | default([]) + __populate_controller_settings_site }}"
-    when: __populate_controller_settings_site is defined
+    - name: "Concatenate Settings list common + site"
+      ansible.builtin.set_fact:
+        __populate_controller_settings_total: "{{ __populate_controller_settings_common | default([]) + __populate_controller_settings_site }}"
+      when: __populate_controller_settings_site is defined
 
-  - name: "Set Settings Data Structure common + site concatenated"
-    ansible.builtin.set_fact:
-      __populate_controller_settings: "{{ __populate_controller_settings_total }}"
-    when: __populate_controller_settings_total is defined
-
+    - name: "Set Settings Data Structure common + site concatenated"
+      ansible.builtin.set_fact:
+        __populate_controller_settings: "{{ __populate_controller_settings_total }}"
+      when: __populate_controller_settings_total is defined
   when: controller_location is defined and __populate_controller_settings is defined
 
 - name: "Set Settings Data Structure"

--- a/roles/filetree_read/tasks/settings.yml
+++ b/roles/filetree_read/tasks/settings.yml
@@ -22,7 +22,7 @@
     loop_var: __populate_settings_list_item
   when: __contents_filetree_controller_settings.results is defined and __populate_settings_list_item.ansible_facts.controller_settings is defined
 
-- name: "Segrated Settings list when controller_location is defined"
+- name: "Segregated Settings list when controller_location is defined"
   block:
     - name: "Populate Settings list by _common objects"
       ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/settings.yml
+++ b/roles/filetree_read/tasks/settings.yml
@@ -23,6 +23,7 @@
   when: __contents_filetree_controller_settings.results is defined and __populate_settings_list_item.ansible_facts.controller_settings is defined
 
 - name: "Segregated Settings list when controller_location is defined"
+  when: controller_location is defined and __populate_controller_settings is defined
   block:
     - name: "Populate Settings list by _common objects"
       ansible.builtin.set_fact:
@@ -49,7 +50,6 @@
       ansible.builtin.set_fact:
         __populate_controller_settings: "{{ __populate_controller_settings_total }}"
       when: __populate_controller_settings_total is defined
-  when: controller_location is defined and __populate_controller_settings is defined
 
 - name: "Set Settings Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/teams.yml
+++ b/roles/filetree_read/tasks/teams.yml
@@ -8,15 +8,19 @@
 
 - name: "Read Teams definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_teams_definitions_item.path }}"
   loop: "{{ __list_files_controller_teams.files }}"
+  loop_control:
+    loop_var: __read_teams_definitions_item
   register: __contents_filetree_controller_teams
 
 - name: "Populate Teams list"
   ansible.builtin.set_fact:
-    __populate_controller_teams: "{{ (__populate_controller_teams | default([])) + item.ansible_facts.controller_teams }}"
+    __populate_controller_teams: "{{ (__populate_controller_teams | default([])) + __populate_teams_list_item.ansible_facts.controller_teams }}"
   loop: "{{ __contents_filetree_controller_teams.results }}"
-  when: __contents_filetree_controller_teams.results is defined and item.ansible_facts.controller_teams is defined
+  loop_control:
+    loop_var: __populate_teams_list_item
+  when: __contents_filetree_controller_teams.results is defined and __populate_teams_list_item.ansible_facts.controller_teams is defined
 
 - name: "Set Teams Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/user_accounts.yml
+++ b/roles/filetree_read/tasks/user_accounts.yml
@@ -8,15 +8,19 @@
 
 - name: "Read User Accounts definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_user_accounts_definitions_item.path }}"
   loop: "{{ __list_files_controller_user_accounts.files }}"
+  loop_control:
+    loop_var: __read_user_accounts_definitions_item
   register: __contents_filetree_controller_user_accounts
 
 - name: "Populate User Accounts list"
   ansible.builtin.set_fact:
-    __populate_controller_user_accounts: "{{ (__populate_controller_user_accounts | default([])) + item.ansible_facts.controller_user_accounts }}"
+    __populate_controller_user_accounts: "{{ (__populate_controller_user_accounts | default([])) + __populate_user_accounts_list_item.ansible_facts.controller_user_accounts }}"
   loop: "{{ __contents_filetree_controller_user_accounts.results }}"
-  when: __contents_filetree_controller_user_accounts.results is defined and item.ansible_facts.controller_user_accounts is defined
+  loop_control:
+    loop_var: __populate_user_accounts_list_item
+  when: __contents_filetree_controller_user_accounts.results is defined and __populate_user_accounts_list_item.ansible_facts.controller_user_accounts is defined
 
 - name: "Set User Accounts Data Structure"
   ansible.builtin.set_fact:

--- a/roles/filetree_read/tasks/workflow_job_templates.yml
+++ b/roles/filetree_read/tasks/workflow_job_templates.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Get list of files inside {{ filetree_controller_templates }}"
+- name: "Get list of files inside {{ filetree_controller_workflow_job_templates }}"
   ansible.builtin.find:
     paths: "{{ filetree_controller_workflow_job_templates }}"
     file_type: file
@@ -8,15 +8,19 @@
 
 - name: "Read Workflow Job Templates definitions"
   ansible.builtin.include_vars:
-    file: "{{ item.path }}"
+    file: "{{ __read_credentials_definitions_item.path }}"
   loop: "{{ __list_files_controller_workflow_job_templates.files }}"
+  loop_control:
+    loop_var: __read_credentials_definitions_item
   register: __contents_filetree_controller_workflow_job_templates
 
 - name: "Populate Workflow Job Templates list"
   ansible.builtin.set_fact:
-    __populate_controller_workflow_job_templates: "{{ (__populate_controller_workflow_job_templates | default([])) + item.ansible_facts.controller_workflows }}"
+    __populate_controller_workflow_job_templates: "{{ (__populate_controller_workflow_job_templates | default([])) + __populate_credentials_list_item.ansible_facts.controller_workflows }}"
   loop: "{{ __contents_filetree_controller_workflow_job_templates.results }}"
-  when: __contents_filetree_controller_workflow_job_templates.results is defined and item.ansible_facts.controller_workflows is defined
+  loop_control:
+    loop_var: __populate_credentials_list_item
+  when: __contents_filetree_controller_workflow_job_templates.results is defined and __populate_credentials_list_item.ansible_facts.controller_workflows is defined
 
 - name: "Set Job Templates Data Structure"
   ansible.builtin.set_fact:


### PR DESCRIPTION
# What does this PR do?

- Added controller_location variable in filetree_read role  to handle multiple sites on an Active/Passive architecture[1] over the Controller objects[2] that might require different values  depend on site.
[2].-[Ref Arch AAP](https://access.redhat.com/webassets/avalon/d/Reference_Architectures-2021-Deploying_Ansible_Automation_Platform_2.1-en-US/images/6e0171f99b891d6c50ebf14af768b576/overview.png)

```
$ tree orgs_vars/org-test/env/dev-site/
├── controller_credentials.d
├── controller_execution_environments.d
├── controller_hosts.d
├── controller_instance_groups.d
├── controller_inventory_sources.d
└── controller_settings.d
```
-  It has been added `loop_var control` to all loops in filetree_read role tasks to be aligned with collection guidelines to use it. The following two tasks were modified:

```
- name: "Read $Object definitions"
  ansible.builtin.include_vars:
    file: "{{ __read_$Object _definitions_item.path }}"
  loop: "{{ __list_files_controller_$Object .files }}"
  loop_control:
    loop_var: __read_$Object _definitions_item
  register: __contents_filetree_controller_$Object 

- name: "Populate $Object  list"
  ansible.builtin.set_fact:
    __populate_controller_applications: "{{ (__populate_controller_$Object  | default([])) + __populate_$Object _list_item.ansible_facts.controller_$Object  }}"
  loop: "{{ __contents_filetree_controller_$Object s.results }}"
  loop_control:
    loop_var: __populate_$Object _list_item
  when: __contents_filetree_controller_$Object .results is defined and __populate_$Object _list_item.ansible_facts.controller_$Object  is defined

```

# How should this be tested?

- Deploy two controllers and two automationhubs.
```
$ cat inventory 
[dev-site1]
lb-ctr-dev-site1.bcnconsulting.com
[dev-site2]
lb-ctr-dev-site2.bcnconsulting.com

[dev:children]
dev-site1
dev-site2

$ cat group_vars/dev/configure_connection_controller_credentials.yml 
---
vault_controller_username: 'org-test'
vault_controller_password: 'password'
vault_controller_validate_certs: false
...
$ cat group_vars/dev-site1/configure_connection_controller_credentials.yml 
---
vault_controller_hostname: "{{ groups['dev-site1'][0] }}"
...

$ cat group_vars/dev-site2/configure_connection_controller_credentials.yml 
---
vault_controller_hostname: "{{ groups['dev-site2'][0] }}"
...
```
- Add credential definition under the directory structure 
```
$ cat orgs_vars/org-test/env/dev-site/controller_credentials.d/controller_credentials_registry.yaml
---
controller_credentials:
  - name: "{{ orgs }} {{ env }} {{ controller_location }} Automation Private Hub Container Registry"
    description: "Credential to connect to Container Registry at AtomationHub Private"
    credential_type: "Container Registry"
    organization: "{{ orgs }}"
    inputs:
      username: "organization-admin"
      password: "password"
      host: lb-hub-dev-site1.bcnconsulting.com
      verify_ssl: false
    controller_location: site1

  - name: "{{ orgs }} {{ env }} {{ controller_location }} Automation Private Hub Container Registry"
    description: "Credential to connect to Container Registry at AtomationHub Private"
    credential_type: "Container Registry"
    organization: "{{ orgs }}"
    inputs:
      username: "organization-admin"
      password: "password"
      host: lb-hub-dev-site2.bcnconsulting.com
      verify_ssl: false
    controller_location: site2

```
- Apply the configuration in one site a time
```
$ ansible-navigator run casc_ctrl_config.yml -i inventory -l dev-site1 -e '{orgs: org-test, dir_orgs_vars: orgs_vars, env: dev-site, controller_location: site1}' -m stdout --eei lb-hub-dev-site1.bcnconsulting.com/ee-casc:latest --pull-arguments=--tls-verify=false --vault-password-file .vault_password --tags credentials 

$ ansible-navigator run casc_ctrl_config.yml -i inventory -l dev-site2 -e '{orgs: org-test, dir_orgs_vars: orgs_vars, env: dev-site, controller_location: site1}' -m stdout --eei lb-hub-dev-site2.bcnconsulting.com/ee-casc:latest --pull-arguments=--tls-verify=false --vault-password-file .vault_password --tags credentials  
```