### PR TITLE
Improve settings template export

### DIFF
--- a/changelogs/fragments/filetree_create.yml
+++ b/changelogs/fragments/filetree_create.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  -  Improve template to export settings with filetree_create role. Settings will be in yaml format.
+...

--- a/changelogs/fragments/filetree_create.yml
+++ b/changelogs/fragments/filetree_create.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  -  Improve template to export settings with filetree_create role. Settings will be in yaml format.
+  - Improve template to export settings with filetree_create role. Settings will be in yaml format.
 ...

--- a/roles/filetree_create/templates/current_settings.j2
+++ b/roles/filetree_create/templates/current_settings.j2
@@ -1,4 +1,5 @@
 ---
 controller_settings:
-  - settings: "{{ changed_settings[0] | replace('\'AUTH_LDAP_GROUP_TYPE_PARAMS\': {}', '\'AUTH_LDAP_GROUP_TYPE_PARAMS\': {\'name_attr\': \'cn\', \'member_attr\': \'member\'}') }}"
+  - settings:
+{{ changed_settings[0] | replace('\'AUTH_LDAP_GROUP_TYPE_PARAMS\': {}', '\'AUTH_LDAP_GROUP_TYPE_PARAMS\': {\'name_attr\': \'cn\', \'member_attr\': \'member\'}') | replace("'", '"') | replace(': True', ': true') | replace(': False', ': false') | replace(': None', ': null') | from_json | to_nice_yaml | indent(width=6, first=True) }}
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Improve template to export settings with filetree_create role. Settings will be in yaml format.

# How should this be tested?

Try to export settings with filetree_create role.