### PR TITLE
An inventory source is not ever assigned to an organization

### DIFF
--- a/roles/filetree_create/templates/current_inventory_sources.j2
+++ b/roles/filetree_create/templates/current_inventory_sources.j2
@@ -3,7 +3,9 @@ controller_inventory_sources:
 {% for inventory_source in current_inventory_sources_asset_value %}
   - name: "{{ inventory_source.name }}"
     description: "{{ inventory_source.description }}"
-    organization: "{{ inventory_source.summary_fields.organization.name | default('ToDo: The Inventory Source \'' + inventory_source.name + '\' must belong to an organization') }}"
+{% if inventory_source.summary_fields.organization %}
+    organization: "{{ inventory_source.summary_fields.organization.name }}"
+{% endif %}
     source: "{{ inventory_source.source | default('ToDo: The source of the inventory_source was originally missing and must be specified',true) }}"
 {% if inventory_source.source_project %}
     source_project: "{{ inventory_source.summary_fields.source_project.name }}"

--- a/roles/filetree_create/templates/current_inventory_sources.j2
+++ b/roles/filetree_create/templates/current_inventory_sources.j2
@@ -3,7 +3,7 @@ controller_inventory_sources:
 {% for inventory_source in current_inventory_sources_asset_value %}
   - name: "{{ inventory_source.name }}"
     description: "{{ inventory_source.description }}"
-    organization: "{{ inventory_source.summary_fields.organization.name }}"
+    organization: "{{ inventory_source.summary_fields.organization.name | default('ToDo: The Inventory Source \'' + inventory_source.name + '\' must belong to an organization') }}"
     source: "{{ inventory_source.source | default('ToDo: The source of the inventory_source was originally missing and must be specified',true) }}"
 {% if inventory_source.source_project %}
     source_project: "{{ inventory_source.summary_fields.source_project.name }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

<!--- Brief explanation of the code or documentation change you've made -->
When exporting an inventory source, if it has not associated organization, the filetree_create role will fail as no organization field is found. This is fixing that error and setting a ToDo organization name instead.

# How should this be tested?

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Automatic tests.

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A