### PR TITLE
#630 - Fix default for enforce_defaults

### DIFF
--- a/roles/applications/defaults/main.yml
+++ b/roles/applications/defaults/main.yml
@@ -4,5 +4,5 @@ controller_applications: []
 controller_configuration_applications_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_applications_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_applications_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_applications_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_applications_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/credential_input_sources/defaults/main.yml
+++ b/roles/credential_input_sources/defaults/main.yml
@@ -4,5 +4,5 @@ controller_credential_input_sources: []
 controller_configuration_credential_input_sources_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_credential_input_sources_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_credential_input_sources_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_credential_input_sources_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_credential_input_sources_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/credential_types/defaults/main.yml
+++ b/roles/credential_types/defaults/main.yml
@@ -4,5 +4,5 @@ controller_credential_types: []
 controller_configuration_credential_types_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_credential_types_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_credential_types_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_credential_types_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_credential_types_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/credentials/defaults/main.yml
+++ b/roles/credentials/defaults/main.yml
@@ -4,5 +4,5 @@ controller_credentials: []
 controller_configuration_credentials_secure_logging: "{{ controller_configuration_secure_logging | default(true) }}"
 controller_configuration_credentials_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_credentials_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_credentials_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_credentials_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/execution_environments/defaults/main.yml
+++ b/roles/execution_environments/defaults/main.yml
@@ -3,5 +3,5 @@
 controller_configuration_execution_environments_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_execution_environments_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_execution_environments_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_execution_environments_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_execution_environments_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/groups/defaults/main.yml
+++ b/roles/groups/defaults/main.yml
@@ -4,5 +4,5 @@ controller_groups: []
 controller_configuration_group_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_group_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_group_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_groups_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_groups_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/hosts/defaults/main.yml
+++ b/roles/hosts/defaults/main.yml
@@ -4,5 +4,5 @@ controller_hosts: []
 controller_configuration_hosts_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_hosts_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_hosts_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_host_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_host_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/instance_groups/defaults/main.yml
+++ b/roles/instance_groups/defaults/main.yml
@@ -3,5 +3,5 @@ controller_instance_groups: []
 controller_configuration_instance_groups_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_instance_groups_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_instance_groups_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_instance_groups_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_instance_groups_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/instances/defaults/main.yml
+++ b/roles/instances/defaults/main.yml
@@ -3,5 +3,5 @@ controller_instances: []
 controller_configuration_instances_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_instances_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_instances_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_instances_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_instances_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/inventories/defaults/main.yml
+++ b/roles/inventories/defaults/main.yml
@@ -4,5 +4,5 @@ controller_inventories: []
 controller_configuration_inventories_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_inventories_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_inventories_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_inventories_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_inventories_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/inventory_sources/defaults/main.yml
+++ b/roles/inventory_sources/defaults/main.yml
@@ -3,5 +3,5 @@ controller_inventory_sources: []
 controller_configuration_inventory_sources_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_inventory_sources_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_inventory_sources_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_inventory_sources_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_inventory_sources_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/job_templates/defaults/main.yml
+++ b/roles/job_templates/defaults/main.yml
@@ -4,5 +4,5 @@ controller_templates: []
 controller_configuration_job_templates_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_job_templates_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_job_templates_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_job_templates_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_job_templates_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/notification_templates/defaults/main.yml
+++ b/roles/notification_templates/defaults/main.yml
@@ -4,5 +4,5 @@ controller_notifications: []
 controller_configuration_notifications_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_notifications_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_notifications_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_notifications_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_notifications_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/organizations/defaults/main.yml
+++ b/roles/organizations/defaults/main.yml
@@ -3,7 +3,7 @@ controller_organizations: []
 controller_configuration_organizations_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_organizations_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_organizations_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_organizations_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_organizations_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 assign_galaxy_credentials_to_org: true
 assign_default_ee_to_org: true
 ...

--- a/roles/projects/defaults/main.yml
+++ b/roles/projects/defaults/main.yml
@@ -4,5 +4,5 @@ controller_projects: []
 controller_configuration_projects_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_projects_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_projects_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_projects_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_projects_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/roles/defaults/main.yml
+++ b/roles/roles/defaults/main.yml
@@ -4,5 +4,5 @@ controller_roles: []
 controller_configuration_role_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_role_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_role_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_role_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_role_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/schedules/defaults/main.yml
+++ b/roles/schedules/defaults/main.yml
@@ -4,5 +4,5 @@ controller_schedules: []
 controller_configuration_schedules_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_schedules_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_schedules_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_schedules_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_schedules_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/teams/defaults/main.yml
+++ b/roles/teams/defaults/main.yml
@@ -4,5 +4,5 @@ controller_teams: []
 controller_configuration_teams_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_teams_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_teams_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_teams_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_teams_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/users/defaults/main.yml
+++ b/roles/users/defaults/main.yml
@@ -8,5 +8,5 @@ controller_user_default_password: "change_me"
 controller_configuration_users_secure_logging: "{{ controller_configuration_secure_logging | default('true') }}"
 controller_configuration_users_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_users_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_users_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_users_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/workflow_job_templates/defaults/main.yml
+++ b/roles/workflow_job_templates/defaults/main.yml
@@ -4,5 +4,5 @@ controller_workflows: []
 workflow_job_templates_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_workflow_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_workflow_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
-controller_configuration_workflows_enforce_defaults: "{{ controller_configuration_enforce_defaults | default('false') }}"
+controller_configuration_workflows_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes the default enforce_default value to be `false` rather than the truthy value of `'false'`
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
We might want to add some kind of CI around this. Should we raise an issue to do this?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #630 

# Other Relevant info, PRs, etc
N/A
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
