### PR TITLE
Add note to labels option in readmes

### DIFF
--- a/roles/job_templates/README.md
+++ b/roles/job_templates/README.md
@@ -108,6 +108,8 @@ This also speeds up the overall role.
 |`webhook_service`|""|no|str|Service that webhook requests will be accepted from (github, gitlab)|
 |`webhook_credential`|""|no|str|Personal Access Token for posting back the status to the service API|
 |`scm_branch`|""|no|str|Branch to use in job run. Project default used if blank. Only allowed if project allow_override field is set to true.|
+<!-- Disabling link check because the CI can't work out that this is a valid link -->
+<!-- markdown-link-check-disable-next-line -->
 |`labels`|""|no|list|The labels applied to this job template. NOTE: Labels must be created with the [labels](/roles/labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`custom_virtualenv`|""|no|str|Local absolute file path containing a custom Python virtualenv to use.|
 |`notification_templates_started`|""|no|list|The notifications on started to use for this organization in a list.|

--- a/roles/job_templates/README.md
+++ b/roles/job_templates/README.md
@@ -108,7 +108,7 @@ This also speeds up the overall role.
 |`webhook_service`|""|no|str|Service that webhook requests will be accepted from (github, gitlab)|
 |`webhook_credential`|""|no|str|Personal Access Token for posting back the status to the service API|
 |`scm_branch`|""|no|str|Branch to use in job run. Project default used if blank. Only allowed if project allow_override field is set to true.|
-|`labels`|""|no|list|The labels applied to this job template. NOTE: Labels must be created with the [labels](../labels) role first, an error will occur if the label supplied to this role does not exist.|
+|`labels`|""|no|list|The labels applied to this job template. NOTE: Labels must be created with the [labels](https://github.com/redhat-cop/controller_configuration/tree/devel/roles/labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`custom_virtualenv`|""|no|str|Local absolute file path containing a custom Python virtualenv to use.|
 |`notification_templates_started`|""|no|list|The notifications on started to use for this organization in a list.|
 |`notification_templates_success`|""|no|list|The notifications on success to use for this organization in a list.|

--- a/roles/job_templates/README.md
+++ b/roles/job_templates/README.md
@@ -108,7 +108,7 @@ This also speeds up the overall role.
 |`webhook_service`|""|no|str|Service that webhook requests will be accepted from (github, gitlab)|
 |`webhook_credential`|""|no|str|Personal Access Token for posting back the status to the service API|
 |`scm_branch`|""|no|str|Branch to use in job run. Project default used if blank. Only allowed if project allow_override field is set to true.|
-|`labels`|""|no|list|The labels applied to this job template|
+|`labels`|""|no|list|The labels applied to this job template. NOTE: Labels must be created with the [labels](/roles/labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`custom_virtualenv`|""|no|str|Local absolute file path containing a custom Python virtualenv to use.|
 |`notification_templates_started`|""|no|list|The notifications on started to use for this organization in a list.|
 |`notification_templates_success`|""|no|list|The notifications on success to use for this organization in a list.|

--- a/roles/job_templates/README.md
+++ b/roles/job_templates/README.md
@@ -108,9 +108,7 @@ This also speeds up the overall role.
 |`webhook_service`|""|no|str|Service that webhook requests will be accepted from (github, gitlab)|
 |`webhook_credential`|""|no|str|Personal Access Token for posting back the status to the service API|
 |`scm_branch`|""|no|str|Branch to use in job run. Project default used if blank. Only allowed if project allow_override field is set to true.|
-<!-- Disabling link check because the CI can't work out that this is a valid link -->
-<!-- markdown-link-check-disable-next-line -->
-|`labels`|""|no|list|The labels applied to this job template. NOTE: Labels must be created with the [labels](/roles/labels) role first, an error will occur if the label supplied to this role does not exist.|
+|`labels`|""|no|list|The labels applied to this job template. NOTE: Labels must be created with the [labels](../labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`custom_virtualenv`|""|no|str|Local absolute file path containing a custom Python virtualenv to use.|
 |`notification_templates_started`|""|no|list|The notifications on started to use for this organization in a list.|
 |`notification_templates_success`|""|no|list|The notifications on success to use for this organization in a list.|

--- a/roles/workflow_job_templates/README.md
+++ b/roles/workflow_job_templates/README.md
@@ -71,6 +71,8 @@ This also speeds up the overall role.
 |`allow_simultaneous`|""|no|bool|Allow simultaneous runs of the workflow job template.|
 |`inventory`|""|no|str|Inventory applied as a prompt, assuming job template prompts for inventory|
 |`limit`|""|no|str|Limit applied as a prompt, assuming job template prompts for limit|
+<!-- Disabling link check because the CI can't work out that this is a valid link -->
+<!-- markdown-link-check-disable-next-line -->
 |`labels`|""|no|str|The labels applied to this job template. NOTE: Labels must be created with the [labels](/roles/labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`ask_labels_on_launch`|""|no|bool|Prompt user for labels on launch.|
 |`job_tags`|""|no|str|Comma separated list of the tags to use for the workflow job template.|
@@ -103,6 +105,8 @@ This also speeds up the overall role.
 |`forks`|Job Template default|no|str|Forks applied as a prompt. Job Template default used if not set. Only allowed if `ask_forks_on_launch` set to true on Job Template|
 |`instance_groups`|Job Template default|no|str| List of Instance Groups applied as a prompt. Job Template default used if not set. Only allowed if `ask_instance_groups_on_launch` set to true on Job Template|
 |`job_slice_count`|Job Template default|no|str|Job Slice Count to use in the job run. Job Template default used if not set. Only allowed if `ask_job_slice_count_on_launch` set to true on Job Template|
+<!-- Disabling link check because the CI can't work out that this is a valid link -->
+<!-- markdown-link-check-disable-next-line -->
 |`labels`|Job Template default|no|list|List of labels to use in the job run. Job Template default used if not set. Only allowed if `ask_labels_on_launch` set to true on Job Template. NOTE: Labels must be created with the [labels](/roles/labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`timeout`|Job Template default|no|str|Timeout to use in the job run. Job Template default used if not set. Only allowed if `ask_timeout_on_launch` set to true on Job Template|
 |`approval_node`|""|no|str|A dictionary of Name, description, and timeout values for the approval node. This parameter is mutually exclusive with unified_job_template.|

--- a/roles/workflow_job_templates/README.md
+++ b/roles/workflow_job_templates/README.md
@@ -71,7 +71,7 @@ This also speeds up the overall role.
 |`allow_simultaneous`|""|no|bool|Allow simultaneous runs of the workflow job template.|
 |`inventory`|""|no|str|Inventory applied as a prompt, assuming job template prompts for inventory|
 |`limit`|""|no|str|Limit applied as a prompt, assuming job template prompts for limit|
-|`labels`|""|no|str|The labels applied to this job template|
+|`labels`|""|no|str|The labels applied to this job template. NOTE: Labels must be created with the [labels](/roles/labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`ask_labels_on_launch`|""|no|bool|Prompt user for labels on launch.|
 |`job_tags`|""|no|str|Comma separated list of the tags to use for the workflow job template.|
 |`skip_tags`|""|no|str|Comma separated list of the tags to skip for the workflow job template.|
@@ -103,7 +103,7 @@ This also speeds up the overall role.
 |`forks`|Job Template default|no|str|Forks applied as a prompt. Job Template default used if not set. Only allowed if `ask_forks_on_launch` set to true on Job Template|
 |`instance_groups`|Job Template default|no|str| List of Instance Groups applied as a prompt. Job Template default used if not set. Only allowed if `ask_instance_groups_on_launch` set to true on Job Template|
 |`job_slice_count`|Job Template default|no|str|Job Slice Count to use in the job run. Job Template default used if not set. Only allowed if `ask_job_slice_count_on_launch` set to true on Job Template|
-|`labels`|Job Template default|no|list|List of labels to use in the job run. Job Template default used if not set. Only allowed if `ask_labels_on_launch` set to true on Job Template|
+|`labels`|Job Template default|no|list|List of labels to use in the job run. Job Template default used if not set. Only allowed if `ask_labels_on_launch` set to true on Job Template. NOTE: Labels must be created with the [labels](/roles/labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`timeout`|Job Template default|no|str|Timeout to use in the job run. Job Template default used if not set. Only allowed if `ask_timeout_on_launch` set to true on Job Template|
 |`approval_node`|""|no|str|A dictionary of Name, description, and timeout values for the approval node. This parameter is mutually exclusive with unified_job_template.|
 |`organization`|""|no|str|The organization of the workflow job template the node exists in. Used for looking up the workflow, not a direct model field.|

--- a/roles/workflow_job_templates/README.md
+++ b/roles/workflow_job_templates/README.md
@@ -71,9 +71,7 @@ This also speeds up the overall role.
 |`allow_simultaneous`|""|no|bool|Allow simultaneous runs of the workflow job template.|
 |`inventory`|""|no|str|Inventory applied as a prompt, assuming job template prompts for inventory|
 |`limit`|""|no|str|Limit applied as a prompt, assuming job template prompts for limit|
-<!-- Disabling link check because the CI can't work out that this is a valid link -->
-<!-- markdown-link-check-disable-next-line -->
-|`labels`|""|no|str|The labels applied to this job template. NOTE: Labels must be created with the [labels](/roles/labels) role first, an error will occur if the label supplied to this role does not exist.|
+|`labels`|""|no|str|The labels applied to this job template. NOTE: Labels must be created with the [labels](../labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`ask_labels_on_launch`|""|no|bool|Prompt user for labels on launch.|
 |`job_tags`|""|no|str|Comma separated list of the tags to use for the workflow job template.|
 |`skip_tags`|""|no|str|Comma separated list of the tags to skip for the workflow job template.|
@@ -105,9 +103,7 @@ This also speeds up the overall role.
 |`forks`|Job Template default|no|str|Forks applied as a prompt. Job Template default used if not set. Only allowed if `ask_forks_on_launch` set to true on Job Template|
 |`instance_groups`|Job Template default|no|str| List of Instance Groups applied as a prompt. Job Template default used if not set. Only allowed if `ask_instance_groups_on_launch` set to true on Job Template|
 |`job_slice_count`|Job Template default|no|str|Job Slice Count to use in the job run. Job Template default used if not set. Only allowed if `ask_job_slice_count_on_launch` set to true on Job Template|
-<!-- Disabling link check because the CI can't work out that this is a valid link -->
-<!-- markdown-link-check-disable-next-line -->
-|`labels`|Job Template default|no|list|List of labels to use in the job run. Job Template default used if not set. Only allowed if `ask_labels_on_launch` set to true on Job Template. NOTE: Labels must be created with the [labels](/roles/labels) role first, an error will occur if the label supplied to this role does not exist.|
+|`labels`|Job Template default|no|list|List of labels to use in the job run. Job Template default used if not set. Only allowed if `ask_labels_on_launch` set to true on Job Template. NOTE: Labels must be created with the [labels](../labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`timeout`|Job Template default|no|str|Timeout to use in the job run. Job Template default used if not set. Only allowed if `ask_timeout_on_launch` set to true on Job Template|
 |`approval_node`|""|no|str|A dictionary of Name, description, and timeout values for the approval node. This parameter is mutually exclusive with unified_job_template.|
 |`organization`|""|no|str|The organization of the workflow job template the node exists in. Used for looking up the workflow, not a direct model field.|

--- a/roles/workflow_job_templates/README.md
+++ b/roles/workflow_job_templates/README.md
@@ -71,7 +71,7 @@ This also speeds up the overall role.
 |`allow_simultaneous`|""|no|bool|Allow simultaneous runs of the workflow job template.|
 |`inventory`|""|no|str|Inventory applied as a prompt, assuming job template prompts for inventory|
 |`limit`|""|no|str|Limit applied as a prompt, assuming job template prompts for limit|
-|`labels`|""|no|str|The labels applied to this job template. NOTE: Labels must be created with the [labels](../labels) role first, an error will occur if the label supplied to this role does not exist.|
+|`labels`|""|no|str|The labels applied to this job template. NOTE: Labels must be created with the [labels](https://github.com/redhat-cop/controller_configuration/tree/devel/roles/labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`ask_labels_on_launch`|""|no|bool|Prompt user for labels on launch.|
 |`job_tags`|""|no|str|Comma separated list of the tags to use for the workflow job template.|
 |`skip_tags`|""|no|str|Comma separated list of the tags to skip for the workflow job template.|
@@ -103,7 +103,7 @@ This also speeds up the overall role.
 |`forks`|Job Template default|no|str|Forks applied as a prompt. Job Template default used if not set. Only allowed if `ask_forks_on_launch` set to true on Job Template|
 |`instance_groups`|Job Template default|no|str| List of Instance Groups applied as a prompt. Job Template default used if not set. Only allowed if `ask_instance_groups_on_launch` set to true on Job Template|
 |`job_slice_count`|Job Template default|no|str|Job Slice Count to use in the job run. Job Template default used if not set. Only allowed if `ask_job_slice_count_on_launch` set to true on Job Template|
-|`labels`|Job Template default|no|list|List of labels to use in the job run. Job Template default used if not set. Only allowed if `ask_labels_on_launch` set to true on Job Template. NOTE: Labels must be created with the [labels](../labels) role first, an error will occur if the label supplied to this role does not exist.|
+|`labels`|Job Template default|no|list|List of labels to use in the job run. Job Template default used if not set. Only allowed if `ask_labels_on_launch` set to true on Job Template. NOTE: Labels must be created with the [labels](https://github.com/redhat-cop/controller_configuration/tree/devel/roles/labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`timeout`|Job Template default|no|str|Timeout to use in the job run. Job Template default used if not set. Only allowed if `ask_timeout_on_launch` set to true on Job Template|
 |`approval_node`|""|no|str|A dictionary of Name, description, and timeout values for the approval node. This parameter is mutually exclusive with unified_job_template.|
 |`organization`|""|no|str|The organization of the workflow job template the node exists in. Used for looking up the workflow, not a direct model field.|


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Adds note to labels option of workflow and JT roles to point out that the label must first be created as per the discussion in #344 

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your Readme change. CI will verify readme links

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #344

# Other Relevant info, PRs, etc
N/A
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
