### PR TITLE
Fix linting issues and set to warn on broken lint rule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -19,6 +19,10 @@ skip_list:
   - fqcn[action]
   - fqcn[keyword]
   - meta-runtime  # This collection with the appropriate awx.awx or ansible.controller still works with older ansible.
+  - role-name[path]
+warn_list:
+  - jinja[invalid]  # Temporarily adding this due to https://github.com/ansible/ansible-lint/issues/3048
+  - jinja[spacing]  # Would be set to warn by default and the only flagged issues are fairly unfixable
 kinds:
   - playbooks: "**/examples/templates/*.{yml,yaml}"
   - playbooks: "**/examples/*.{yml,yaml}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ galaxy.yml
 *.tar.gz
 *.pyc
 id_rsa*
+test

--- a/roles/filetree_create/tests/filetree_create.yml
+++ b/roles/filetree_create/tests/filetree_create.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: all
+- name: Filetree Create Test
+  hosts: all
   connection: local
   gather_facts: false
   vars:

--- a/roles/filetree_read/tests/config-controller-filetree.yml
+++ b/roles/filetree_read/tests/config-controller-filetree.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: all
+- name: Filetree read test
+  hosts: all
   connection: local
   gather_facts: false
   vars:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes lint issues caused by update to ansible-lint 6.13.0
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
CI should pass
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
Note that I've set jinja[invalid] to warn for now because the new version has caused a regression in this rule which I've raised a bug for: https://github.com/ansible/ansible-lint/issues/3048
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
