### PR TITLE
remove OBJECT DIFF from task name

### DIFF
--- a/roles/object_diff/tasks/credential_types.yml
+++ b/roles/object_diff/tasks/credential_types.yml
@@ -1,26 +1,26 @@
 ---
 # tasks file for controller_credential_types
-- name: "OBJECT DIFF: Get the API list of all Credential Types"
+- name: "Get the API list of all Credential Types"
   ansible.builtin.set_fact:
     __controller_api_credential_types: "{{ query(controller_api_plugin, 'credential_types',
       query_params={'managed': false},
       host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) }}"
   when: is_aap
 
-- name: "OBJECT DIFF: Get the API list of all Credential Types"
+- name: "Get the API list of all Credential Types"
   ansible.builtin.set_fact:
     __controller_api_credential_types: "{{ query(controller_api_plugin, 'credential_types',
       query_params={'managed_by_tower': false},
       host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs) }}"
   when: not is_aap
 
-- name: "OBJECT DIFF: Find the difference of Credential Types between what is on the Controller versus CasC on SCM"
+- name: "Find the difference of Credential Types between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
     __credential_types_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
       api_list=__controller_api_credential_types, compare_list=controller_credential_types,
       with_present=false, set_absent=true) }}"
 
-- name: "OBJECT DIFF: Set credential's list to be configured"
+- name: "Set credential's list to be configured"
   ansible.builtin.set_fact:
     controller_credential_types: "{{ __credential_types_difference }}"
 ...

--- a/roles/object_diff/tasks/credentials.yml
+++ b/roles/object_diff/tasks/credentials.yml
@@ -7,21 +7,21 @@
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all Credentials in Organization {{ orgs }}"
+- name: "Get the API list of all Credentials in Organization {{ orgs }}"
   ansible.builtin.set_fact:
     __controller_api_credentials: "{{ query(controller_api_plugin, 'credentials',
                                             query_params={'organization': __controller_organization_id.id},
                                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Find the difference of Credentials between what is on the Controller versus CasC on SCM"
+- name: "Find the difference of Credentials between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
     __credentials_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                           api_list=__controller_api_credentials, compare_list=controller_credentials,
                                           with_present=false, set_absent=true)
                                }}"
 
-- name: "OBJECT DIFF: Set credential's list to be configured"
+- name: "Set credential's list to be configured"
   ansible.builtin.set_fact:
     controller_credentials: "{{ __credentials_difference }}"
 ...

--- a/roles/object_diff/tasks/groups.yml
+++ b/roles/object_diff/tasks/groups.yml
@@ -6,7 +6,7 @@
                                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                  }}"
 
-- name: "OBJECT DIFF: Get the API list of all inventories"
+- name: "Get the API list of all inventories"
   ansible.builtin.set_fact:
     __controller_api_inventories: "{{ query(controller_api_plugin, 'inventories',
                                             query_params={'organization': controller_organization_id.id,
@@ -16,7 +16,7 @@
                                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all groups in the inventories at organization {{ orgs }}"
+- name: "Get the API list of all groups in the inventories at organization {{ orgs }}"
   ansible.builtin.set_fact:
     __controller_api_groups: "{{ (__controller_api_groups | default([])) + query(controller_api_plugin, 'groups',
                                           query_params={'inventory': current_inventory.id},
@@ -29,7 +29,7 @@
 - name: "Group differences (block)"
   when: __controller_api_groups is defined
   block:
-    - name: "OBJECT DIFF: Find the difference of Groups between what is on the Controller versus CasC on SCM"
+    - name: "Find the difference of Groups between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         __groups_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                         query_params={'summary_fields.inventory.organization_id': controller_organization_id.id},
@@ -37,7 +37,7 @@
                                         with_present=false, set_absent=true)
                               }}"
 
-    - name: "OBJECT DIFF: Set the inventory key at the correct place"
+    - name: "Set the inventory key at the correct place"
       ansible.builtin.set_fact:
         controller_groups: "{{ __groups_difference }}"
 ...

