### PR TITLE
filetree_create now allows to export objects for the specified organization

### DIFF
--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -21,6 +21,7 @@ jobs:
           - devel
           - 22.4.0
           - 22.3.0
+          - 21.13.0
           - 21.11.0
     uses: "./.github/workflows/ci_standalone_versioned.yml"
     with:

--- a/changelogs/fragments/610-filetree_create-now-allows-to-export-objects-for-the-specified-organization.yml
+++ b/changelogs/fragments/610-filetree_create-now-allows-to-export-objects-for-the-specified-organization.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - filetree_create now allows to export objects for the specified organization

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -15,6 +15,7 @@ The following variables are required for that role to work properly:
 | Variable Name | Default Value | Required | Type | Description |
 | :------------ | :-----------: | :------: | :------: | :---------- |
 | `controller_api_plugin` | `ansible.controller` | yes | str | Full path for the controller_api_plugin to be used. <br/> Can have two possible values: <br/>&nbsp;&nbsp;- awx.awx.controller_api             # For the community Collection version <br/>&nbsp;&nbsp;- ansible.controller.controller_api  # For the Red Hat Certified Collection version|
+| `organization_filter` | N/A | no | str | Exports only the objects belonging to the specified organization (applies to all the objects that can be assigned to an organization). |
 | `output_path` | `/tmp/filetree_output` | yes | str | The path to the output directory where all the generated `yaml` files with the corresponding Objects as code will be written to. |
 | `input_tag` | `['all']` | no | bool | The tags which are applied to the 'sub-roles'. If 'all' is in the list (the default value) then all roles will be called. |
 

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -18,7 +18,7 @@ The following variables are required for that role to work properly:
 | `organization_filter` | N/A | no | str | Exports only the objects belonging to the specified organization (applies to all the objects that can be assigned to an organization). |
 | `organization_id` | N/A | no | int | Alternative to `organization_filter`, but specifiying the current organization's ID to filter by. Exports only the objects belonging to the specified organization (applies to all the objects that can be assigned to an organization). |
 | `output_path` | `/tmp/filetree_output` | yes | str | The path to the output directory where all the generated `yaml` files with the corresponding Objects as code will be written to. |
-| `input_tag` | `['all']` | no | bool | The tags which are applied to the 'sub-roles'. If 'all' is in the list (the default value) then all roles will be called. |
+| `input_tag` | `['all']` | no | List of Strings | The tags which are applied to the 'sub-roles'. If 'all' is in the list (the default value) then all roles will be called. |
 
 ## Dependencies
 

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -16,6 +16,7 @@ The following variables are required for that role to work properly:
 | :------------ | :-----------: | :------: | :------: | :---------- |
 | `controller_api_plugin` | `ansible.controller` | yes | str | Full path for the controller_api_plugin to be used. <br/> Can have two possible values: <br/>&nbsp;&nbsp;- awx.awx.controller_api             # For the community Collection version <br/>&nbsp;&nbsp;- ansible.controller.controller_api  # For the Red Hat Certified Collection version|
 | `organization_filter` | N/A | no | str | Exports only the objects belonging to the specified organization (applies to all the objects that can be assigned to an organization). |
+| `organization_id` | N/A | no | int | Alternative to `organization_filter`, but specifiying the current organization's ID to filter by. Exports only the objects belonging to the specified organization (applies to all the objects that can be assigned to an organization). |
 | `output_path` | `/tmp/filetree_output` | yes | str | The path to the output directory where all the generated `yaml` files with the corresponding Objects as code will be written to. |
 | `input_tag` | `['all']` | no | bool | The tags which are applied to the 'sub-roles'. If 'all' is in the list (the default value) then all roles will be called. |
 

