### PR TITLE
fixes a reserved name collision

### DIFF
--- a/changelogs/fragments/project_updates.yml
+++ b/changelogs/fragments/project_updates.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Renamed the field `update` to `do_update` to avoid colliding with the Python dict update method
+...

--- a/changelogs/fragments/project_updates.yml
+++ b/changelogs/fragments/project_updates.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - Renamed the field `update` to `do_update` to avoid colliding with the Python dict update method
+  - Renamed the field `update` to `update_project` to avoid colliding with the Python dict update method
 ...

--- a/roles/project_update/README.md
+++ b/roles/project_update/README.md
@@ -63,7 +63,7 @@ This also speeds up the overall role.
 |`wait`|""|no|str|Wait for the project to complete.|
 |`interval`|`controller_configuration_project_update_async_delay`|no|str|The interval to request an update from controller.|
 |`timeout`|""|no|str|If waiting for the job to complete this will abort after this amount of seconds.|
-|`do_update`|false|no|bool|If defined and true, the project update will be executed, otherwise it won't.|
+|`update_project`|false|no|bool|If defined and true, the project update will be executed, otherwise it won't.|
 
 ### Standard Project Data Structure
 

--- a/roles/project_update/README.md
+++ b/roles/project_update/README.md
@@ -63,6 +63,7 @@ This also speeds up the overall role.
 |`wait`|""|no|str|Wait for the project to complete.|
 |`interval`|`controller_configuration_project_update_async_delay`|no|str|The interval to request an update from controller.|
 |`timeout`|""|no|str|If waiting for the job to complete this will abort after this amount of seconds.|
+|`do_update`|false|no|bool|If defined and true, the project update will be executed, otherwise it won't.|
 
 ### Standard Project Data Structure
 

--- a/roles/project_update/tasks/main.yml
+++ b/roles/project_update/tasks/main.yml
@@ -21,7 +21,7 @@
   no_log: "{{ controller_configuration_project_update_secure_logging }}"
   when:
     - controller_projects is defined
-    - __project_update_update_item.do_update | default(false)
+    - __project_update_update_item.update_project | default(false)
     - __project_update_update_item.state | default('present') != "absent"
   async: 1000
   poll: 0

--- a/roles/project_update/tasks/main.yml
+++ b/roles/project_update/tasks/main.yml
@@ -21,7 +21,7 @@
   no_log: "{{ controller_configuration_project_update_secure_logging }}"
   when:
     - controller_projects is defined
-    - __project_update_update_item.update
+    - __project_update_update_item.do_update | default(false)
     - __project_update_update_item.state | default('present') != "absent"
   async: 1000
   poll: 0

--- a/roles/project_update/tests/configs/projects.yml
+++ b/roles/project_update/tests/configs/projects.yml
@@ -7,7 +7,7 @@ controller_projects:
     scm_clean: true
     description: Test Project 1
     organization: Satellite
-    do_update: true
+    update_project: true
     wait: true
   - name: Test Project 2
     scm_type: git

--- a/roles/project_update/tests/configs/projects.yml
+++ b/roles/project_update/tests/configs/projects.yml
@@ -7,7 +7,7 @@ controller_projects:
     scm_clean: true
     description: Test Project 1
     organization: Satellite
-    update: true
+    do_update: true
     wait: true
   - name: Test Project 2
     scm_type: git


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Renamed the field `update` to `do_update` to avoid colliding with the Python dict update method

# How should this be tested?

Manually tested the problem itself, but not the complete functionality. The change seems quite simple.

# Is there a relevant Issue open for this?

resolves #385 

# Other Relevant info, PRs, etc

N/A