### PR TITLE
add new object types to object_diff role

### DIFF
--- a/changelogs/fragments/object_diff_role_and_plugin.yml
+++ b/changelogs/fragments/object_diff_role_and_plugin.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "Add new type of objects for object_diff role:  applications, execution environments, instance groups, notifications and schedules"
+

--- a/changelogs/fragments/object_diff_role_and_plugin.yml
+++ b/changelogs/fragments/object_diff_role_and_plugin.yml
@@ -1,3 +1,4 @@
+---
 minor_changes:
   - "Add new type of objects for object_diff role:  applications, execution environments, instance groups, notifications and schedules"
-
+...

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -256,8 +256,13 @@ class LookupModule(LookupBase):
             for item in list_to_remove:
                 compare_list_reduced.remove(item)
             compare_list_reduced.extend(list_to_extend)
-        elif (api_list[0]["type"] != "organization" and api_list[0]["type"] != "user" and api_list[0]["type"] != "credential_type"
-              and api_list[0]["type"] != "schedule" and api_list[0]["type"] != "instance_group"):
+        elif (
+            api_list[0]["type"] != "organization"
+            and api_list[0]["type"] != "user"
+            and api_list[0]["type"] != "credential_type"
+            and api_list[0]["type"] != "schedule"
+            and api_list[0]["type"] != "instance_group"
+        ):
             for item in api_list_reduced:
                 item.update({"organization": item["summary_fields"]["organization"]["name"]})
                 item.pop("summary_fields")

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -120,7 +120,7 @@ class LookupModule(LookupBase):
             return [api_list]
 
         # Set Keys to keep for each list. Depending on type
-        if api_list[0]["type"] == "organization" or api_list[0]["type"] == "credential_type":
+        if api_list[0]["type"] == "organization" or api_list[0]["type"] == "credential_type" or api_list[0]["type"] == "instance_group":
             keys_to_keep = ["name"]
             api_keys_to_keep = ["name"]
         elif api_list[0]["type"] == "user":
@@ -132,6 +132,12 @@ class LookupModule(LookupBase):
         elif api_list[0]["type"] == "group" or api_list[0]["type"] == "host":
             keys_to_keep = ["name", "inventory"]
             api_keys_to_keep = ["name", "summary_fields"]
+        elif api_list[0]["type"] == "schedule":
+            keys_to_keep = ["name", "unified_job_template"]
+            api_keys_to_keep = ["name", "summary_fields"]
+        elif api_list[0]["type"] == "execution_environment":
+            keys_to_keep = ["name", "organization", "image"]
+            api_keys_to_keep = ["name", "summary_fields", "image"]
         elif api_list[0]["type"] == "role":
             pass
         else:
@@ -158,12 +164,15 @@ class LookupModule(LookupBase):
                         self.handle_error(msg="Key: '{0}' missing from item in api_list. Does this object come from the api? item: {1}".format(key, item))
 
         # Reduce list to name and organization
-        if api_list[0]["type"] != "role":
-            compare_list_reduced = [{key: item[key] for key in keys_to_keep} for item in compare_list]
-            api_list_reduced = [{key: item[key] for key in api_keys_to_keep} for item in api_list]
-        else:
+        if api_list[0]["type"] == "role":
             compare_list_reduced = copy.deepcopy(compare_list)
             api_list_reduced = copy.deepcopy(api_list)
+        elif api_list[0]["type"] == "instance_group":
+            compare_list_reduced = [{key: item[key] for key in keys_to_keep} for item in compare_list]
+            api_list_reduced = [{key: item[key] for key in api_keys_to_keep} for item in api_list if item["summary_fields"]["user_capabilities"]["delete"]]
+        else:
+            compare_list_reduced = [{key: item[key] for key in keys_to_keep} for item in compare_list]
+            api_list_reduced = [{key: item[key] for key in api_keys_to_keep} for item in api_list]
 
         # Convert summary field name into org name Only if not type organization
         if api_list[0]["type"] == "group" or api_list[0]["type"] == "host":