--- a/roles/filetree_create/tasks/all.yml
+++ b/roles/filetree_create/tasks/all.yml
@@ -6,6 +6,24 @@
                        verify_ssl=controller_validate_certs).version is version('4.0.0', '>=') }}"
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
+- name: "Block to get the organization_filter ID to filter all the queries"
+  when:
+    - organization_filter is defined
+    - organization_filter | length > 0
+  block:
+    - name: "Get the organization_filter ID to restrict the API queries"
+      ansible.builtin.set_fact:
+        organization_id: "{{ lookup(controller_api_plugin, 'organizations',
+                                    query_params={'name': organization_filter},
+                                    host=controller_hostname, oauth_token=controller_oauthtoken,
+                                    verify_ssl=controller_validate_certs).id
+                          }}"
+      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+
+    - name: "Show the organization_filter ID"
+      ansible.builtin.debug:
+        msg: "The organization {{ organization_filter }} has the ID {{ organization_id }}"
+
 - name: Include tasks (block)
   when: "['all', 'labels', 'applications', 'instance_groups', 'settings', 'inventory', 'credentials', 'credential_types', 'notification_templates', 'users', 'teams', 'organizations', 'projects', 'execution_environments', 'job_templates', 'workflow_job_templates', 'workflow_job_template_nodes', 'schedules'] | intersect(input_tag) | length > 0"
   block:

--- a/roles/filetree_create/tasks/applications.yml
+++ b/roles/filetree_create/tasks/applications.yml
@@ -1,11 +1,14 @@
 ---
 - name: "Get current Applications from the API"
   ansible.builtin.set_fact:
-    applications_lookvar: "{{ query(controller_api_plugin, 'api/v2/applications/',
-                                query_params={'order_by': 'organization,id'},
+    applications_lookvar: "{{ query(controller_api_plugin, 'applications/',
+                                query_params=(query_params | combine({'organization': organization_id})) if organization_id is defined else query_params,
                                 host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                 return_all=true, max_objects=query_controller_api_max_objects)
                            }}"
+  vars:
+    query_params:
+      order_by: 'organization,id'
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Create the <ORGANIZATION_NAME>/applications output directory for applications in {{ output_path }}"
@@ -15,7 +18,6 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/applications"
-  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -33,7 +35,6 @@
     application_id: "{{ current_applications_asset_value.id }}"
     application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"
     __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/applications/{{ application_id }}_{{ application_name | regex_replace('/', '_') }}.yaml"
-  when: organization_filter is not defined or (current_applications_asset_value.summary_fields.organization.name is match(organization_filter))
   loop: "{{ applications_lookvar }}"
   loop_control:
     loop_var: current_applications_asset_value

--- a/roles/filetree_create/tasks/applications.yml
+++ b/roles/filetree_create/tasks/applications.yml
@@ -15,6 +15,7 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/applications"
+  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -32,6 +33,7 @@
     application_id: "{{ current_applications_asset_value.id }}"
     application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"
     __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/applications/{{ application_id }}_{{ application_name | regex_replace('/', '_') }}.yaml"
+  when: organization_filter is not defined or (current_applications_asset_value.summary_fields.organization.name is match(organization_filter))
   loop: "{{ applications_lookvar }}"
   loop_control:
     loop_var: current_applications_asset_value

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -2,10 +2,13 @@
 - name: "Get current Credentials from the API"
   ansible.builtin.set_fact:
     credentials_lookvar: "{{ query(controller_api_plugin, 'api/v2/credentials/',
-                                   query_params={'order_by': 'organization,id'},
+                                   query_params=(query_params | combine({'organization': organization_id})) if organization_id is defined else query_params,
                                    host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                    return_all=true, max_objects=query_controller_api_max_objects)
                           }}"
+  vars:
+    query_params:
+      order_by: 'organization,id'
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Create the <ORGANIZATION_NAME>/credentials output directory for credentials in {{ output_path }}"
@@ -15,7 +18,6 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path }}/credentials"
-  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -33,10 +35,6 @@
     credentials_id: "{{ current_credentials_asset_value.id }}"
     credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"
     __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/credentials/{{ credentials_id }}_{{ credentials_name | regex_replace('/', '_') }}.yaml"
