### PR TITLE
add options to roles role

### DIFF
--- a/changelogs/fragments/roles_update.yml
+++ b/changelogs/fragments/roles_update.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - added option to roles role to support upcoming change to allow lists of teams and users to be used in the module.
+...

--- a/roles/roles/README.md
+++ b/roles/roles/README.md
@@ -75,7 +75,9 @@ This also speeds up the overall role.
 |Variable Name|Default Value|Required|Type|Description|
 |:---:|:---:|:---:|:---:|:---:|
 |`user`|""|no|str|The user for which the role applies|
+|`users`|""|no|list|The users for which the role applies|
 |`team`|""|no|str|The team for which the role applies|
+|`teams`|""|no|list|The teams for which the role applies|
 |`role`|""|no|str (see note below)|The role which is applied to one of {`target_team`, `inventory`, `job_template`, `target_team`, `inventory`, `job_template`} for either `user` or `team` |
 |`target_team`|""|no|str|The team the role applies against|
 |`target_teams`|""|no|list|The teams the role applies against|
@@ -140,6 +142,9 @@ This also speeds up the overall role.
 ---
 controller_roles:
 - user: jdoe
+  users:
+    - thing1
+    - thing2
   target_team: "My Team"
   role: member
 - team: "My Team"

--- a/roles/roles/tasks/main.yml
+++ b/roles/roles/tasks/main.yml
@@ -2,7 +2,9 @@
 - name: Create Role Based Access Entry on Controller
   role:
     user:                           "{{ __controller_role_item.user | default(omit, true) }}"
+    users:                          "{{ __controller_role_item.user | default(( [] if controller_configuration_role_enforce_defaults else omit), true) }}"
     team:                           "{{ __controller_role_item.team | default(omit, true) }}"
+    teams:                          "{{ __controller_role_item.team | default(( [] if controller_configuration_role_enforce_defaults else omit), true) }}"
     role:                           "{{ __controller_role_item.role | mandatory }}"
     target_team:                    "{{ __controller_role_item.target_team | default(omit, true) }}"
     target_teams:                   "{{ __controller_role_item.target_teams | default(( [] if controller_configuration_role_enforce_defaults else omit), true) }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
add options to roles role. This is not live in a published awx.awx collection but it has been merged.
Adds teams/users as options so that lists can be consolidated.

# How should this be tested?
Additional tests should be added later, adding now will fail CI.


# Other Relevant info, PRs, etc
https://github.com/ansible/awx/pull/13930
