### PR TITLE
Fix dispatch to use general vars instead of specific hostvars

### DIFF
--- a/changelogs/fragments/dispatch_fix.yml
+++ b/changelogs/fragments/dispatch_fix.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Ensures vars get loaded properly by dispatch role
+...

--- a/roles/dispatch/tasks/main.yml
+++ b/roles/dispatch/tasks/main.yml
@@ -4,7 +4,7 @@
     name: "{{ __role.role }}"
     apply:
       tags: "{{ __role.tags }}"
-  when: hostvars[inventory_hostname][__role.var] is defined
+  when: vars[__role.var] is defined
   tags: always
   loop: "{{ controller_configuration_dispatcher_roles }}"
   loop_control:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Change the when clause for variable lookup of the dispatch role to vars instead of hostvars

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
This should not modify behavior except for also including vars that are for example set on the play level.

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

No