-  when: organization_filter is not defined or (
-          current_credentials_asset_value.summary_fields.organization is defined and
-          current_credentials_asset_value.summary_fields.organization.name is match(organization_filter)
-        )
   loop: "{{ credentials_lookvar }}"
   loop_control:
     loop_var: current_credentials_asset_value

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -15,6 +15,7 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path }}/credentials"
+  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -32,6 +33,10 @@
     credentials_id: "{{ current_credentials_asset_value.id }}"
     credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"
     __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/credentials/{{ credentials_id }}_{{ credentials_name | regex_replace('/', '_') }}.yaml"
+  when: organization_filter is not defined or (
+          current_credentials_asset_value.summary_fields.organization is defined and
+          current_credentials_asset_value.summary_fields.organization.name is match(organization_filter)
+        )
   loop: "{{ credentials_lookvar }}"
   loop_control:
     loop_var: current_credentials_asset_value

--- a/roles/filetree_create/tasks/execution_environments.yml
+++ b/roles/filetree_create/tasks/execution_environments.yml
@@ -20,4 +20,12 @@
     mode: '0644'
   vars:
     current_execution_environments_asset_value: "{{ execution_environments_lookvar }}"
+  when: organization_filter is not defined or organization_filter in (
+          current_execution_environments_asset_value |
+          map(attribute='summary_fields') |
+          selectattr('organization', 'defined') |
+          map(attribute='organization') |
+          map(attribute='name') |
+          unique
+        )
 ...

--- a/roles/filetree_create/tasks/execution_environments.yml
+++ b/roles/filetree_create/tasks/execution_environments.yml
@@ -2,9 +2,13 @@
 - name: "Get current Execution Environments from the API"
   ansible.builtin.set_fact:
     execution_environments_lookvar: "{{ query(controller_api_plugin, 'api/v2/execution_environments/',
+                                              query_params=(query_params | combine({'organization': organization_id})) if organization_id is defined else query_params,
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                               return_all=true, max_objects=query_controller_api_max_objects)
                                      }}"
+  vars:
+    query_params:
+      order_by: 'organization,id'
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Create the output directory for execution environments: {{ output_path }}"
@@ -20,12 +24,4 @@
     mode: '0644'
   vars:
     current_execution_environments_asset_value: "{{ execution_environments_lookvar }}"
-  when: organization_filter is not defined or organization_filter in (
-          current_execution_environments_asset_value |
-          map(attribute='summary_fields') |
-          selectattr('organization', 'defined') |
-          map(attribute='organization') |
-          map(attribute='name') |
-          unique
-        )
 ...

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -2,10 +2,14 @@
 - name: "Get the inventories from the API"
   ansible.builtin.set_fact:
     inventory_lookvar: "{{ query(controller_api_plugin, 'api/v2/inventories/',
-                                 query_params={'not__kind': 'smart', 'order_by': 'organization,id'},
+                                 query_params=(query_params | combine({'organization': organization_id})) if organization_id is defined else query_params,
                                  host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                  return_all=true, max_objects=query_controller_api_max_objects)
                         }}"
+  vars:
+    query_params:
+      not__kind: 'smart'
+      order_by: 'organization,id'
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Create the <ORGANIZATION_NAME>/inventories output directory for inventories in {{ output_path }}"
@@ -17,7 +21,6 @@
     inventory_organization: "{{ needed_path.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
     inventory_name: "{{ needed_path.name | regex_replace('/', '_') }}"
     __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
-  when: organization_filter is not defined or (inventory_organization is match(organization_filter))
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: needed_path
@@ -32,7 +35,6 @@
     inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
     inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
     __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ current_inventories_asset_value.id }}_{{ inventory_name | regex_replace('/', '_') }}.yaml"
