### PR TITLE
Update README.md with correct badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Red Hat Communities of Practice Controller Configuration Collection
 
-![Ansible Lint](https://github.com/redhat-cop/controller_configuration/workflows/Yaml%20and%20Ansible%20Lint/badge.svg)
+![pre-commit tests](https://github.com/redhat-cop/controller_configuration/actions/workflows/pre-commit.yml/badge.svg)
 ![Galaxy Release](https://github.com/redhat-cop/controller_configuration/workflows/galaxy-release/badge.svg)
 <!-- Further CI badges go here as above -->
 


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

When going through other repos and fixing links I realised this badge was from the old CI jobs. I've now updated to the correct badge for the current CI

# How should this be tested?

Should mark as passing when CI passes

# Is there a relevant Issue open for this?

N/A

# Other Relevant info, PRs, etc

N/A