@@ -184,6 +193,10 @@ class LookupModule(LookupBase):
             for item in api_list_reduced:
                 item.update({"unified_job_template": item["summary_fields"]["unified_job_template"]["name"]})
                 item.update({"workflow_job_template": item["summary_fields"]["workflow_job_template"]["name"]})
+                item.pop("summary_fields")
+        elif api_list[0]["type"] == "schedule":
+            for item in api_list_reduced:
+                item.update({"unified_job_template": item["summary_fields"]["unified_job_template"]["name"]})
                 item.pop("summary_fields")
         elif api_list[0]["type"] == "role":
             for item in api_list_reduced:
@@ -243,7 +256,7 @@ class LookupModule(LookupBase):
             for item in list_to_remove:
                 compare_list_reduced.remove(item)
             compare_list_reduced.extend(list_to_extend)
-        elif api_list[0]["type"] != "organization" and api_list[0]["type"] != "user" and api_list[0]["type"] != "credential_type":
+        elif api_list[0]["type"] != "organization" and api_list[0]["type"] != "user" and api_list[0]["type"] != "credential_type" and api_list[0]["type"] != "schedule" and api_list[0]["type"] != "instance_group":
             for item in api_list_reduced:
                 item.update({"organization": item["summary_fields"]["organization"]["name"]})
                 item.pop("summary_fields")

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -256,8 +256,8 @@ class LookupModule(LookupBase):
             for item in list_to_remove:
                 compare_list_reduced.remove(item)
             compare_list_reduced.extend(list_to_extend)
-        elif (api_list[0]["type"] != "organization" and api_list[0]["type"] != "user" and api_list[0]["type"] != "credential_type" and
-             api_list[0]["type"] != "schedule" and api_list[0]["type"] != "instance_group"):
+        elif (api_list[0]["type"] != "organization" and api_list[0]["type"] != "user" and api_list[0]["type"] != "credential_type"
+              and api_list[0]["type"] != "schedule" and api_list[0]["type"] != "instance_group"):
             for item in api_list_reduced:
                 item.update({"organization": item["summary_fields"]["organization"]["name"]})
                 item.pop("summary_fields")

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -256,7 +256,8 @@ class LookupModule(LookupBase):
             for item in list_to_remove:
                 compare_list_reduced.remove(item)
             compare_list_reduced.extend(list_to_extend)
-        elif api_list[0]["type"] != "organization" and api_list[0]["type"] != "user" and api_list[0]["type"] != "credential_type" and api_list[0]["type"] != "schedule" and api_list[0]["type"] != "instance_group":
+        elif (api_list[0]["type"] != "organization" and api_list[0]["type"] != "user" and api_list[0]["type"] != "credential_type" and
+             api_list[0]["type"] != "schedule" and api_list[0]["type"] != "instance_group"):
             for item in api_list_reduced:
                 item.update({"organization": item["summary_fields"]["organization"]["name"]})
                 item.pop("summary_fields")

--- a/roles/object_diff/defaults/main.yml
+++ b/roles/object_diff/defaults/main.yml
@@ -30,6 +30,7 @@ controller_roles: []
 
 # object_diff tasks name
 controller_configuration_object_diff_tasks:
+  - {name: schedules, var: controller_schedules, tags: schedules}
   - {name: workflow_job_templates, var: controller_workflows, tags: workflow_job_templates}
   - {name: job_templates, var: controller_templates, tags: job_templates}
   - {name: roles, var: controller_roles, tags: roles}
@@ -37,9 +38,13 @@ controller_configuration_object_diff_tasks:
   - {name: user_accounts, var: controller_user_accounts, tags: users}
   - {name: groups, var: controller_groups, tags: groups}
   - {name: hosts, var: controller_hosts, tags: hosts}
+  - {name: instance_groups, var: controller_instance_groups, tags: instance_groups}
+  - {name: applications, var: controller_applications, tags: applications}
+  - {name: execution_environments, var: controller_execution_environments, tags: execution_environments}
   - {name: inventory_sources, var: controller_inventory_sources, tags: inventory_sources}
   - {name: inventories, var: controller_inventories, tags: inventories}
   - {name: projects, var: controller_projects, tags: projects}
