### PR TITLE
Protect delete org

### DIFF
--- a/roles/object_diff/defaults/main.yml
+++ b/roles/object_diff/defaults/main.yml
@@ -44,4 +44,6 @@ controller_configuration_object_diff_tasks:
 
 controller_configuration_object_diff_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 
+controller_api_version: "v2"
+
 ...

--- a/roles/object_diff/tasks/organizations.yml
+++ b/roles/object_diff/tasks/organizations.yml
@@ -25,13 +25,13 @@
 
     - name: "Sets Organization differences"
       vars:
-        __api_url_users: "api/v2/organizations/{{ __org.name}}/users/"
-        __api_url_admins: "api/v2/organizations/{{ __org.name}}/admins/"
-        __api_url_inventories: "api/v2/organizations/{{ __org.name}}/inventories/"
-        __api_url_teams: "api/v2/organizations/{{ __org.name}}/teams/"
-        __api_url_projects: "api/v2/organizations/{{ __org.name}}/projects/"
-        __api_url_job_templates: "api/v2/organizations/{{ __org.name}}/job_templates/"
-        __api_url_workflow_job_templates: "api/v2/organizations/{{ __org.name}}/workflow_job_templates/"
+        __api_url_users: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/users/"
+        __api_url_admins: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/admins/"
+        __api_url_inventories: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/inventories/"
+        __api_url_teams: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/teams/"
+        __api_url_projects: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/projects/"
+        __api_url_job_templates: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/job_templates/"
+        __api_url_workflow_job_templates: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/workflow_job_templates/"
       ansible.builtin.set_fact:
         controller_organizations: "{{ controller_organizations | combine(__org) }}"
       loop: "{{ __organizations_difference }}"

--- a/roles/object_diff/tasks/organizations.yml
+++ b/roles/object_diff/tasks/organizations.yml
@@ -25,24 +25,25 @@
 
     - name: "Sets Organization differences"
       vars:
-        __api_url_users: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/users/"
-        __api_url_admins: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/admins/"
-        __api_url_inventories: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/inventories/"
-        __api_url_teams: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/teams/"
-        __api_url_projects: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/projects/"
-        __api_url_job_templates: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/job_templates/"
-        __api_url_workflow_job_templates: "api/{{ controller_api_version }}/organizations/{{ __org.name | urlencode }}/workflow_job_templates/"
+        __bool_thereare_users: "{{ query(controller_api_plugin, 'api/' + controller_api_version + '/organizations/' + (__org.name | urlencode) + '/users/',
+                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }}"
+        __bool_thereare_admins: "{{ query(controller_api_plugin, 'api/' + controller_api_version + '/organizations/' + (__org.name | urlencode) + '/admins/',
+                           host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }}"
+        __bool_thereare_inventories: "{{ query(controller_api_plugin, 'api/' + controller_api_version + '/organizations/' + (__org.name | urlencode) + '/inventories/',
+                                host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }}"
+        __bool_thereare_teams: "{{ query(controller_api_plugin, 'api/' + controller_api_version + '/organizations/' + (__org.name | urlencode) + '/teams/',
+                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }}"
+        __bool_thereare_projects: "{{ query(controller_api_plugin, 'api/' + controller_api_version + '/organizations/' + (__org.name | urlencode) + '/projects/',
+                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }}"
+        __bool_thereare_job_templates: "{{ query(controller_api_plugin, 'api/' + controller_api_version + '/organizations/' + (__org.name | urlencode) + '/job_templates/',
+                                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }}"
+        __bool_thereare_workflow_job_templates: "{{ query(controller_api_plugin, 'api/' + controller_api_version + '/organizations/' + (__org.name | urlencode) + '/workflow_job_templates/',
+                                           host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }}"
       ansible.builtin.set_fact:
         controller_organizations: "{{ controller_organizations | combine(__org) }}"
       loop: "{{ __organizations_difference }}"
       loop_control:
         loop_var: __org
       when: protect_not_empty_orgs is not defined or not protect_not_empty_orgs or
