### PR TITLE
filetree_create: fix export objects to add extra variables

### DIFF
--- a/changelogs/fragments/filetree_create.yml
+++ b/changelogs/fragments/filetree_create.yml
@@ -1,4 +1,5 @@
 ---
 minor_changes:
   - Improve template to export settings with filetree_create role. Settings will be in yaml format.
+  - Add or fix some variables or extra_vars exported from objects like notifications, inventory, inventory_source, hosts, groups, jt or wjt.
 ...

--- a/roles/filetree_create/templates/current_groups.j2
+++ b/roles/filetree_create/templates/current_groups.j2
@@ -1,9 +1,13 @@
 ---
-configure_tower_groups:
+controller_groups:
 {% for group in current_groups_asset_value %}
   - name: "{{ group.name }}"
     description: "{{ group.description }}"
     inventory: "{{ group.summary_fields.inventory.name }}"
+{% if group.variables and group.variables != '---' and group.variables != '' %}
+    variables:
+      {{ group.variables | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") }}
+{%- endif %}
     hosts:
 {{ query(controller_api_plugin, group.related.hosts,
          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,

--- a/roles/filetree_create/templates/current_hosts.j2
+++ b/roles/filetree_create/templates/current_hosts.j2
@@ -4,5 +4,9 @@ controller_hosts:
   - name: "{{ host.name }}"
     description: "{{ host.description }}"
     inventory: "{{ host.summary_fields.inventory.name | default('ToDo: The host \'' + host.name + '\' must have an associated inventory') }}"
+{% if host.variables and host.variables != '---' and host.variables != '' %}
+    variables:
+      {{ host.variables | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") }}
+{%- endif %}
 {% endfor %}
 ...

--- a/roles/filetree_create/templates/current_inventories.j2
+++ b/roles/filetree_create/templates/current_inventories.j2
@@ -9,8 +9,8 @@ controller_inventories:
 {% if current_inventories_asset_value.kind %}
     kind: "{{ current_inventories_asset_value.kind }}"
 {% endif %}
-{% if current_inventories_asset_value.variables and current_inventories_asset_value.variables != '---' %}
+{% if current_inventories_asset_value.variables and current_inventories_asset_value.variables != '---' and current_inventories_asset_value.variables != '' %}
     variables:
-      {{ current_inventories_asset_value.variables | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) }}
+      {{ current_inventories_asset_value.variables | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") }}
 {%- endif %}
 ...

--- a/roles/filetree_create/templates/current_inventory_sources.j2
+++ b/roles/filetree_create/templates/current_inventory_sources.j2
@@ -3,6 +3,7 @@ controller_inventory_sources:
 {% for inventory_source in current_inventory_sources_asset_value %}
   - name: "{{ inventory_source.name }}"
     description: "{{ inventory_source.description }}"
+    organization: "{{ inventory_source.summary_fields.organization.name }}"
     source: "{{ inventory_source.source | default('ToDo: The source of the inventory_source was originally missing and must be specified',true) }}"
 {% if inventory_source.source_project %}
     source_project: "{{ inventory_source.summary_fields.source_project.name }}"
@@ -10,7 +11,7 @@ controller_inventory_sources:
 {% if inventory_source.source_path %}
     source_path: "{{ inventory_source.source_path }}"
 {% endif %}
-{% if inventory_source.source_vars and inventory_source.source_vars != '---' %}
+{% if inventory_source.source_vars and inventory_source.source_vars != '---' and inventory_source.source_vars != '' %}
     source_vars:
       {{ inventory_source.source_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") }}
 {%- endif %}
@@ -18,7 +19,7 @@ controller_inventory_sources:
     update_on_launch: "{{ inventory_source.update_on_launch }}"
     overwrite: "{{ inventory_source.overwrite }}"
 {% if inventory_source.credential %}
-    credential: "{{ inventory_source.credential }}"
+    credential: "{{ inventory_source.summary_fields.credential.name }}"
 {% endif %}
 {% set query_notification_error = query(controller_api_plugin, inventory_source.related.notification_templates_error,
                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -21,14 +21,10 @@ controller_templates:
     ask_tags_on_launch: "{{ current_job_templates_asset_value.ask_tags_on_launch }}"
     ask_verbosity_on_launch: "{{ current_job_templates_asset_value.ask_verbosity_on_launch }}"
     ask_variables_on_launch: "{{ current_job_templates_asset_value.ask_variables_on_launch }}"
-{% if (current_job_templates_asset_value.extra_vars | length) > 3 %}
+{% if current_job_templates_asset_value.extra_vars and current_job_templates_asset_value.extra_vars != '---' and current_job_templates_asset_value.extra_vars != '' %}
     extra_vars:
-{% if (current_job_templates_asset_value.extra_vars[0] is match('{')) %}
-{{ current_job_templates_asset_value.extra_vars | from_json | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
-{% else %}
-{{ current_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=True) }}
-{% endif %}
-{%- endif -%}
+      {{ current_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") }}
+{%- endif %}
 {% if is_aap %}
     execution_environment: "{{ current_job_templates_asset_value.summary_fields.execution_environment.name | default(omit) }}"
 {% endif %}

--- a/roles/filetree_create/templates/current_notification_templates.j2
+++ b/roles/filetree_create/templates/current_notification_templates.j2
@@ -1,8 +1,6 @@
 ---
-controller_notification_templates:
-- name: "{{ current_notification_templates_asset_value.name }}"
-  notification_template:
-    name: "{{ current_notification_templates_asset_value.name }}"
+controller_notifications:
+  - name: "{{ current_notification_templates_asset_value.name }}"
     organization: "{{ current_notification_templates_asset_value.summary_fields.organization.name }}"
     notification_type: "{{ current_notification_templates_asset_value.notification_type }}"
     notification_configuration:

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -41,6 +41,10 @@ controller_workflows:
     allow_simultaneous: "{{ current_workflow_job_templates_asset_value.allow_simultaneous }}"
     scm_branch: "{{ current_workflow_job_templates_asset_value.scm_branch }}"
     webhook_service: "{{ current_workflow_job_templates_asset_value.webhook_service }}"
+{% if current_workflow_job_templates_asset_value.extra_vars and current_workflow_job_templates_asset_value.extra_vars != '---' and current_workflow_job_templates_asset_value.extra_vars != '' %}
+    extra_vars:
+      {{ current_workflow_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") }}
+{%- endif %}
 {% if query_labels | length > 0 %}
     labels:
 {% for label in query_labels %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Add or fix variables and extra_vars to some kind of objects like: inventory, inventory_source, hosts, groups, jt, wfjt and notifications

# How should this be tested?

Launch filetree_create to export all objects.