-  when: organization_filter is not defined or (current_inventories_asset_value.summary_fields.organization.name is match(organization_filter))
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: current_inventories_asset_value
@@ -49,7 +51,6 @@
                                                           return_all=true, max_objects=query_controller_api_max_objects)
                                                     if current_inventory_sources.has_inventory_sources else []
                                             }}"
-  when: organization_filter is not defined or (inventory_organization is match(organization_filter))
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: current_inventory_sources
@@ -67,7 +68,6 @@
                                               return_all=true, max_objects=query_controller_api_max_objects)
                                         if not current_inventory_hosts.has_inventory_sources else []
                                 }}"
-  when: organization_filter is not defined or (inventory_organization is match(organization_filter))
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: current_inventory_hosts
@@ -85,7 +85,6 @@
                                                return_all=true, max_objects=query_controller_api_max_objects)
                                          if not current_inventory_groups.has_inventory_sources else []
                                  }}"
-  when: organization_filter is not defined or (inventory_organization is match(organization_filter))
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: current_inventory_groups

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -17,6 +17,7 @@
     inventory_organization: "{{ needed_path.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
     inventory_name: "{{ needed_path.name | regex_replace('/', '_') }}"
     __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
+  when: organization_filter is not defined or (inventory_organization is match(organization_filter))
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: needed_path
@@ -31,6 +32,7 @@
     inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
     inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
     __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ current_inventories_asset_value.id }}_{{ inventory_name | regex_replace('/', '_') }}.yaml"
+  when: organization_filter is not defined or (current_inventories_asset_value.summary_fields.organization.name is match(organization_filter))
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: current_inventories_asset_value
@@ -47,6 +49,7 @@
                                                           return_all=true, max_objects=query_controller_api_max_objects)
                                                     if current_inventory_sources.has_inventory_sources else []
                                             }}"
+  when: organization_filter is not defined or (inventory_organization is match(organization_filter))
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: current_inventory_sources
@@ -64,6 +67,7 @@
                                               return_all=true, max_objects=query_controller_api_max_objects)
                                         if not current_inventory_hosts.has_inventory_sources else []
                                 }}"
+  when: organization_filter is not defined or (inventory_organization is match(organization_filter))
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: current_inventory_hosts
@@ -81,6 +85,7 @@
                                                return_all=true, max_objects=query_controller_api_max_objects)
                                          if not current_inventory_groups.has_inventory_sources else []
                                  }}"
+  when: organization_filter is not defined or (inventory_organization is match(organization_filter))
   loop: "{{ inventory_lookvar }}"
   loop_control:
     loop_var: current_inventory_groups

--- a/roles/filetree_create/tasks/inventory_sources.yml
+++ b/roles/filetree_create/tasks/inventory_sources.yml
@@ -12,5 +12,4 @@
     mode: '0644'
   when:
     - current_inventory_sources_asset_value | length > 0
-    - organization_filter is not defined or (inventory_organization is match(organization_filter))
 ...

--- a/roles/filetree_create/tasks/inventory_sources.yml
+++ b/roles/filetree_create/tasks/inventory_sources.yml
@@ -10,5 +10,7 @@
     src: "templates/current_inventory_sources.j2"
     dest: "{{ inventory_sources_output_path }}/current_inventory_sources.yaml"
     mode: '0644'
-  when: current_inventory_sources_asset_value | length > 0
+  when:
+    - current_inventory_sources_asset_value | length > 0
+    - organization_filter is not defined or (inventory_organization is match(organization_filter))
 ...

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -15,6 +15,7 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/job_templates"
+  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -44,6 +45,7 @@
     query_notification_success: "{{ query(controller_api_plugin, current_job_templates_asset_value.related.notification_templates_success,
                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) }}"
+  when: organization_filter is not defined or (job_template_organization is match(organization_filter))
   loop: "{{ job_templates_lookvar }}"
   loop_control:
     loop_var: current_job_templates_asset_value

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -2,10 +2,13 @@
 - name: "Get current Job Templates from the API"
   ansible.builtin.set_fact:
     job_templates_lookvar: "{{ query(controller_api_plugin, 'api/v2/job_templates/',
