### PR TITLE
Bug/fix credentials role ignoring update secrets

### DIFF
--- a/changelogs/fragments/credentials_role_bugfix.yml
+++ b/changelogs/fragments/credentials_role_bugfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fix 'credentials' role ignoring 'update_secrets: false' and forcing to default 'true'

--- a/roles/credentials/tasks/main.yml
+++ b/roles/credentials/tasks/main.yml
@@ -10,7 +10,7 @@
     inputs:                         "{{ __controller_credentials_item.inputs | default(( {} if controller_configuration_credentials_enforce_defaults else omit), true) }}"
     user:                           "{{ __controller_credentials_item.user.username | default(__controller_credentials_item.user | default(( '' if controller_configuration_credentials_enforce_defaults else omit), true)) }}"
     team:                           "{{ __controller_credentials_item.team.name | default(__controller_credentials_item.team | default(( '' if controller_configuration_credentials_enforce_defaults else omit), true)) }}"
-    update_secrets:                 "{{ __controller_credentials_item.update_secrets | default(( true if controller_configuration_credentials_enforce_defaults else omit), true) }}"
+    update_secrets:                 "{{ __controller_credentials_item.update_secrets | default( true if controller_configuration_credentials_enforce_defaults else omit) }}"
     state:                          "{{ __controller_credentials_item.state | default(controller_state | default('present')) }}"
 
     # Role specific options


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Fix problem with credentials role always changing the secret even when 'update_secrets: false' is set.  When evaluating the 'update_secrets' parameter, 'default' is forcing it to true when 'update_secrets' is set to false.

The normal behavior should not change the secret when user is setting 'update_secrets: false' and providing all required input matching the credential type.

The secret should only be changed when 'update_secrets' is set to true or not defined, and the credential inputs (except the secret value) are different from existing credential.

# How should this be tested?

Explicitly setting controller_credentials variable like following with update_secrets as false

```
controller_credentials:
- name: "test-ssh-key"
  description: Testing password overwritten
  organization: "Test Org"
  credential_type: Machine
  update_secrets: true
  inputs:
    username: root
    ssh_key_data: |
      -----BEGIN OPENSSH PRIVATE KEY-----
      b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn
      NhAAAAAwEAAQAAAYEAsOeWLkvhr58gJWd7n9oNBFCqVduQprjD1KhGpBLq2iPsYlOn48p4
      NCW/oYJ77HyubpzKUfwL0c8R8EnQOZVgudGonuzaINyfyK7JXbT4PAztcAxwGInK4TJPcz
      gRnAlrTLkAcCRHB9VKENmaD3RFnFRTy6lH9JcPoeYRzFpj4dziAKbHn8GdWThCp9GqxNp3
      A6zcsRpJC+sGkAAAARZWNob25nQGVjaG9uZy1tYWMBAg==
      -----END OPENSSH PRIVATE KEY-----
    become_method: ""
    become_username: ""
```

This always change the secret.  Debugging shows the call to credential.py with update_secrets variable always set to true

# Is there a relevant Issue open for this?

No

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
