### PR TITLE
relocate team and user roles when export with filetree_create

### DIFF
--- a/roles/filetree_create/tasks/team_roles.yml
+++ b/roles/filetree_create/tasks/team_roles.yml
@@ -8,14 +8,14 @@
 
 - name: "Create the output directory for team roles: {{ output_path }}"
   ansible.builtin.file:
-    path: "{{ output_path }}"
+    path: "{{ output_path }}/team_roles"
     state: directory
     mode: '0755'
 
 - name: "Add current roles to the output yaml file"
   ansible.builtin.template:
     src: "templates/current_team_roles.j2"
-    dest: "{{ output_path }}/current_roles_{{ teamname | regex_replace('/', '_') }}.yaml"
+    dest: "{{ output_path }}/team_roles/current_roles_{{ teamname | regex_replace('/', '_') }}.yaml"
     mode: '0644'
   vars:
     current_team_roles_asset_value: "{{ team_roles_lookvar }}"

--- a/roles/filetree_create/tasks/user_roles.yml
+++ b/roles/filetree_create/tasks/user_roles.yml
@@ -8,14 +8,14 @@
 
 - name: "Create the output directory for user roles: {{ output_path }}"
   ansible.builtin.file:
-    path: "{{ output_path }}"
+    path: "{{ output_path }}/user_roles"
     state: directory
     mode: '0755'
 
 - name: "Add current roles to the output yaml file"
   ansible.builtin.template:
     src: "templates/current_user_roles.j2"
-    dest: "{{ output_path }}/current_roles_{{ username | regex_replace('/', '_') }}.yaml"
+    dest: "{{ output_path }}/user_roles/current_roles_{{ username | regex_replace('/', '_') }}.yaml"
     mode: '0644'
   vars:
     current_user_roles_asset_value: "{{ user_roles_lookvar }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

relocate team and user roles when export with filetree_create

# How should this be tested?

export roles of teams and users with filetree_create role.