### PR TITLE
avoid to create orgs during drop_diff

### DIFF
--- a/changelogs/fragments/object_diff_role_and_plugin.yml
+++ b/changelogs/fragments/object_diff_role_and_plugin.yml
@@ -1,4 +1,5 @@
 ---
 minor_changes:
   - "Add new type of objects for object_diff role:  applications, execution environments, instance groups, notifications and schedules"
+  - "avoid to create orgs during drop_diff"
 ...

--- a/roles/object_diff/tasks/organizations.yml
+++ b/roles/object_diff/tasks/organizations.yml
@@ -63,6 +63,5 @@
 
     - name: "Set organization's list to be configured"
       ansible.builtin.set_fact:
-        controller_organizations: "{{ __controller_organizations }}"
-      when: __controller_organizations is defined
+        controller_organizations: "{{ __controller_organizations | default([]) }}"
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Due to conditional "when: __controller_organizations is defined", if there are not any org to remove, it was sent the controller_organizations variable read from filetree_read. Then, organizations will try to be created during drop_diff process. 

With this change, if any org has to be removed, an empty list will be sent for controller_organizations.