### PR TITLE
Change lookup to query to ensure list

### DIFF
--- a/changelogs/fragments/change_from_lookup_to_query.yml
+++ b/changelogs/fragments/change_from_lookup_to_query.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - 'Fix addition of `state: present` when `with_present: true`'
+minor_changes:
+  - Change from lookup to query in the object_diff task files

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -67,7 +67,7 @@ EXAMPLES = """
 
 - name: "Find the difference of Project between what is on the Controller versus curated list."
   set_fact:
-    project_difference: "{{ lookup('infra.controller_configuration.controller_object_diff',
+    project_difference: "{{ query('infra.controller_configuration.controller_object_diff',
       api_list=controller_api_results, compare_list=differential_item.differential_test_items,
       with_present=true, set_absent=true ) }}"
 

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -295,7 +295,7 @@ class LookupModule(LookupBase):
                 item.update({"state": "absent"})
         # Combine Lists
         if self.get_option("with_present"):
-            self.create_present_list(compare_list_reduced)
+            compare_list = self.create_present_list(compare_list)
             compare_list.extend(difference)
             # Return Compare list with difference attached
             difference = compare_list

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -106,11 +106,12 @@ class LookupModule(LookupBase):
         self.display.warning(warning)
 
     def create_present_list(self, compare_list):
-        if not compare_list:
+        if not compare_list and not isinstance(compare_list, list):
             return [compare_list]
 
         for item in compare_list:
             item.update({"state": "present"})
+
         return compare_list
 
     def run(self, terms, variables=None, **kwargs):
@@ -307,4 +308,4 @@ class LookupModule(LookupBase):
             for item in difference_to_remove:
                 difference.remove(item)
 
-        return [difference]
+        return difference

--- a/roles/object_diff/tasks/applications.yml
+++ b/roles/object_diff/tasks/applications.yml
@@ -16,7 +16,7 @@
 
 - name: "Find the difference of Application between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
-    __applications_difference: "{{ lookup(controller_role_plugin,
+    __applications_difference: "{{ query(controller_role_plugin,
                                       api_list=__controller_api_applications, compare_list=controller_applications,
                                       with_present=include_present_state, set_absent=true)
                             }}"

--- a/roles/object_diff/tasks/credential_types.yml
+++ b/roles/object_diff/tasks/credential_types.yml
@@ -22,7 +22,7 @@
 
 - name: "Find the difference of Credential Types between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
-    __credential_types_difference: "{{ lookup(controller_role_plugin,
+    __credential_types_difference: "{{ query(controller_role_plugin,
       api_list=__controller_api_credential_types, compare_list=controller_credential_types,
       with_present=include_present_state, set_absent=true) }}"
 

--- a/roles/object_diff/tasks/credentials.yml
+++ b/roles/object_diff/tasks/credentials.yml
@@ -19,7 +19,7 @@
 
 - name: "Find the difference of Credentials between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
-    __credentials_difference: "{{ lookup(controller_role_plugin,
+    __credentials_difference: "{{ query(controller_role_plugin,
                                           api_list=__controller_api_credentials, compare_list=controller_credentials,
                                           with_present=include_present_state, set_absent=true)
                                }}"

--- a/roles/object_diff/tasks/execution_environments.yml
+++ b/roles/object_diff/tasks/execution_environments.yml
@@ -16,7 +16,7 @@
 
 - name: "Find the difference of Execution Environment between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
-    __execution_environments_difference: "{{ lookup(controller_role_plugin,
+    __execution_environments_difference: "{{ query(controller_role_plugin,
                                       api_list=__controller_api_execution_environments, compare_list=controller_execution_environments,
                                       with_present=include_present_state, set_absent=true)
                             }}"

--- a/roles/object_diff/tasks/groups.yml
+++ b/roles/object_diff/tasks/groups.yml
@@ -36,7 +36,7 @@
   block:
     - name: "Find the difference of Groups between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
-        __groups_difference: "{{ lookup(controller_role_plugin,
+        __groups_difference: "{{ query(controller_role_plugin,
                                         query_params={'summary_fields.inventory.organization_id': controller_organization_id.id},
                                         api_list=__controller_api_groups, compare_list=controller_groups,
                                         with_present=include_present_state, set_absent=true)

--- a/roles/object_diff/tasks/hosts.yml
+++ b/roles/object_diff/tasks/hosts.yml
@@ -36,7 +36,7 @@
   block:
     - name: "Find the difference of Hosts between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
-        __hosts_difference: "{{ lookup(controller_role_plugin,
+        __hosts_difference: "{{ query(controller_role_plugin,
                                         query_params={'summary_fields.inventory.organization_id': controller_organization_id.id},
                                         api_list=__controller_api_hosts, compare_list=controller_hosts,
                                         with_present=include_present_state, set_absent=true)

--- a/roles/object_diff/tasks/instance_groups.yml
+++ b/roles/object_diff/tasks/instance_groups.yml
@@ -18,7 +18,7 @@
 
     - name: "Find the difference of Instance Groups between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
-        __instance_groups_difference: "{{ lookup(controller_role_plugin,
+        __instance_groups_difference: "{{ query(controller_role_plugin,
                                         api_list=__controller_api_instance_groups,
                                         compare_list=controller_instance_groups,
                                         with_present=include_present_state,

--- a/roles/object_diff/tasks/inventories.yml
+++ b/roles/object_diff/tasks/inventories.yml
@@ -18,7 +18,7 @@
 
 - name: "Find the difference of Inventories between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
-    __inventories_difference: "{{ lookup(controller_role_plugin,
+    __inventories_difference: "{{ query(controller_role_plugin,
                                          api_list=__controller_api_inventories, compare_list=controller_inventories,
                                          with_present=include_present_state, set_absent=true)
                                }}"

--- a/roles/object_diff/tasks/inventory_sources.yml
+++ b/roles/object_diff/tasks/inventory_sources.yml
@@ -18,7 +18,7 @@
 
 - name: "Find the difference of Inventory Sources between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
-    __inventory_sources_difference: "{{ lookup(controller_role_plugin,
+    __inventory_sources_difference: "{{ query(controller_role_plugin,
                                                 api_list=__controller_api_inventory_sources,
                                                 compare_list=controller_inventory_sources,
                                                 with_present=include_present_state, set_absent=true)

--- a/roles/object_diff/tasks/job_templates.yml
+++ b/roles/object_diff/tasks/job_templates.yml
@@ -18,7 +18,7 @@
 
 - name: "Find the difference of Job Templates between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
-    __job_templates_difference: "{{ lookup(controller_role_plugin,
+    __job_templates_difference: "{{ query(controller_role_plugin,
                                             api_list=__controller_api_job_templates, compare_list=controller_templates,
                                             with_present=include_present_state, set_absent=true)
                                  }}"

--- a/roles/object_diff/tasks/notification_templates.yml
+++ b/roles/object_diff/tasks/notification_templates.yml
@@ -16,7 +16,7 @@
 
 - name: "Find the difference of Notification Template between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
-    __notification_templates_difference: "{{ lookup(controller_role_plugin,
+    __notification_templates_difference: "{{ query(controller_role_plugin,
                                       api_list=__controller_api_notification_templates, compare_list=controller_notifications,
                                       with_present=include_present_state, set_absent=true)
                             }}"

--- a/roles/object_diff/tasks/organizations.yml
+++ b/roles/object_diff/tasks/organizations.yml
@@ -20,7 +20,7 @@
 
     - name: "Find the difference of Organizations between what is on the Controller versus curated list."
       ansible.builtin.set_fact:
-        __organizations_difference: "{{ lookup(controller_role_plugin,
+        __organizations_difference: "{{ query(controller_role_plugin,
                                                 api_list=__controller_api_organizations, compare_list=controller_organizations,
                                                 with_present=include_present_state, set_absent=true)
                                      }}"

--- a/roles/object_diff/tasks/projects.yml
+++ b/roles/object_diff/tasks/projects.yml
@@ -18,7 +18,7 @@
 
 - name: "Find the difference of Project between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
-    __projects_difference: "{{ lookup(controller_role_plugin,
+    __projects_difference: "{{ query(controller_role_plugin,
                                       api_list=__controller_api_projects, compare_list=controller_projects,
                                       with_present=include_present_state, set_absent=true)
                             }}"

--- a/roles/object_diff/tasks/roles.yml
+++ b/roles/object_diff/tasks/roles.yml
@@ -52,7 +52,7 @@
 
     - name: "Find the difference of Roles between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
-        __roles_difference: "{{ lookup(controller_role_plugin,
+        __roles_difference: "{{ query(controller_role_plugin,
                                         api_list=__full_controller_api_roles, compare_list=controller_roles,
                                         with_present=include_present_state, set_absent=true)
                              }}"

--- a/roles/object_diff/tasks/schedules.yml
+++ b/roles/object_diff/tasks/schedules.yml
@@ -37,7 +37,7 @@
 
 - name: "Find the difference of Schedule between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
-    __schedules_difference: "{{ lookup(controller_role_plugin,
+    __schedules_difference: "{{ query(controller_role_plugin,
                                       api_list=__controller_api_schedules, compare_list=controller_schedules,
                                       with_present=include_present_state, set_absent=true)
                             }}"

--- a/roles/object_diff/tasks/teams.yml
+++ b/roles/object_diff/tasks/teams.yml
@@ -29,7 +29,7 @@
 
     - name: "Find the difference of Teams between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
-        __teams_difference: "{{ lookup(controller_role_plugin,
+        __teams_difference: "{{ query(controller_role_plugin,
                                         api_list=__controller_api_teams,
                                         compare_list=controller_teams,
                                         with_present=include_present_state,

--- a/roles/object_diff/tasks/user_accounts.yml
+++ b/roles/object_diff/tasks/user_accounts.yml
@@ -35,7 +35,7 @@
   block:
     - name: "Find the difference of User Accounts between what is on the Controller versus CasC on SCM"
       ansible.builtin.set_fact:
-        __user_accounts_difference: "{{ lookup(controller_role_plugin,
+        __user_accounts_difference: "{{ query(controller_role_plugin,
                                                 api_list=__controller_api_user_accounts, compare_list=controller_user_accounts,
                                                 with_present=include_present_state, set_absent=true)
                                      }}"

--- a/roles/object_diff/tasks/workflow_job_templates.yml
+++ b/roles/object_diff/tasks/workflow_job_templates.yml
@@ -18,7 +18,7 @@
 
 - name: "Find the difference of Workflow Job Templates between what is on the Controller versus CasC on SCM"
   ansible.builtin.set_fact:
-    __workflow_job_templates_difference: "{{ lookup(controller_role_plugin,
+    __workflow_job_templates_difference: "{{ query(controller_role_plugin,
                                                     api_list=__controller_api_workflow_job_templates,
                                                     compare_list=controller_workflows,
                                                     with_present=include_present_state, set_absent=true)

--- a/tests/configs/differential_items.yml
+++ b/tests/configs/differential_items.yml
@@ -45,17 +45,20 @@ differential_items:
         organization: Default
         scm_type: git
         scm_url: https://github.com/ansible/tower-example.git
+        state: present
       - description: ansible-examples
         name: Test Inventory source project
         organization: Default
         scm_type: git
         scm_url: https://github.com/ansible/ansible-examples.git
+        state: present
       - credential: gitlab-personal-access-token for satqe_auto_droid
         description: ansible-examples
         name: Test Inventory source project with credential
         organization: Default
         scm_type: git
         scm_url: https://github.com/ansible/ansible-examples.git
+        state: present
         wait: false
       - description: Test Project 1
         name: Test Project
@@ -64,6 +67,7 @@ differential_items:
         scm_clean: true
         scm_type: git
         scm_url: https://github.com/ansible/tower-example.git
+        state: present
       - name: Demo Project
         organization: Default
         state: absent

--- a/tests/configure_controller.yml
+++ b/tests/configure_controller.yml
@@ -183,13 +183,13 @@
 
     - name: "Error out on empty list"
       ansible.builtin.set_fact:
-        error_empty_diff: "{{ lookup('controller_object_diff', api_list=controller_api_results, compare_list=differential_test_items, warn_on_empty_api=false) }}"
+        error_empty_diff: "{{ query('controller_object_diff', api_list=controller_api_results, compare_list=differential_test_items, warn_on_empty_api=false) }}"
       ignore_errors: true
       register: error_results
 
     - name: "Warn out on empty list"
       ansible.builtin.set_fact:
-        warn_empty_diff: "{{ lookup('controller_object_diff', api_list=controller_api_results, compare_list=differential_test_items) }}"
+        warn_empty_diff: "{{ query('controller_object_diff', api_list=controller_api_results, compare_list=differential_test_items) }}"
       register: warn_results
 
     - name: "Assert that the empty list error correctly"

--- a/tests/tasks/differential.yml
+++ b/tests/tasks/differential.yml
@@ -1,11 +1,11 @@
 ---
 - name: "Get the API list in the Default Organization of all {{ differential_item.name }}"
   ansible.builtin.set_fact:
-    controller_api_results: "{{ lookup(controller_api_plugin, differential_item.name, query_params={'organization': controller_organization_id.id}, host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=false) }}"
+    controller_api_results: "{{ query(controller_api_plugin, differential_item.name, query_params={'organization': controller_organization_id.id}, host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=false) }}"
 
 - name: "Find the difference between what is on the Controller versus curated list of {{ differential_item.name }}"
   ansible.builtin.set_fact:
-    set_absent_diff: "{{ lookup('controller_object_diff', api_list=controller_api_results, compare_list=differential_item.differential_test_items, with_present=differential_item.with_present) }}"
+    set_absent_diff: "{{ query('controller_object_diff', api_list=controller_api_results, compare_list=differential_item.differential_test_items, with_present=differential_item.with_present) }}"
 
 - name: Display set_absent_diff
   ansible.builtin.debug:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

When first configuring an organization with only 1 inventory defined, the configuration fails with the message:
`argument 'controller_inventories' is of type <class 'dict'> and we were unable to convert to list`

The diff_role tasks use the `lookup` plugin to calculate the differences, which doesn't necessarily create a list when it recieves one item. This change will move from `lookup` to `query`, which will always return a list (see relevant link for more info)

# How should this be tested?

1. Create an empty organization (without inventories)
2. Define 1 inventory for created organization
3. Run the configuraion with diff_role and `with_present: true`

# Other Relevant info, PRs, etc

https://docs.ansible.com/ansible/latest/plugins/lookup.html#forcing-lookups-to-return-lists-query-and-wantlist-true
