### PR TITLE
Replaced the 'warning' call for the 'v' call to show the information only when verbosity is required

### DIFF
--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -248,8 +248,8 @@ class LookupModule(LookupBase):
                 item.update({"organization": item["summary_fields"]["organization"]["name"]})
                 item.pop("summary_fields")
 
-        self.display.warning("compare_list_reduced: {0}".format(compare_list_reduced))
-        self.display.warning("api_list_reduced: {0}".format(api_list_reduced))
+        self.display.v("compare_list_reduced: {0}".format(compare_list_reduced))
+        self.display.v("api_list_reduced: {0}".format(api_list_reduced))
 
         # Find difference between lists
         if api_list[0]["type"] != "role":


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Replaced the 'warning' call for the 'v' call to show the information only when verbosity is required.

# How should this be tested?

Tested manually.

# Is there a relevant Issue open for this?

resolves #384 

# Other Relevant info, PRs, etc

N/A