### PR TITLE
add default variable for controller_configuration_filetree_read_secure

### DIFF
--- a/roles/filetree_read/defaults/main.yml
+++ b/roles/filetree_read/defaults/main.yml
@@ -5,6 +5,7 @@
 orgs: "Acme"
 dir_orgs_vars: orgs_vars
 env: dev
+controller_configuration_filetree_read_secure_logging: "{{ controller_configuration_secure_logging | default(true) }}"
 
 # Controller lists
 

--- a/roles/object_diff/defaults/main.yml
+++ b/roles/object_diff/defaults/main.yml
@@ -49,7 +49,7 @@ controller_configuration_object_diff_tasks:
   - {name: credential_types, var: controller_credential_types, tags: credential_types}
   - {name: organizations, var: controller_organizations, tags: organizations}
 
-controller_configuration_object_diff_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
+controller_configuration_object_diff_secure_logging: "{{ controller_configuration_secure_logging | default(true) }}"
 
 controller_api_version: "v2"
 


### PR DESCRIPTION

<!--- markdownlint-disable MD041 -->
# What does this PR do?
controller_configuration_filetree_read_secure_logging did not have default value and it is bringing an error in the populate task.
