### PR TITLE
#496 fix to omit labels if it is not defined

### DIFF
--- a/roles/job_templates/tasks/main.yml
+++ b/roles/job_templates/tasks/main.yml
@@ -52,7 +52,7 @@
     webhook_service:                      "{{ __controller_template_item.webhook_service | default(omit, true) }}"
     webhook_credential:                   "{{ __controller_template_item.webhook_credential | default(omit, true) }}"
     scm_branch:                           "{{ __controller_template_item.scm_branch | default(omit, true) }}"
-    labels:                               "{{ __controller_template_item.labels | default(__controller_template_item.related.labels | default([]) | map(attribute='name') | list) | default(omit) }}"
+    labels:                               "{{ __controller_template_item.labels | default(__controller_template_item.related.labels | default([]) | map(attribute='name') | list if __controller_template_item.related.labels is defined else omit) }}"
     state:                                "{{ __controller_template_item.state | default(controller_state | default('present')) }}"
     notification_templates_started:       "{{ __controller_template_item.notification_templates_started | default(__controller_template_item.related.notification_templates_started | default([]) | map(attribute='name') | list) | default(omit, true) }}"
     notification_templates_success:       "{{ __controller_template_item.notification_templates_success | default(__controller_template_item.related.notification_templates_success | default([]) | map(attribute='name') | list) | default(omit, true) }}"

--- a/roles/schedules/tasks/main.yml
+++ b/roles/schedules/tasks/main.yml
@@ -13,7 +13,7 @@
     forks:                          "{{ __controller_schedule_item.forks | default(omit, true) }}"
     instance_groups:                "{{ __controller_schedule_item.instance_groups | default(omit, true) }}"
     job_slice_count:                "{{ __controller_schedule_item.job_slice_count | default(omit, true) }}"
-    labels:                         "{{ __controller_schedule_item.labels | default(__controller_schedule_item.related.labels | default([]) | map(attribute='name') | list) | default(omit) }}"
+    labels:                         "{{ __controller_schedule_item.labels | default(__controller_schedule_item.related.labels | default([]) | map(attribute='name') | list if __controller_schedule_item.related.labels is defined else omit) }}"
     timeout:                        "{{ __controller_schedule_item.timeout | default(omit, true) }}"
     job_type:                       "{{ __controller_schedule_item.job_type | default(omit, true) }}"
     job_tags:                       "{{ __controller_schedule_item.job_tags | default(omit, true) }}"

--- a/roles/workflow_job_templates/tasks/add_workflows_schema.yml
+++ b/roles/workflow_job_templates/tasks/add_workflows_schema.yml
@@ -20,7 +20,7 @@
     forks:                          "{{ __workflow_loop_node_item.forks | default(omit, true) }}"
     instance_groups:                "{{ __workflow_loop_node_item.instance_groups | default(omit, true) }}"
     job_slice_count:                "{{ __workflow_loop_node_item.job_slice_count | default(omit, true) }}"
-    labels:                         "{{ __workflow_loop_node_item.labels | default(__workflow_loop_node_item.related.labels | default([]) | map(attribute='name') | list) | default(omit) }}"
+    labels:                         "{{ __workflow_loop_node_item.labels | default(__workflow_loop_node_item.related.labels | default([]) | map(attribute='name') | list if __workflow_loop_node_item.related.labels is defined else omit) }}"
     timeout:                        "{{ __workflow_loop_node_item.timeout | default(omit, true) }}"
     approval_node:                  "{{ __workflow_loop_node_item.approval_node | default(omit, true) }}"
     workflow:                       "{{ __workflow_loop_item.name | mandatory }}"        # Workflow job template name to associate with

--- a/roles/workflow_job_templates/tasks/main.yml
+++ b/roles/workflow_job_templates/tasks/main.yml
@@ -12,7 +12,7 @@
     ask_variables_on_launch:            "{{ __workflow_loop_item.ask_variables_on_launch | default(omit) }}"  # only supported starting from Ansible 2.9
     inventory:                          "{{ __workflow_loop_item.inventory.name | default(__workflow_loop_item.inventory | default(omit, true)) }}"
     limit:                              "{{ __workflow_loop_item.limit | default(omit, true) }}"
-    labels:                             "{{ __workflow_loop_item.labels | default(__workflow_loop_item.related.labels | default([]) | map(attribute='name') | list) | default(omit) }}"
+    labels:                             "{{ __workflow_loop_item.labels | default(__workflow_loop_item.related.labels | default([]) | map(attribute='name') | list if __workflow_loop_item.related.labels is defined else omit) }}"
     scm_branch:                         "{{ __workflow_loop_item.scm_branch | default(omit, true) }}"
     ask_inventory_on_launch:            "{{ __workflow_loop_item.ask_inventory_on_launch | default(omit) }}"
     ask_scm_branch_on_launch:           "{{ __workflow_loop_item.ask_scm_branch_on_launch | default(omit) }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

As labels are defined, they always will send something even though they are not defined as code.  It is due to default([]) defined for "related.labels". With this change, labels will be omited if they are not defined as code.

# How should this be tested?

Create JT, WFJT or Schedules as code with defined labels and after that, empty the labels defining it:

labels: []

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #496
