### PR TITLE
Filetree create schedules instance groups

### DIFF
--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -21,6 +21,7 @@ jobs:
           - devel
           - 22.4.0
           - 22.3.0
+          - 21.13.0
           - 21.11.0
     uses: "./.github/workflows/ci_standalone_versioned.yml"
     with:

--- a/roles/filetree_create/tasks/schedules.yml
+++ b/roles/filetree_create/tasks/schedules.yml
@@ -24,13 +24,13 @@
     __dest: "{{ output_path }}/schedules/{{ label_id }}_{{ label_name | regex_replace('/', '_') }}.yaml"
     query_credentials: "{{ query(controller_api_plugin, current_schedules_asset_value.related.credentials,
                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                 return_all=true, max_objects=query_controller_api_max_objects) }}"
+                 return_all=true, max_objects=query_controller_api_max_objects) if current_schedules_asset_value.related.credentials is defined else [] }}"
     query_instance_groups: "{{ query(controller_api_plugin, current_schedules_asset_value.related.instance_groups,
                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                  return_all=true, max_objects=query_controller_api_max_objects) if current_schedules_asset_value.related.instance_groups is defined else [] }}"
     query_labels: "{{ query(controller_api_plugin, current_schedules_asset_value.related.labels,
                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                 return_all=true, max_objects=query_controller_api_max_objects) }}"
+                 return_all=true, max_objects=query_controller_api_max_objects) if current_schedules_asset_value.related.labels is defined else [] }}"
   loop: "{{ schedules_lookvar }}"
   loop_control:
     loop_var: current_schedules_asset_value

--- a/roles/filetree_create/tasks/schedules.yml
+++ b/roles/filetree_create/tasks/schedules.yml
@@ -27,7 +27,7 @@
                  return_all=true, max_objects=query_controller_api_max_objects) }}"
     query_instance_groups: "{{ query(controller_api_plugin, current_schedules_asset_value.related.instance_groups,
                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                 return_all=true, max_objects=query_controller_api_max_objects) }}"
+                 return_all=true, max_objects=query_controller_api_max_objects) if current_schedules_asset_value.related.instance_groups is defined else [] }}"
     query_labels: "{{ query(controller_api_plugin, current_schedules_asset_value.related.labels,
                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                  return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/templates/current_schedules.j2
+++ b/roles/filetree_create/templates/current_schedules.j2
@@ -16,10 +16,18 @@ controller_schedules:
       - "{{ instance_group.name }}"
 {% endfor %}
 {% endif %}
+{% if current_schedules_asset_value.dtstart is defined %}
     dtstart: "{{ current_schedules_asset_value.dtstart }}"
+{% endif %}
+{% if current_schedules_asset_value.dtend is defined %}
     dtend: "{{ current_schedules_asset_value.dtend }}"
+{% endif %}
+{% if current_schedules_asset_value.timezone is defined %}
     timezone: "{{ current_schedules_asset_value.timezone }}"
+{% endif %}
+{% if current_schedules_asset_value.rrule is defined %}
     rrule: "{{ current_schedules_asset_value.rrule }}"
+{% endif %}
 {% if current_schedules_asset_value.summary_fields.execution_environment is defined %}
     execution_environment: "{{ current_schedules_asset_value.summary_fields.execution_environment.name }}"
 {% endif %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
When exporting schedules, if they don't have instance_groups associated, they are causing the export to fail. This PR fixes this problem.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Tested manually. Automated tests also.
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
N/A
<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!--- resolves #[number] -->

# Other Relevant info, PRs, etc
N/A
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