+  - {name: notification_templates, var: controller_notification_templates, tags: notification_templates}
   - {name: credentials, var: controller_credentials, tags: credentials}
   - {name: credential_types, var: controller_credential_types, tags: credential_types}
   - {name: organizations, var: controller_organizations, tags: organizations}

--- a/roles/object_diff/tasks/applications.yml
+++ b/roles/object_diff/tasks/applications.yml
@@ -1,0 +1,27 @@
+---
+- name: Get the organization ID
+  ansible.builtin.set_fact:
+    __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
+                                              query_params={'name': orgs},
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
+                                   }}"
+
+- name: "Get the API list of all Applications in Organization {{ orgs }}"
+  ansible.builtin.set_fact:
+    __controller_api_applications: "{{ query(controller_api_plugin, 'applications',
+                                          query_params={'organization': __controller_organization_id.id},
+                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                          return_all=true, max_objects=query_controller_api_max_objects)
+                                }}"
+
+- name: "Find the difference of Application between what is on the Controller versus CasC on SCM"
+  ansible.builtin.set_fact:
+    __applications_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
+                                      api_list=__controller_api_applications, compare_list=controller_applications,
+                                      with_present=false, set_absent=true)
+                            }}"
+
+- name: "Set application's list to be configured"
+  ansible.builtin.set_fact:
+    controller_applications: "{{ __applications_difference }}"
+...

--- a/roles/object_diff/tasks/execution_environments.yml
+++ b/roles/object_diff/tasks/execution_environments.yml
@@ -1,0 +1,27 @@
+---
+- name: Get the organization ID
+  ansible.builtin.set_fact:
+    __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
+                                              query_params={'name': orgs},
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
+                                   }}"
+
+- name: "Get the API list of all Execution Environments in Organization {{ orgs }}"
+  ansible.builtin.set_fact:
+    __controller_api_execution_environments: "{{ query(controller_api_plugin, 'execution_environments',
+                                          query_params={'organization': __controller_organization_id.id},
+                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                          return_all=true, max_objects=query_controller_api_max_objects)
+                                }}"
+
+- name: "Find the difference of Execution Environment between what is on the Controller versus CasC on SCM"
+  ansible.builtin.set_fact:
+    __execution_environments_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
+                                      api_list=__controller_api_execution_environments, compare_list=controller_execution_environments,
+                                      with_present=false, set_absent=true)
+                            }}"
+
+- name: "Set execution_environment's list to be configured"
+  ansible.builtin.set_fact:
+    controller_execution_environments: "{{ __execution_environments_difference }}"
+...

--- a/roles/object_diff/tasks/instance_groups.yml
+++ b/roles/object_diff/tasks/instance_groups.yml
@@ -1,0 +1,32 @@
+---
+- name: "Get the current controller user to determine if it is super-admin"
+  ansible.builtin.set_fact:
+    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
+                                                              query_params={'username': controller_username},
+                                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
+                                                   }}"
+
+- name: "Instance Group differences (block)"
+  when:
+    - __controller_api_current_user_check_is_admin.is_superuser
+  block:
+    - name: "Get the API list of all instance_groups"
+      ansible.builtin.set_fact:
+        __controller_api_instance_groups: "{{ query(controller_api_plugin, 'instance_groups',
+                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                          return_all=true, max_objects=query_controller_api_max_objects)
+                                 }}"
+
+    - name: "Find the difference of Instance Groups between what is on the Controller versus CasC on SCM"
+      ansible.builtin.set_fact:
+        __instance_groups_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
+                                        api_list=__controller_api_instance_groups,
+                                        compare_list=controller_instance_groups,
+                                        with_present=false,
+                                        set_absent=true)
+                             }}"
+
+    - name: "Sets the difference of Instance Groups between what is on the Controller versus CasC on SCM"
+      ansible.builtin.set_fact:
+        controller_instance_groups: "{{ __instance_groups_difference }}"
+...

