### PR TITLE
#626 remove depencency of CONTROLER_USERNAME variable for object_diff role

### DIFF
--- a/changelogs/fragments/remove_username_dependency_objectdiff
+++ b/changelogs/fragments/remove_username_dependency_objectdiff
@@ -1,2 +1,0 @@
-minor_changes:
-  - remove depencency of CONTROLER_USERNAME variable for object_diff role by calling the API with api/me instead of calling the api/users and filtering by username

--- a/changelogs/fragments/remove_username_dependency_objectdiff
+++ b/changelogs/fragments/remove_username_dependency_objectdiff
@@ -1,0 +1,2 @@
+minor_changes:
+  - remove depencency of CONTROLER_USERNAME variable for object_diff role by calling the API with api/me instead of calling the api/users and filtering by username

--- a/changelogs/fragments/remove_username_dependency_objectdiff.yml
+++ b/changelogs/fragments/remove_username_dependency_objectdiff.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - remove depencency of CONTROLER_USERNAME variable for object_diff role by calling the API with api/me instead of calling the api/users and filtering by username

--- a/roles/object_diff/tasks/hosts.yml
+++ b/roles/object_diff/tasks/hosts.yml
@@ -14,8 +14,7 @@
                                               'has_inventory_sources': 'false',
                                               'not__total_hosts': '0',
                                               'not__kind': 'smart'},
-                                            host=controller_hostname, username=controller_username,
-                                            oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                                            host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                             return_all=true, max_objects=query_controller_api_max_objects)
                                    }}"
   no_log: "{{ controller_configuration_object_diff_secure_logging }}"

--- a/roles/object_diff/tasks/instance_groups.yml
+++ b/roles/object_diff/tasks/instance_groups.yml
@@ -1,8 +1,7 @@
 ---
 - name: "Get the current controller user to determine if it is super-admin"
   ansible.builtin.set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
-                                                              query_params={'username': controller_username},
+    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'me',
                                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                                    }}"
 

--- a/roles/object_diff/tasks/organizations.yml
+++ b/roles/object_diff/tasks/organizations.yml
@@ -1,8 +1,7 @@
 ---
 - name: "Get the current controller user to determine if it is super-admin"
   ansible.builtin.set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
-                                                              query_params={'username': controller_username},
+    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'me',
                                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                                    }}"
   no_log: "{{ controller_configuration_object_diff_secure_logging }}"

--- a/roles/object_diff/tasks/roles.yml
+++ b/roles/object_diff/tasks/roles.yml
@@ -1,8 +1,7 @@
 ---
 - name: "Get the current controller user to determine if it is super-admin"
   ansible.builtin.set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
-                                                              query_params={'username': controller_username},
+    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'me',
                                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                                    }}"
   no_log: "{{ controller_configuration_object_diff_secure_logging }}"

--- a/roles/object_diff/tasks/teams.yml
+++ b/roles/object_diff/tasks/teams.yml
@@ -1,8 +1,7 @@
 ---
 - name: "Get the current controller user to determine if it is super-admin"
   ansible.builtin.set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
-                                                              query_params={'username': controller_username},
+    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'me',
                                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                                    }}"
   no_log: "{{ controller_configuration_object_diff_secure_logging }}"

--- a/roles/object_diff/tasks/user_accounts.yml
+++ b/roles/object_diff/tasks/user_accounts.yml
@@ -2,8 +2,7 @@
 # tasks file for controller_ldap_settings
 - name: "Get the current controller user to determine if it is super-admin"
   ansible.builtin.set_fact:
-    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'users',
-                                                              query_params={'username': controller_username},
+    __controller_api_current_user_check_is_admin: "{{ lookup(controller_api_plugin, 'me',
                                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)
                                                    }}"
   no_log: "{{ controller_configuration_object_diff_secure_logging }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

remove depencency of CONTROLER_USERNAME variable for object_diff role by calling the API with api/me instead of calling the api/users and filtering by username

# How should this be tested?

Launch object_diff role in order to try to remove some objects with dispatch role.

# Is there a relevant Issue open for this?

#626 