--- a/roles/object_diff/tasks/hosts.yml
+++ b/roles/object_diff/tasks/hosts.yml
@@ -6,7 +6,7 @@
                                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                  }}"
 
-- name: "OBJECT DIFF: Get the API list of all inventories"
+- name: "Get the API list of all inventories"
   ansible.builtin.set_fact:
     __controller_api_inventories: "{{ query(controller_api_plugin, 'inventories',
                                             query_params={'organization': controller_organization_id.id,
@@ -17,7 +17,7 @@
                                             password=controller_password, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all hosts in the inventories at organization {{ orgs }}"
+- name: "Get the API list of all hosts in the inventories at organization {{ orgs }}"
   ansible.builtin.set_fact:
     __controller_api_hosts: "{{ (__controller_api_hosts | default([])) + query(controller_api_plugin, 'hosts',
                                     query_params={'inventory': current_inventory.id},
@@ -30,7 +30,7 @@
 - name: "Host differences (block)"
   when: __controller_api_hosts is defined
   block:
-    - name: "OBJECT DIFF: Find the difference of Hosts between what is on the Controller versus CasC on SCM"
+    - name: "Find the difference of Hosts between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         __hosts_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                         query_params={'summary_fields.inventory.organization_id': controller_organization_id.id},
@@ -38,7 +38,7 @@
                                         with_present=false, set_absent=true)
                              }}"
 
-    - name: "OBJECT DIFF: Set the inventory key at the correct place"
+    - name: "Set the inventory key at the correct place"
       ansible.builtin.set_fact:
         controller_hosts: "{{ __hosts_difference }}"
 ...

--- a/roles/object_diff/tasks/inventories.yml
+++ b/roles/object_diff/tasks/inventories.yml
@@ -6,21 +6,21 @@
                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all Inventories"
+- name: "Get the API list of all Inventories"
   ansible.builtin.set_fact:
     __controller_api_inventories: "{{ query(controller_api_plugin, 'inventories',
                                             query_params={'organization': __controller_organization_id.id},
                                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Find the difference of Inventories between what is on the Controller versus CasC on SCM"
+- name: "Find the difference of Inventories between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
     __inventories_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                          api_list=__controller_api_inventories, compare_list=controller_inventories,
                                          with_present=false, set_absent=true)
                                }}"
 
-- name: "OBJECT DIFF: Set inventores' list to be configured"
+- name: "Set inventores' list to be configured"
   ansible.builtin.set_fact:
     controller_inventories: "{{ __inventories_difference }}"
 ...

--- a/roles/object_diff/tasks/inventory_sources.yml
+++ b/roles/object_diff/tasks/inventory_sources.yml
@@ -6,14 +6,14 @@
                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all Inventory Sources"
+- name: "Get the API list of all Inventory Sources"
   ansible.builtin.set_fact:
     __controller_api_inventory_sources: "{{ query(controller_api_plugin, 'inventory_sources',
                                                   query_params={'organization': __controller_organization_id.id},
                                                   host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                          }}"
 
-- name: "OBJECT DIFF: Find the difference of Inventory Sources between what is on the Controller versus CasC on SCM"
+- name: "Find the difference of Inventory Sources between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
     __inventory_sources_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                                 api_list=__controller_api_inventory_sources,
@@ -21,7 +21,7 @@
                                                 with_present=false, set_absent=true)
                                      }}"
 
-- name: "OBJECT DIFF: Set inventory_sources' list to be configured"
+- name: "Set inventory_sources' list to be configured"
   ansible.builtin.set_fact:
     controller_inventory_sources: "{{ __inventory_sources_difference }}"
 ...

--- a/roles/object_diff/tasks/job_templates.yml
+++ b/roles/object_diff/tasks/job_templates.yml
@@ -6,21 +6,21 @@
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all Job Templates in Organization {{ orgs }}"
+- name: "Get the API list of all Job Templates in Organization {{ orgs }}"
   ansible.builtin.set_fact:
     __controller_api_job_templates: "{{ query(controller_api_plugin, 'job_templates',
                                               query_params={'organization': __controller_organization_id.id},
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                      }}"
 
