### PR TITLE
add organizations tag to second dispatch task

### DIFF
--- a/changelogs/fragments/add_organizations_tag.yml
+++ b/changelogs/fragments/add_organizations_tag.yml
@@ -1,3 +1,2 @@
 minor_changes:
   - add organizations tag in a dispatch task which is in charge of applying galaxy credencitals in the organization.
-

--- a/changelogs/fragments/add_organizations_tag.yml
+++ b/changelogs/fragments/add_organizations_tag.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - add organizations tag in a dispatch task which is in charge of applying galaxy credencitals in the organization.
+

--- a/roles/dispatch/tasks/main.yml
+++ b/roles/dispatch/tasks/main.yml
@@ -19,4 +19,5 @@
     apply:
       tags:
         - organizations
+  tags: organizations
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

The second task of dispatch role was not being executed when organizations tag was sent. With this change, organizations will be created properly when organizations tag is present in the execution.

# How should this be tested?

Add a new organization using the organizations tag in the execution.

