### PR TITLE
Added task to simplify the assignment of  galaxy/ee to org

### DIFF
--- a/changelogs/fragments/dispatch_creds_ee_orgs_creation.yml
+++ b/changelogs/fragments/dispatch_creds_ee_orgs_creation.yml
@@ -1,7 +1,6 @@
 ---
 minor_changes:
-  - Set the following variables to false when run all roles at dispatch role:
-      - assign_galaxy_credentials_to_org: false
-      - assign_default_ee_to_org: false
-  - Add task to add Galaxy credentials and Execution Environments to Organization
+  - Set the variables to assign_galaxy_credentials_to_org and assign_default_ee_to_org to false in the task to run all roles at dispatch role.
+  - Add task to add Galaxy credentials and Execution Environments to Organization.
+  - Adapt filetree_read role tests playbook config-controller-filetree.yml.
 ...

--- a/changelogs/fragments/dispatch_creds_ee_orgs_creation.yml
+++ b/changelogs/fragments/dispatch_creds_ee_orgs_creation.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - Set the following variables to false when run all roles at dispatch role:
+      - assign_galaxy_credentials_to_org: false
+      - assign_default_ee_to_org: false
+  - Add task to add Galaxy credentials and Execution Environments to Organization
+...

--- a/roles/dispatch/tasks/main.yml
+++ b/roles/dispatch/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: "Run redhat_cop.controller_configuration.{{ __role.role }}"
   ansible.builtin.include_role:
     name: "{{ __role.role }}"
@@ -10,4 +9,17 @@
   loop: "{{ controller_configuration_dispatcher_roles }}"
   loop_control:
     loop_var: __role
+  vars:
+    assign_galaxy_credentials_to_org: false
+    assign_default_ee_to_org: false
+
+- name: Include Tasks to add Galaxy credentials and Execution Environments to Organizations
+  ansible.builtin.include_role:
+    name: redhat_cop.controller_configuration.dispatch
+    apply:
+      tags:
+        - organizations
+  vars:
+    controller_configuration_dispatcher_roles:
+      - {role: organizations, var: controller_organizations, tags: organizations}
 ...

--- a/roles/dispatch/tasks/main.yml
+++ b/roles/dispatch/tasks/main.yml
@@ -15,11 +15,8 @@
 
 - name: Include Tasks to add Galaxy credentials and Execution Environments to Organizations
   ansible.builtin.include_role:
-    name: dispatch
+    name: organizations
     apply:
       tags:
         - organizations
-  vars:
-    controller_configuration_dispatcher_roles:
-      - {role: organizations, var: controller_organizations, tags: organizations}
 ...

--- a/roles/dispatch/tasks/main.yml
+++ b/roles/dispatch/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Include Tasks to add Galaxy credentials and Execution Environments to Organizations
   ansible.builtin.include_role:
-    name: redhat_cop.controller_configuration.dispatch
+    name: dispatch
     apply:
       tags:
         - organizations

--- a/roles/filetree_read/tests/config-controller-filetree.yml
+++ b/roles/filetree_read/tests/config-controller-filetree.yml
@@ -32,23 +32,10 @@
       tags:
         - always
   roles:
-    - {role: redhat_cop.controller_configuration.filetree_read, assign_galaxy_credentials_to_org: false}
-    - {role: redhat_cop.controller_configuration.dispatch, assign_galaxy_credentials_to_org: false}
+    - redhat_cop.controller_configuration.filetree_read
+    - redhat_cop.controller_configuration.dispatch
 
   post_tasks:
-    - block:
-        - name: Include Tasks to add Galaxy credentials to Organizations
-          ansible.builtin.include_role:
-            name: redhat_cop.controller_configuration.dispatch
-            apply:
-              tags:
-                - organizations
-          vars:
-            controller_configuration_dispatcher_roles:
-              - {role: organizations, var: controller_organizations, tags: organizations}
-      tags:
-        - organizations
-
     - name: "Delete the Authentication Token used"
       ansible.builtin.uri:
         url: "https://{{ controller_hostname }}{{ controller_oauthtoken_url }}"


### PR DESCRIPTION
# What does this PR do?

Solve the chicken and egg problem to add galaxy credentials and execution environments to organizations in the dispatch role. Basically, through variables we can create the organizations and credentials in the first run, then a tasks has been include to add the  galaxy credentials and execution environments to organizations.

# How should this be tested?

Tested manually.

# Is there a relevant Issue open for this?

resolves #477 