-- name: "OBJECT DIFF: Find the difference of Job Templates between what is on the Controller versus CasC on SCM"
+- name: "Find the difference of Job Templates between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
     __job_templates_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                             api_list=__controller_api_job_templates, compare_list=controller_templates,
                                             with_present=false, set_absent=true)
                                  }}"
 
-- name: "OBJECT DIFF: Set job_template's list to be configured"
+- name: "Set job_template's list to be configured"
   ansible.builtin.set_fact:
     controller_templates: "{{ __job_templates_difference }}"
 ...

--- a/roles/object_diff/tasks/organizations.yml
+++ b/roles/object_diff/tasks/organizations.yml
@@ -1,5 +1,5 @@
 ---
-- name: "OBJECT DIFF: Get the current controller user to determine if it is super-admin"
+- name: "Get the current controller user to determine if it is super-admin"
   ansible.builtin.set_fact:
     __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
                                                               query_params={'username': controller_username},
@@ -16,7 +16,7 @@
                                                   host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                          }}"
 
-    - name: "OBJECT DIFF: Find the difference of Organizations between what is on the Controller versus curated list."
+    - name: "Find the difference of Organizations between what is on the Controller versus curated list."
       ansible.builtin.set_fact:
         __organizations_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                                 api_list=__controller_api_organizations, compare_list=controller_organizations,

--- a/roles/object_diff/tasks/projects.yml
+++ b/roles/object_diff/tasks/projects.yml
@@ -6,21 +6,21 @@
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all Projects in Organization {{ orgs }}"
+- name: "Get the API list of all Projects in Organization {{ orgs }}"
   ansible.builtin.set_fact:
     __controller_api_projects: "{{ query(controller_api_plugin, 'projects',
                                           query_params={'organization': __controller_organization_id.id},
                                           host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                 }}"
 
-- name: "OBJECT DIFF: Find the difference of Project between what is on the Controller versus CasC on SCM"
+- name: "Find the difference of Project between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
     __projects_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                       api_list=__controller_api_projects, compare_list=controller_projects,
                                       with_present=false, set_absent=true)
                             }}"
 
-- name: "OBJECT DIFF: Set project's list to be configured"
+- name: "Set project's list to be configured"
   ansible.builtin.set_fact:
     controller_projects: "{{ __projects_difference }}"
 ...

--- a/roles/object_diff/tasks/roles.yml
+++ b/roles/object_diff/tasks/roles.yml
@@ -1,5 +1,5 @@
 ---
-- name: "OBJECT DIFF: Get the current controller user to determine if it is super-admin"
+- name: "Get the current controller user to determine if it is super-admin"
   ansible.builtin.set_fact:
     __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
                                                               query_params={'username': controller_username},
@@ -11,20 +11,20 @@
     - __controller_api_current_user_check_is_admin.is_superuser
   block:
 
-    - name: "OBJECT DIFF: Get the API list of all roles"
+    - name: "Get the API list of all roles"
       ansible.builtin.set_fact:
         __controller_api_roles: "{{ query(controller_api_plugin, 'roles',
                                           host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                  }}"
 
-    - name: "OBJECT DIFF: Find the difference of Roles between what is on the Controller versus CasC on SCM"
+    - name: "Find the difference of Roles between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         __roles_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                         api_list=__controller_api_roles, compare_list=controller_roles,
                                         with_present=false, set_absent=true)
                              }}"
 
-    - name: "OBJECT DIFF: Sets differences between Roles what is on the Controller versus CasC on SCM"
+    - name: "Sets differences between Roles what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         controller_roles: "{{ __roles_difference }}"
 ...

--- a/roles/object_diff/tasks/teams.yml
+++ b/roles/object_diff/tasks/teams.yml
@@ -1,5 +1,5 @@
 ---
