### PR TITLE
Avoid double pipeline on PRs

### DIFF
--- a/.github/workflows/ci_testing.yaml
+++ b/.github/workflows/ci_testing.yaml
@@ -1,6 +1,14 @@
 ---
 name: Run Test Playbooks on AWX workflow
-on: [push, pull_request]
+on:
+  push:
+    branches: ['*_']
+    tags:
+    - '*_'  # ending underscore for trying things
+    - 'v[0-9]+.[0-9]+.[0-9]+'  # final version
+    - 'v[0-9]+.[0-9]+.[0-9]+[abrc]+[0-9]+'  # alpha, beta, release candidate (rc)
+    - 'v[0-9]+.[0-9]+.[0-9]+.dev[0-9]+'  # development versions
+  pull_request:
 
 jobs:
   Integration-test:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,8 +5,14 @@ name: pre-commit tests
 
 
 on:
-  pull_request:
   push:
+    branches: ['*_']
+    tags:
+    - '*_'  # ending underscore for trying things
+    - 'v[0-9]+.[0-9]+.[0-9]+'  # final version
+    - 'v[0-9]+.[0-9]+.[0-9]+[abrc]+[0-9]+'  # alpha, beta, release candidate (rc)
+    - 'v[0-9]+.[0-9]+.[0-9]+.dev[0-9]+'  # development versions
+  pull_request:
   schedule:
     - cron: "0 6 * * *"
 


### PR DESCRIPTION


<!--- markdownlint-disable MD041 -->
# What does this PR do?

I got annoyed by unstable pipelines running twice on each PR. The changes should make sure that the pipeline only triggers on very specific pushes. The devel branch is anyway protected so that it can only be modified by pull requests

# How should this be tested?

Create a PR and enjoy to have e.g. pre-commit running only once. You can also create a branch (or a tag) ending in underscore to see how the pipeline triggers.

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
n/a

# Other Relevant info, PRs, etc

n/a