-                                     query_params={'order_by': 'organization,id'},
+                                     query_params=(query_params | combine({'organization': organization_id})) if organization_id is defined else query_params,
                                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                      return_all=true, max_objects=query_controller_api_max_objects)
                             }}"
+  vars:
+    query_params:
+      order_by: 'organization,id'
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Create the <ORGANIZATION_NAME> output directories for job templates in {{ output_path }}"
@@ -15,7 +18,6 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/job_templates"
-  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -45,7 +47,6 @@
     query_notification_success: "{{ query(controller_api_plugin, current_job_templates_asset_value.related.notification_templates_success,
                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) }}"
-  when: organization_filter is not defined or (job_template_organization is match(organization_filter))
   loop: "{{ job_templates_lookvar }}"
   loop_control:
     loop_var: current_job_templates_asset_value

--- a/roles/filetree_create/tasks/labels.yml
+++ b/roles/filetree_create/tasks/labels.yml
@@ -2,10 +2,13 @@
 - name: "Get current Labels from the API"
   ansible.builtin.set_fact:
     labels_lookvar: "{{ query(controller_api_plugin, 'api/v2/labels/',
-                                query_params={'order_by': 'organization,id'},
-                                host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
-                                return_all=true, max_objects=query_controller_api_max_objects)
+                              query_params=(query_params | combine({'organization': organization_id})) if organization_id is defined else query_params,
+                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
+                              return_all=true, max_objects=query_controller_api_max_objects)
                        }}"
+  vars:
+    query_params:
+      order_by: 'organization,id'
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Create the <ORGANIZATION_NAME>/labels output directory for labels in {{ output_path }}"
@@ -15,7 +18,6 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/labels"
-  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (labels_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((labels_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -33,7 +35,6 @@
     label_id: "{{ current_labels_asset_value.id }}"
     label_name: "{{ current_labels_asset_value.name | regex_replace('/', '_') }}"
     __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/labels/{{ label_id }}_{{ label_name | regex_replace('/', '_') }}.yaml"
-  when: organization_filter is not defined or (label_organization is match(organization_filter))
   loop: "{{ labels_lookvar }}"
   loop_control:
     loop_var: current_labels_asset_value

--- a/roles/filetree_create/tasks/labels.yml
+++ b/roles/filetree_create/tasks/labels.yml
@@ -15,6 +15,7 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/labels"
+  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (labels_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((labels_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -32,6 +33,7 @@
     label_id: "{{ current_labels_asset_value.id }}"
     label_name: "{{ current_labels_asset_value.name | regex_replace('/', '_') }}"
     __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/labels/{{ label_id }}_{{ label_name | regex_replace('/', '_') }}.yaml"
+  when: organization_filter is not defined or (label_organization is match(organization_filter))
   loop: "{{ labels_lookvar }}"
   loop_control:
     loop_var: current_labels_asset_value

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -14,6 +14,7 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/notification_templates"
+  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -28,6 +29,7 @@
     mode: '0644'
   vars:
     __dest: "{{ output_path }}/{{ (current_notification_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}/notification_templates/{{ current_notification_templates_asset_value.name | regex_replace('/', '_') }}.yaml"
+  when: organization_filter is not defined or (current_notification_templates_asset_value.summary_fields.organization.name is match(organization_filter))
   loop: "{{ notification_templates_lookvar }}"
   loop_control:
     loop_var: current_notification_templates_asset_value

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -2,9 +2,13 @@
 - name: "Get current Notification Templates from the API"
   ansible.builtin.set_fact:
     notification_templates_lookvar: "{{ query(controller_api_plugin, 'api/v2/notification_templates/',
+                                              query_params=(query_params | combine({'organization': organization_id})) if organization_id is defined else query_params,
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                               return_all=true, max_objects=query_controller_api_max_objects)
                                      }}"
+  vars:
+    query_params:
+      order_by: 'organization,id'
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Create the <ORGANIZATION_NAME>/notification_templates output directory for notification templates in {{ output_path }}"
@@ -14,7 +18,6 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/notification_templates"
-  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -29,7 +32,6 @@
     mode: '0644'
   vars:
     __dest: "{{ output_path }}/{{ (current_notification_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}/notification_templates/{{ current_notification_templates_asset_value.name | regex_replace('/', '_') }}.yaml"
-  when: organization_filter is not defined or (current_notification_templates_asset_value.summary_fields.organization.name is match(organization_filter))
   loop: "{{ notification_templates_lookvar }}"
   loop_control:
     loop_var: current_notification_templates_asset_value

--- a/roles/filetree_create/tasks/organizations.yml
+++ b/roles/filetree_create/tasks/organizations.yml
@@ -15,6 +15,7 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ current_organization_dir.name | regex_replace('/', '_') }}"
+  when: organization_filter is not defined or (current_organization_dir.name is match(organization_filter))
   loop: "{{ orgs_lookvar }}"
   loop_control:
     loop_var: current_organization_dir
@@ -39,6 +40,7 @@
     query_notification_approvals: "{{ query(controller_api_plugin, current_organization.related.notification_templates_approvals,
                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) }}"
