### PR TITLE
fix issue #594 for roles with blank spaces in the name

### DIFF
--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -202,7 +202,7 @@ class LookupModule(LookupBase):
             for item in api_list_reduced:
                 if item["resource_type"] == "organization":
                     item.update({"organizations": [item[item["resource_type"]]]})
-                item.update({"role": item["name"].lower()})
+                item.update({"role": item["name"].lower().replace(" ", "_")})
                 # Remove the extra fields
                 item.pop("users")
                 item.pop("teams")


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Fix issue #594. Role name has blank spaces for role types:

"project_admin"
"inventory_admin"
"credential_admin"
"workflow_admin"
"notification_admin"
"job_template_admin"
"execution_environment_admin"

It can be checked going to the API and look for some role with one of this type.

This role name is setting as role in the plugin controller_object_diff.py:

`                item.update({"role": item["name"].lower()})
`

And this value is not valid so we need no change the blank spaces for underscores:

`                item.update({"role": item["name"].lower().replace(" ", "_")})
`

# How should this be tested?

```
>>> my_string = "This is a sample String"
>>> my_string = my_string.lower().replace(" ", "_")
>>> print(my_string)
this_is_a_sample_string
```


# Is there a relevant Issue open for this?

 #594