-- name: "OBJECT DIFF: Get the current controller user to determine if it is super-admin"
+- name: "Get the current controller user to determine if it is super-admin"
   ansible.builtin.set_fact:
     __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
                                                               query_params={'username': controller_username},
@@ -17,14 +17,14 @@
                                                   host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                        }}"
 
-    - name: "OBJECT DIFF: Get the API list of all teams in Organization {{ orgs }}"
+    - name: "Get the API list of all teams in Organization {{ orgs }}"
       ansible.builtin.set_fact:
         __controller_api_teams: "{{ query(controller_api_plugin, 'teams',
                                           query_params={'organization': __controller_organization_id.id},
                                           host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                  }}"
 
-    - name: "OBJECT DIFF: Find the difference of Teams between what is on the Controller versus CasC on SCM"
+    - name: "Find the difference of Teams between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         __teams_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                         api_list=__controller_api_teams,
@@ -33,7 +33,7 @@
                                         set_absent=true)
                              }}"
 
-    - name: "OBJECT DIFF: Sets the difference of Teams between what is on the Controller versus CasC on SCM"
+    - name: "Sets the difference of Teams between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         controller_teams: "{{ __teams_difference }}"
 ...

--- a/roles/object_diff/tasks/user_accounts.yml
+++ b/roles/object_diff/tasks/user_accounts.yml
@@ -1,13 +1,13 @@
 ---
 # tasks file for controller_ldap_settings
-- name: "OBJECT DIFF: Get the current controller user to determine if it is super-admin"
+- name: "Get the current controller user to determine if it is super-admin"
   ansible.builtin.set_fact:
     __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
                                                               query_params={'username': controller_username},
                                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                                    }}"
 
-- name: "OBJECT DIFF: Get all users from the API"
+- name: "Get all users from the API"
   ansible.builtin.set_fact:
     __controller_api_user_accounts: "{{ query(controller_api_plugin, 'users',
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
@@ -29,14 +29,14 @@
   when:
     - __controller_api_current_user_check_is_admin.is_superuser
   block:
-    - name: "OBJECT DIFF: Find the difference of User Accounts between what is on the Controller versus CasC on SCM"
+    - name: "Find the difference of User Accounts between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         __user_accounts_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                                 api_list=__controller_api_user_accounts, compare_list=controller_user_accounts,
                                                 with_present=false, set_absent=true)
                                      }}"
 
-    - name: "OBJECT DIFF: Sets the difference of User Accounts between what is on the Controller versus CasC on SCM"
+    - name: "Sets the difference of User Accounts between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
         controller_user_accounts: "{{ __user_accounts_difference }}"
 ...

--- a/roles/object_diff/tasks/workflow_job_templates.yml
+++ b/roles/object_diff/tasks/workflow_job_templates.yml
@@ -6,14 +6,14 @@
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                    }}"
 
-- name: "OBJECT DIFF: Get the API list of all Workflow Job Templates"
+- name: "Get the API list of all Workflow Job Templates"
   ansible.builtin.set_fact:
     __controller_api_workflow_job_templates: "{{ query(controller_api_plugin, 'workflow_job_templates',
                                                         query_params={'organization': __controller_organization_id.id},
                                                         host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                               }}"
 
-- name: "OBJECT DIFF: Find the difference of Workflow Job Templates between what is on the Controller versus CasC on SCM"
+- name: "Find the difference of Workflow Job Templates between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
     __workflow_job_templates_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
                                                     api_list=__controller_api_workflow_job_templates,
@@ -21,7 +21,7 @@
                                                     with_present=false, set_absent=true)
                                           }}"
 
-- name: "OBJECT DIFF: Set job_template's list to be configured"
+- name: "Set job_template's list to be configured"
   ansible.builtin.set_fact:
     controller_workflows: "{{ __workflow_job_templates_difference }}"
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
remove OBJECT DIFF from task name because it does not have sense. When tasks are running we can see role name in the task itself.

# How should this be tested?
Launch test playbooks for filetree_create, filetree_read and object_diff roles.