+  when: organization_filter is not defined or (current_organization.name is match(organization_filter))
   loop: "{{ orgs_lookvar }}"
   loop_control:
     loop_var: current_organization

--- a/roles/filetree_create/tasks/organizations.yml
+++ b/roles/filetree_create/tasks/organizations.yml
@@ -2,10 +2,13 @@
 - name: "Get current Organizations from the API"
   ansible.builtin.set_fact:
     orgs_lookvar: "{{ query(controller_api_plugin, 'api/v2/organizations/',
-                            query_params={'order_by': 'id'},
+                            query_params=(query_params | combine({'id': organization_id})) if organization_id is defined else query_params,
                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                             return_all=true, max_objects=query_controller_api_max_objects)
                    }}"
+  vars:
+    query_params:
+      order_by: 'id'
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Create the output directory for organizations: {{ output_path + '/' + current_organization_dir.name }}"
@@ -15,7 +18,6 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ current_organization_dir.name | regex_replace('/', '_') }}"
-  when: organization_filter is not defined or (current_organization_dir.name is match(organization_filter))
   loop: "{{ orgs_lookvar }}"
   loop_control:
     loop_var: current_organization_dir
@@ -40,7 +42,6 @@
     query_notification_approvals: "{{ query(controller_api_plugin, current_organization.related.notification_templates_approvals,
                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) }}"
-  when: organization_filter is not defined or (current_organization.name is match(organization_filter))
   loop: "{{ orgs_lookvar }}"
   loop_control:
     loop_var: current_organization

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -2,10 +2,13 @@
 - name: "Get current Projects from the API"
   ansible.builtin.set_fact:
     projects_lookvar: "{{ query(controller_api_plugin, 'api/v2/projects/',
-                                query_params={'order_by': 'organization,id'},
+                                query_params=(query_params | combine({'organization': organization_id})) if organization_id is defined else query_params,
                                 host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                 return_all=true, max_objects=query_controller_api_max_objects)
                        }}"
+  vars:
+    query_params:
+      order_by: 'organization,id'
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Create the <ORGANIZATION_NAME>/projects output directory for projects in {{ output_path }}"
@@ -15,7 +18,6 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/projects"
-  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -42,7 +44,6 @@
     query_notification_success: "{{ query(controller_api_plugin, current_projects_asset_value.related.notification_templates_success,
                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) }}"
