### PR TITLE
Add back in broken linting rule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -20,8 +20,6 @@ skip_list:
   - fqcn[keyword]
   - meta-runtime  # This collection with the appropriate awx.awx or ansible.controller still works with older ansible.
   - role-name[path]
-warn_list:
-  - jinja[invalid]  # Temporarily adding this due to https://github.com/ansible/ansible-lint/issues/3048
 kinds:
   - playbooks: "**/examples/templates/*.{yml,yaml}"
   - playbooks: "**/examples/*.{yml,yaml}"

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -12,10 +12,11 @@ That role requires the following:
 
 The following variables are required for that role to work properly:
 
-| Variable Name | Default Value | Required | Description |
-| :------------ | :-----------: | :------: | :---------- |
-| `controller_api_plugin` | `ansible.controller` | yes | Full path for the controller_api_plugin to be used. <br/> Can have two possible values: <br/>&nbsp;&nbsp;- awx.awx.controller_api             # For the community Collection version <br/>&nbsp;&nbsp;- ansible.controller.controller_api  # For the Red Hat Certified Collection version|
-| `output_path` | `/tmp/filetree_output` | yes | The path to the output directory where all the generated `yaml` files with the corresponding Objects as code will be written to. |
+| Variable Name | Default Value | Required | Type | Description |
+| :------------ | :-----------: | :------: | :------: | :---------- |
+| `controller_api_plugin` | `ansible.controller` | yes | str | Full path for the controller_api_plugin to be used. <br/> Can have two possible values: <br/>&nbsp;&nbsp;- awx.awx.controller_api             # For the community Collection version <br/>&nbsp;&nbsp;- ansible.controller.controller_api  # For the Red Hat Certified Collection version|
+| `output_path` | `/tmp/filetree_output` | yes | str | The path to the output directory where all the generated `yaml` files with the corresponding Objects as code will be written to. |
+| `input_tag` | `['all']` | no | bool | The tags which are applied to the 'sub-roles'. If 'all' is in the list (the default value) then all roles will be called. |
 
 ## Dependencies
 

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -25,4 +25,7 @@ query_controller_api_max_objects: 10000
 
 controller_configuration_filetree_create_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 
+input_tag:
+  - all
+
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Previously broken linting rule has been fixed in current version of ansible-lint. (Although we merged a pre-release version which I don't like) This shouldn't now fail as the error was a false positive which we had set to warn instead of fail.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
CI will pass
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->

# Other Relevant info, PRs, etc
This issue was fixed: https://github.com/ansible/ansible-lint/issues/3048
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