--- a/roles/object_diff/tasks/notification_templates.yml
+++ b/roles/object_diff/tasks/notification_templates.yml
@@ -1,0 +1,27 @@
+---
+- name: Get the organization ID
+  ansible.builtin.set_fact:
+    __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
+                                              query_params={'name': orgs},
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
+                                   }}"
+
+- name: "Get the API list of all Notification Templates in Organization {{ orgs }}"
+  ansible.builtin.set_fact:
+    __controller_api_notification_templates: "{{ query(controller_api_plugin, 'notification_templates',
+                                          query_params={'organization': __controller_organization_id.id},
+                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                          return_all=true, max_objects=query_controller_api_max_objects)
+                                }}"
+
+- name: "Find the difference of Notification Template between what is on the Controller versus CasC on SCM"
+  ansible.builtin.set_fact:
+    __notification_templates_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
+                                      api_list=__controller_api_notification_templates, compare_list=controller_notifications,
+                                      with_present=false, set_absent=true)
+                            }}"
+
+- name: "Set notification_template's list to be configured"
+  ansible.builtin.set_fact:
+    controller_notifications: "{{ __notification_templates_difference }}"
+...

--- a/roles/object_diff/tasks/schedules.yml
+++ b/roles/object_diff/tasks/schedules.yml
@@ -1,0 +1,48 @@
+---
+- name: Get the organization ID
+  ansible.builtin.set_fact:
+    __controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations',
+                                              query_params={'name': orgs},
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
+                                   }}"
+
+- name: "Get the API list of all WF and Job Templates in Organization {{ orgs }}"
+  ansible.builtin.set_fact:
+    __controller_api_job_templates: "{{ query(controller_api_plugin, 'job_templates',
+                                              query_params={'organization': __controller_organization_id.id},
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                              return_all=true, max_objects=query_controller_api_max_objects)
+                                     }}"
+    __controller_api_workflow_job_templates: "{{ query(controller_api_plugin, 'workflow_job_templates',
+                                              query_params={'organization': __controller_organization_id.id},
+                                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                              return_all=true, max_objects=query_controller_api_max_objects)
+                                     }}"
+
+
+- name: "Get WF and JT IDs"
+  ansible.builtin.set_fact:
+    __controller_api_templates_ids: '{{ __controller_api_job_templates | selectattr("id", "defined") | map(attribute="id") | flatten | unique  +  __controller_api_workflow_job_templates | selectattr("id", "defined") | map(attribute="id") | flatten | unique }}'
+
+- name: "Get the API list of all Schedules"
+  ansible.builtin.set_fact:
+    __controller_api_schedules_prefilter: "{{ query(controller_api_plugin, 'schedules',
+                                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                          return_all=true, max_objects=query_controller_api_max_objects)
+                                }}"
+
+- name: "Get the API list of all Schedules in Organization {{ orgs }}"
+  ansible.builtin.set_fact:
+    __controller_api_schedules: "{{ __controller_api_schedules_prefilter | selectattr('unified_job_template', 'in', __controller_api_templates_ids) }}"
+
+- name: "Find the difference of Schedule between what is on the Controller versus CasC on SCM"
+  ansible.builtin.set_fact:
+    __schedules_difference: "{{ lookup('redhat_cop.controller_configuration.controller_object_diff',
+                                      api_list=__controller_api_schedules, compare_list=controller_schedules,
+                                      with_present=false, set_absent=true)
+                            }}"
+
+- name: "Set schedule's list to be configured"
+  ansible.builtin.set_fact:
+    controller_schedules: "{{ __schedules_difference }}"
+...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Add new object types to object_diff role: applications, execution environments, instance groups, notifications and schedules.

Particular cases: 
- Execution Environments: They will be removed /listed only EE of organization. So, EE which are globaly available (no org), they won't listed or removed with object_diff (disared state of CasC).
- Instance Groups:  They will be filtered by user_capabilities.delete: true to avoid that it try to remove some default instance group.
- Schedules: They doesn't have organization so, object_diff role for this kind of object will search for JT and WFJT of its organization and then, it keep schedules which are in some of the JT and WFTJ. 


# How should this be tested?

Try to add new objects to the controller and launch the object_diff role to check if applications, execution environments, instance groups, notifications and schedules appear now.