-  when: organization_filter is not defined or (project_organization is match(organization_filter))
   loop: "{{ projects_lookvar }}"
   loop_control:
     loop_var: current_projects_asset_value

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -15,6 +15,7 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/projects"
+  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -41,6 +42,7 @@
     query_notification_success: "{{ query(controller_api_plugin, current_projects_asset_value.related.notification_templates_success,
                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) }}"
+  when: organization_filter is not defined or (project_organization is match(organization_filter))
   loop: "{{ projects_lookvar }}"
   loop_control:
     loop_var: current_projects_asset_value

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -2,10 +2,13 @@
 - name: "Get current Teams from the API"
   ansible.builtin.set_fact:
     teams_lookvar: "{{ query(controller_api_plugin, 'api/v2/teams/',
-                             query_params={'order_by': 'organization,id'},
+                             query_params=(query_params | combine({'organization': organization_id})) if organization_id is defined else query_params,
                              host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                              return_all=true, max_objects=query_controller_api_max_objects)
                     }}"
+  vars:
+    query_params:
+      order_by: 'organization,id'
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Create the <ORGANIZATION_NAME>/teams output directory for teams in {{ output_path }}"
@@ -15,7 +18,6 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/teams"
-  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -33,7 +35,6 @@
     team_id: "{{ current_teams_asset_value.id }}"
     team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"
     __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/teams/{{ team_id }}_{{ team_name | regex_replace('/', '_') }}.yaml"
-  when: organization_filter is not defined or (team_organization is match(organization_filter))
   loop: "{{ teams_lookvar }}"
   loop_control:
     loop_var: current_teams_asset_value
@@ -45,7 +46,6 @@
     team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
     teamname: "{{ current_team.name }}"
     teamid: "{{ current_team.id }}"
-  when: organization_filter is not defined or (team_organization is match(organization_filter))
   loop: "{{ teams_lookvar }}"
   loop_control:
     loop_var: current_team

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -15,6 +15,7 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/teams"
+  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -32,6 +33,7 @@
     team_id: "{{ current_teams_asset_value.id }}"
     team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"
     __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/teams/{{ team_id }}_{{ team_name | regex_replace('/', '_') }}.yaml"
+  when: organization_filter is not defined or (team_organization is match(organization_filter))
   loop: "{{ teams_lookvar }}"
   loop_control:
     loop_var: current_teams_asset_value
@@ -40,8 +42,10 @@
 - name: "Set the team's roles"
   ansible.builtin.include_tasks: "team_roles.yml"
   vars:
+    team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
     teamname: "{{ current_team.name }}"
     teamid: "{{ current_team.id }}"
+  when: organization_filter is not defined or (team_organization is match(organization_filter))
   loop: "{{ teams_lookvar }}"
   loop_control:
     loop_var: current_team

--- a/roles/filetree_create/tasks/users.yml
+++ b/roles/filetree_create/tasks/users.yml
@@ -22,6 +22,8 @@
     label: "User {{ user_lookvar_item.username }}"
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
+- debug: var=current_users
+
 - name: "Create the <ORGANIZATION_NAME> output directory for users in {{ output_path }}"
   ansible.builtin.file:
     path: "{{ __path }}"
@@ -29,6 +31,7 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ current_user_dir | regex_replace('/', '_') }}/users"
+  when: organization_filter is not defined or (current_user_dir is match(organization_filter))
   loop: "{{ current_users | selectattr('organizations', 'defined') | map(attribute='organizations') | flatten | unique }}"
   loop_control:
     loop_var: current_user_dir
@@ -42,6 +45,7 @@
   vars:
     current_users_asset_value: "{{ current_user_dir.0 }}"
     __dest: "{{ output_path }}/{{ current_user_dir.1 | regex_replace('/', '_') }}/users/{{ current_user_dir.0.username | regex_replace('/', '_') }}.yaml"
+  when: organization_filter is not defined or (current_user_dir.1 is match(organization_filter))
   loop: "{{ current_users | subelements('organizations') }}"
   loop_control:
     loop_var: current_user_dir