-        ( {{ query(controller_api_plugin, __api_url_users, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }} and
-          {{ query(controller_api_plugin, __api_url_admins, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }} and
-          {{ query(controller_api_plugin, __api_url_inventories, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }} and
-          {{ query(controller_api_plugin, __api_url_teams, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }} and
-          {{ query(controller_api_plugin, __api_url_projects, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }} and
-          {{ query(controller_api_plugin, __api_url_job_templates, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }} and
-          {{ query(controller_api_plugin, __api_url_workflow_job_templates, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }})
+          (__bool_thereare_users and __bool_admins and __bool_inventories and __bool_teams and __bool_projects and __bool_job_templates and __bool_workflow_job_templates)
 ...

--- a/roles/object_diff/tasks/organizations.yml
+++ b/roles/object_diff/tasks/organizations.yml
@@ -1,17 +1,48 @@
 ---
-- name: "Gets current Organizations configured"
+- name: "OBJECT DIFF: Get the current controller user to determine if it is super-admin"
   ansible.builtin.set_fact:
-    __controller_api_organizations: "{{ query(controller_api_plugin, 'organizations',
-      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) }}"
+    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
+                                                              query_params={'username': controller_username},
+                                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
+                                                   }}"
 
-- name: "OBJECT DIFF: Find the difference of Organizations between what is on the Controller versus curated list."
-  ansible.builtin.set_fact:
-    __organizations_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
-                                            api_list=__controller_api_organizations, compare_list=controller_organizations,
-                                            with_present=false, set_absent=true)
-                                 }}"
+- name: "Role differences (block)"
+  when:
+    - __controller_api_current_user_check_is_admin.is_superuser
+  block:
+    - name: "Gets current Organizations configured"
+      ansible.builtin.set_fact:
+        __controller_api_organizations: "{{ query(controller_api_plugin, 'organizations',
+                                                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
+                                         }}"
 
-- name: "Sets Organization differences"
-  ansible.builtin.set_fact:
-    controller_organizations: "{{ __organizations_difference }}"
+    - name: "OBJECT DIFF: Find the difference of Organizations between what is on the Controller versus curated list."
+      ansible.builtin.set_fact:
+        __organizations_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
+                                                api_list=__controller_api_organizations, compare_list=controller_organizations,
+                                                with_present=false, set_absent=true)
+                                     }}"
+
+    - name: "Sets Organization differences"
+      vars:
+        __api_url_users: "api/v2/organizations/{{ __org.name}}/users/"
+        __api_url_admins: "api/v2/organizations/{{ __org.name}}/admins/"
+        __api_url_inventories: "api/v2/organizations/{{ __org.name}}/inventories/"
+        __api_url_teams: "api/v2/organizations/{{ __org.name}}/teams/"
+        __api_url_projects: "api/v2/organizations/{{ __org.name}}/projects/"
+        __api_url_job_templates: "api/v2/organizations/{{ __org.name}}/job_templates/"
+        __api_url_workflow_job_templates: "api/v2/organizations/{{ __org.name}}/workflow_job_templates/"
+      ansible.builtin.set_fact:
+        controller_organizations: "{{ controller_organizations | combine(__org) }}"
+      loop: "{{ __organizations_difference }}"
+      loop_control:
+        loop_var: __org
+      when: protect_not_empty_orgs is not defined or not protect_not_empty_orgs or
+        ( {{ query(controller_api_plugin, __api_url_users, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }} and
+          {{ query(controller_api_plugin, __api_url_admins, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }} and
+          {{ query(controller_api_plugin, __api_url_inventories, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }} and
+          {{ query(controller_api_plugin, __api_url_teams, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }} and
+          {{ query(controller_api_plugin, __api_url_projects, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }} and
+          {{ query(controller_api_plugin, __api_url_job_templates, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }} and
+          {{ query(controller_api_plugin, __api_url_workflow_job_templates, host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) | length == 0 }})
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Allow user to set protect_not_empty_orgs to avoid remove orgs which are not empty. 
Only superuser can remove orgs after run object diff.

# How should this be tested?

Launch test playbooks for filetree_create, filetree_read and object_diff roles.
