### PR TITLE
Allow state to be undefined on workflow_job_templates when  using simplified_workflow_nodes

### DIFF
--- a/.github/tests/configs/differential_items.yml
+++ b/.github/tests/configs/differential_items.yml
@@ -138,4 +138,7 @@ differential_items:
       - name: Simple workflow schema2
         organization: Default
         state: absent
+      - name: Simple workflow schema no state defined
+        organization: Default
+        state: absent
 ...

--- a/.github/tests/configs/workflows.yml
+++ b/.github/tests/configs/workflows.yml
@@ -73,4 +73,47 @@ controller_workflows:
     notification_templates_success: []
     notification_templates_error: []
     notification_templates_approvals: []
+  - name: Simple workflow schema no state defined
+    description: a basic workflow
+    extra_vars: {}
+    survey_enabled: false
+    allow_simultaneous: false
+    ask_variables_on_launch: false
+    inventory:
+    limit:
+    job_tags:
+      - stuff
+      - stuff2
+    skip_tags:
+      - stuff3
+    ask_labels_on_launch: true
+    ask_skip_tags_on_launch: true
+    labels:
+      - Prod
+    scm_branch:
+    ask_inventory_on_launch: false
+    ask_scm_branch_on_launch: false
+    ask_limit_on_launch: false
+    organization: Default
+    schedules: []
+    simplified_workflow_nodes:
+      - all_parents_must_converge: false
+        identifier: node101
+        unified_job_template: RHVM-01
+        success_nodes:
+          - node201
+      - all_parents_must_converge: false
+        identifier: node201
+        unified_job_template: test-template-1
+        instance_groups:
+          - default
+        labels:
+          - differential
+          - differential2
+        timeout: 165
+    notification_templates_started: []
+    notification_templates_success: []
+    notification_templates_error: []
+    notification_templates_approvals: []
+    survey_spec: {}
 ...

--- a/changelogs/fragments/workflow_job_template_state_and_nodes.yml
+++ b/changelogs/fragments/workflow_job_template_state_and_nodes.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - Enable the ability to define simple_workflow_nodes on workflow_job_templates
+    without the need to set the `state` on a workflow_job_template
+    (https://github.com/redhat-cop/controller_configuration/issues/297).

--- a/roles/workflow_job_templates/tasks/main.yml
+++ b/roles/workflow_job_templates/tasks/main.yml
@@ -75,5 +75,5 @@
     loop_var: __workflow_loop_item
   when:
     - __workflow_loop_item.simplified_workflow_nodes is defined
-    - __workflow_loop_item.state == "present"
+    - (__workflow_loop_item.state | default('present')) ==  "present"
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

The `state` key is optional for workflow_job_templates unless you are using simplified_workflow_nodes.
This change allows the state key to remain optional when using simplified_workflow_nodes.

# How should this be tested?

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Automated tests have been added

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #297 

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