@@ -50,7 +54,11 @@
 - name: "Set the user's roles"
   ansible.builtin.include_tasks: "user_roles.yml"
   vars:
-    username: "{{ item.username }}"
-  loop: "{{ users_lookvar }}"
-  when: not item.is_superuser
+    username: "{{ current_user.0.username }}"
+  when:
+    - not current_user.0.is_superuser
+    - organization_filter is not defined or (current_user.1 is match(organization_filter))
+  loop: "{{ current_users | subelements('organizations') }}"
+  loop_control:
+    loop_var: current_user
 ...

--- a/roles/filetree_create/tasks/users.yml
+++ b/roles/filetree_create/tasks/users.yml
@@ -22,8 +22,6 @@
     label: "User {{ user_lookvar_item.username }}"
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
-- debug: var=current_users
-
 - name: "Create the <ORGANIZATION_NAME> output directory for users in {{ output_path }}"
   ansible.builtin.file:
     path: "{{ __path }}"

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -2,10 +2,13 @@
 - name: "Get current Workflow Job Templates from the API"
   ansible.builtin.set_fact:
     workflow_job_templates_lookvar: "{{ query(controller_api_plugin, 'api/v2/workflow_job_templates/',
-                                              query_params={'order_by': 'organization,id'},
+                                              query_params=(query_params | combine({'organization': organization_id})) if organization_id is defined else query_params,
                                               host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                               return_all=true, max_objects=query_controller_api_max_objects)
                                      }}"
+  vars:
+    query_params:
+      order_by: 'organization,id'
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Create the <ORGANIZATION_NAME>/workflow_job_templates output directory for workflow job templates in {{ output_path }}"
@@ -15,7 +18,6 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/workflow_job_templates/"
-  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -48,7 +50,6 @@
     query_notification_approvals: "{{ query(controller_api_plugin, current_workflow_job_templates_asset_value.related.notification_templates_approvals,
                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) }}"
-  when: organization_filter is not defined or (workflow_job_template_organization is match(organization_filter))
   loop: "{{ workflow_job_templates_lookvar }}"
   loop_control:
     loop_var: current_workflow_job_templates_asset_value

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -15,6 +15,7 @@
     mode: '0755'
   vars:
     __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/workflow_job_templates/"
+  when: organization_filter is not defined or (needed_path is match(organization_filter))
   loop: "{{ (workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
             + (['ORGANIZATIONLESS'] if ((workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
          }}"
@@ -47,6 +48,7 @@
     query_notification_approvals: "{{ query(controller_api_plugin, current_workflow_job_templates_asset_value.related.notification_templates_approvals,
                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) }}"
+  when: organization_filter is not defined or (workflow_job_template_organization is match(organization_filter))
   loop: "{{ workflow_job_templates_lookvar }}"
   loop_control:
     loop_var: current_workflow_job_templates_asset_value

--- a/roles/filetree_create/templates/current_execution_environments.j2
+++ b/roles/filetree_create/templates/current_execution_environments.j2
@@ -1,12 +1,17 @@
 ---
 controller_execution_environments:
 {% for ee in current_execution_environments_asset_value %}
+{% if organization_filter is not defined or (ee.summary_fields.organization is defined and ee.summary_fields.organization.name is match(organization_filter)) %}
   - name: "{{ ee.name }}"
     description: "{{ ee.description }}"
+{% if ee.summary_fields.organization.name is defined %}
+    organization: "{{ ee.summary_fields.organization.name }}"
+{% endif %}
     image: "{{ ee.image }}"
     pull: "{{ ee.pull }}"
 {% if ee.summary_fields.credential is defined %}
     credential: "{{ ee.summary_fields.credential.name }}"
+{% endif %}
 {% endif %}
 {% endfor %}
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Adds the possibility of exporting only the objects related to the specified organization.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Manually tested. Automatic tests.
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #610 

# Other Relevant info, PRs, etc
N/A
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
