### PR TITLE
Up delay on projects async to prevent failures

### DIFF
--- a/tests/configs/projects.yml
+++ b/tests/configs/projects.yml
@@ -1,6 +1,6 @@
 ---
 controller_configuration_projects_async_retries: 60
-controller_configuration_projects_async_delay: 3
+controller_configuration_projects_async_delay: 5
 controller_projects:
   - name: Test Project
     scm_type: git


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Increases delay on the project creation async because it regularly fails there randomly (presumably because its slow to do the project pull)
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
CI will be more stable
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
No
# Other Relevant info, PRs, etc
N/A
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
