### PR TITLE
[#407] change default behavior of job_slice_count in job_launch

### DIFF
--- a/roles/job_launch/README.md
+++ b/roles/job_launch/README.md
@@ -49,22 +49,22 @@ controller_configuration_job_launch_secure_logging defaults to the value of cont
 |`inventory`|""|no|str|Inventory to use for the job, only used if prompt for inventory is set.|
 |`organization`|""|no|str|Organization the inventory belongs to.|
 |`credentials`|""|no|list|TCredential to use for job, only used if prompt for credential is set.|
-|`extra_vars`|""|no|str|extra_vars to use for the Job Template. ask_extra_vars needs to be set to True via controller_job_template module.|
+|`extra_vars`|""|no|dict|extra_vars to use for the Job Template. ask_extra_vars needs to be set to True via controller_job_template module.|
 |`limit`|""|no|str|Limit to use for the job_template.|
 |`tags`|""|no|str|Specific tags to use for from playbook.|
 |`scm_branch`|""|no|str|A specific of the SCM project to run the template on.|
 |`skip_tags`|""|no|str|Specific tags to skip from the playbook.|
 |`verbosity`|""|no|int|Verbosity level for this job run.|
-|`diff_mode`|""|no|str|Show the changes made by Ansible tasks where supported.|
+|`diff_mode`|""|no|bool|Show the changes made by Ansible tasks where supported.|
 |`credential_passwords`|""|no|str|Passwords for credentials which are set to prompt on launch.|
 |`execution_environment`|Job Template default|no|str|Execution Environment applied as a prompt. Job Template default used if not set. Only allowed if `ask_execution_environment_on_launch` set to true on Job Template|
-|`forks`|Job Template default|no|str|Forks applied as a prompt. Job Template default used if not set. Only allowed if `ask_forks_on_launch` set to true on Job Template|
+|`forks`|Job Template default|no|int|Forks applied as a prompt. Job Template default used if not set. Only allowed if `ask_forks_on_launch` set to true on Job Template|
 |`instance_groups`|Job Template default|no|str| List of Instance Groups applied as a prompt. Job Template default used if not set. Only allowed if `ask_instance_groups_on_launch` set to true on Job Template|
-|`job_slice_count`|Job Template default|no|str|Job Slice Count to use in the job run. Job Template default used if not set. Only allowed if `ask_job_slice_count_on_launch` set to true on Job Template|
+|`job_slice_count`|Job Template default|no|int|Job Slice Count to use in the job run. Job Template default used if not set. Only allowed if `ask_job_slice_count_on_launch` set to true on Job Template|
 |`labels`|Job Template default|no|list|List of labels to use in the job run. Job Template default used if not set. Only allowed if `ask_labels_on_launch` set to true on Job Template|
-|`job_timeout`|Job Template default|no|str|Timeout to use in the job run. Job Template default used if not set. Only allowed if `ask_timeout_on_launch` set to true on Job Template|
+|`job_timeout`|Job Template default|no|int|Timeout to use in the job run. Job Template default used if not set. Only allowed if `ask_timeout_on_launch` set to true on Job Template|
 |`wait`|""|no|bool|Wait for the job to complete.|
-|`interval`|2|no|int|The interval to request an update from controller.|
+|`interval`|2|no|float|The interval to request an update from controller.|
 |`timeout`|""|no|int|If waiting for the job to complete this will abort after this amount of seconds.|
 
 ### Standard Project Data Structure

--- a/roles/job_launch/tasks/main.yml
+++ b/roles/job_launch/tasks/main.yml
@@ -18,7 +18,7 @@
     execution_environment:    "{{ __job_launch_item.execution_environment.name | default(__job_launch_item.execution_environment | default(omit, true)) }}"
     forks:                    "{{ __job_launch_item.forks | default(omit, true) }}"
     instance_groups:          "{{ __job_launch_item.instance_groups | default(omit, true) }}"
-    job_slice_count:          "{{ __job_launch_item.job_slice_count | default(1) }}"
+    job_slice_count:          "{{ __job_launch_item.job_slice_count | default(omit, true) }}"
     labels:                   "{{ __job_launch_item.labels | default(__job_launch_item.related.labels | default([]) | map(attribute='name') | list) | default(omit, true) }}"
     job_timeout:              "{{ __job_launch_item.job_timeout | default(omit, true) }}"
     wait:                     "{{ __job_launch_item.wait | default(omit) }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Change default behavior of job_slice_count. 

job_slice_count is not set by default because is only allowed when ask_job_slice_count_on_launch is true but by default it is false. 

I think it is better to set job_slice_count without default 1 and give the responsibility to user who has to know when set it up due to ask_job_slice_count_on_launch is true in the JT. Moreover, JT can have a default value which is 1 if user does not change it, so I think even although user will not send job_slice_count with ask_job_slice_count_on_launch=true, it will work.

Also it will work fine in AAP 2.2 and Tower.

# Is there a relevant Issue open for this?
https://github.com/redhat-cop/controller_configuration/issues/407
