### PR TITLE
add controller_configuration_async_dir var

### DIFF
--- a/changelogs/fragments/async.yml
+++ b/changelogs/fragments/async.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add option to change async directory, and set the default to null. /tmp/.ansible_async was a workaround while the default was broken previously.
+...

--- a/roles/applications/README.md
+++ b/roles/applications/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_applications_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_applications_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/applications/defaults/main.yml
+++ b/roles/applications/defaults/main.yml
@@ -4,5 +4,6 @@ controller_applications: []
 controller_configuration_applications_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_applications_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_applications_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_applications_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/applications/meta/argument_specs.yml
+++ b/roles/applications/meta/argument_specs.yml
@@ -62,6 +62,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/applications/tasks/main.yml
+++ b/roles/applications/tasks/main.yml
@@ -28,7 +28,7 @@
   register: __applications_job_async
   changed_when: not __applications_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Create Applications | Wait for finish the Applications creation"
   ansible.builtin.async_status:
@@ -43,5 +43,5 @@
   when: __applications_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_applications_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/bulk_host_create/README.md
+++ b/roles/bulk_host_create/README.md
@@ -50,6 +50,7 @@ This also speeds up the overall role.
 |`controller_configuration_bulk_hosts_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_bulk_hosts_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/bulk_host_create/defaults/main.yml
+++ b/roles/bulk_host_create/defaults/main.yml
@@ -2,4 +2,5 @@
 controller_configuration_bulk_hosts_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_bulk_hosts_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_bulk_hosts_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 ...

--- a/roles/bulk_host_create/meta/argument_specs.yml
+++ b/roles/bulk_host_create/meta/argument_specs.yml
@@ -8,6 +8,12 @@ argument_specs:
         type: list
         elements: dict
 
+      # Async variables
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
+
       # No_log variables
       controller_configuration_bulk_hosts_secure_logging:
         default: "{{ controller_configuration_secure_logging | default(false) }}"

--- a/roles/bulk_host_create/tasks/main.yml
+++ b/roles/bulk_host_create/tasks/main.yml
@@ -21,7 +21,7 @@
   register: __controller_bulk_hosts_job_async
   changed_when: not __controller_bulk_hosts_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure bulk_hosts | Wait for finish the bulk_hosts creation"
   ansible.builtin.async_status:
@@ -36,5 +36,5 @@
   when: __controller_bulk_hosts_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_bulk_hosts_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/credential_input_sources/README.md
+++ b/roles/credential_input_sources/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_credential_input_sources_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_credential_input_sources_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/credential_input_sources/defaults/main.yml
+++ b/roles/credential_input_sources/defaults/main.yml
@@ -4,5 +4,6 @@ controller_credential_input_sources: []
 controller_configuration_credential_input_sources_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_credential_input_sources_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_credential_input_sources_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_credential_input_sources_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/credential_input_sources/meta/argument_specs.yml
+++ b/roles/credential_input_sources/meta/argument_specs.yml
@@ -51,6 +51,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/credential_input_sources/tasks/main.yml
+++ b/roles/credential_input_sources/tasks/main.yml
@@ -24,7 +24,7 @@
   register: __credential_input_sources_job_async
   changed_when: not __credential_input_sources_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Create Controller Credential Input Sources | Wait for finish the Controller Credential Input Sources creation"
   ansible.builtin.async_status:
@@ -39,5 +39,5 @@
   when: __credential_input_sources_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_credential_input_sources_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/credential_types/README.md
+++ b/roles/credential_types/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_credential_types_async_retries`|`controller_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_credential_types_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/credential_types/defaults/main.yml
+++ b/roles/credential_types/defaults/main.yml
@@ -4,5 +4,6 @@ controller_credential_types: []
 controller_configuration_credential_types_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_credential_types_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_credential_types_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_credential_types_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/credential_types/meta/argument_specs.yml
+++ b/roles/credential_types/meta/argument_specs.yml
@@ -59,6 +59,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/credential_types/tasks/main.yml
+++ b/roles/credential_types/tasks/main.yml
@@ -25,7 +25,7 @@
   register: __credentialtypes_job_async
   changed_when: not __credentialtypes_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Controller Credential Types | Wait for finish the credential types creation"
   ansible.builtin.async_status:
@@ -40,5 +40,5 @@
   when: __credentialtypes_job_async_result_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_credential_types_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/credentials/README.md
+++ b/roles/credentials/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_credentials_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_credentials_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/credentials/defaults/main.yml
+++ b/roles/credentials/defaults/main.yml
@@ -4,5 +4,6 @@ controller_credentials: []
 controller_configuration_credentials_secure_logging: "{{ controller_configuration_secure_logging | default(true) }}"
 controller_configuration_credentials_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_credentials_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_credentials_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/credentials/meta/argument_specs.yml
+++ b/roles/credentials/meta/argument_specs.yml
@@ -72,6 +72,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/credentials/tasks/main.yml
+++ b/roles/credentials/tasks/main.yml
@@ -30,7 +30,7 @@
   register: __credentials_job_async
   changed_when: not __credentials_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Controller Credentials | Wait for finish the credential creation"
   ansible.builtin.async_status:
@@ -46,5 +46,5 @@
   when: __credentials_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_credentials_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/execution_environments/README.md
+++ b/roles/execution_environments/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_execution_environments_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_execution_environments_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/execution_environments/defaults/main.yml
+++ b/roles/execution_environments/defaults/main.yml
@@ -3,5 +3,6 @@
 controller_configuration_execution_environments_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_execution_environments_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_execution_environments_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_execution_environments_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/execution_environments/meta/argument_specs.yml
+++ b/roles/execution_environments/meta/argument_specs.yml
@@ -60,6 +60,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/execution_environments/tasks/main.yml
+++ b/roles/execution_environments/tasks/main.yml
@@ -28,7 +28,7 @@
   register: __execution_environments_job_async
   changed_when: not __execution_environments_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Create Controller Execution Environments | Wait for finish the Controller Execution Environments creation"
   ansible.builtin.async_status:
@@ -43,5 +43,5 @@
   when: __execution_environments_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_execution_environments_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/groups/README.md
+++ b/roles/groups/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_groups_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_groups_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ### Formating Variables
 

--- a/roles/groups/defaults/main.yml
+++ b/roles/groups/defaults/main.yml
@@ -4,5 +4,6 @@ controller_groups: []
 controller_configuration_group_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_group_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_group_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_groups_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/groups/meta/argument_specs.yml
+++ b/roles/groups/meta/argument_specs.yml
@@ -71,6 +71,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/groups/tasks/main.yml
+++ b/roles/groups/tasks/main.yml
@@ -30,7 +30,7 @@
   register: __group_job_async
   changed_when: not __group_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Create Controller Group | Wait for finish the Controller Group creation"
   ansible.builtin.async_status:
@@ -45,5 +45,5 @@
   when: __group_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_group_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/hosts/README.md
+++ b/roles/hosts/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_host_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_host_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ### Formating Variables
 

--- a/roles/hosts/defaults/main.yml
+++ b/roles/hosts/defaults/main.yml
@@ -4,5 +4,6 @@ controller_hosts: []
 controller_configuration_hosts_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_hosts_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_hosts_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_host_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/hosts/meta/argument_specs.yml
+++ b/roles/hosts/meta/argument_specs.yml
@@ -56,6 +56,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/hosts/tasks/main.yml
+++ b/roles/hosts/tasks/main.yml
@@ -25,7 +25,7 @@
   register: __host_job_async
   changed_when: not __host_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Controller Hosts | Wait for finish the Hosts creation"
   ansible.builtin.async_status:
@@ -40,5 +40,5 @@
   when: __host_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_hosts_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/instance_groups/README.md
+++ b/roles/instance_groups/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_instance_groups_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_instance_groups_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/instance_groups/defaults/main.yml
+++ b/roles/instance_groups/defaults/main.yml
@@ -3,5 +3,6 @@ controller_instance_groups: []
 controller_configuration_instance_groups_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_instance_groups_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_instance_groups_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_instance_groups_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/instance_groups/meta/argument_specs.yml
+++ b/roles/instance_groups/meta/argument_specs.yml
@@ -80,6 +80,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/instance_groups/tasks/main.yml
+++ b/roles/instance_groups/tasks/main.yml
@@ -32,7 +32,7 @@
   register: __instance_groups_job_async
   changed_when: not __instance_groups_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Controller instance groups | Wait for finish the instance groups creation"
   ansible.builtin.async_status:
@@ -47,5 +47,5 @@
   when: __instance_groups_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_instance_groups_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/instances/README.md
+++ b/roles/instances/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_instances_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_instances_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/instances/defaults/main.yml
+++ b/roles/instances/defaults/main.yml
@@ -3,5 +3,6 @@ controller_instances: []
 controller_configuration_instances_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_instances_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_instances_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_instances_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/instances/meta/argument_specs.yml
+++ b/roles/instances/meta/argument_specs.yml
@@ -56,6 +56,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/instances/tasks/main.yml
+++ b/roles/instances/tasks/main.yml
@@ -27,7 +27,7 @@
   register: __instance_job_async
   changed_when: not __instance_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Controller instances | Wait for finish the instance creation"
   ansible.builtin.async_status:
@@ -42,5 +42,5 @@
   when: __instance_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_instances_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/inventories/README.md
+++ b/roles/inventories/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_inventories_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_inventories_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ### Formating Variables
 

--- a/roles/inventories/defaults/main.yml
+++ b/roles/inventories/defaults/main.yml
@@ -4,5 +4,6 @@ controller_inventories: []
 controller_configuration_inventories_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_inventories_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_inventories_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_inventories_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/inventories/meta/argument_specs.yml
+++ b/roles/inventories/meta/argument_specs.yml
@@ -74,6 +74,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/inventories/tasks/main.yml
+++ b/roles/inventories/tasks/main.yml
@@ -30,7 +30,7 @@
   register: __inventories_job_async
   changed_when: not __inventories_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Create Controller inventories | Wait for finish the inventories creation"
   ansible.builtin.async_status:
@@ -45,5 +45,5 @@
   when: __inventories_job_async_result_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_inventories_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/inventory_source_update/README.md
+++ b/roles/inventory_source_update/README.md
@@ -51,6 +51,7 @@ This also speeds up the overall role.
 |`controller_configuration_inventory_source_update_async_retries`|`controller_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_inventory_source_update_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/inventory_source_update/defaults/main.yml
+++ b/roles/inventory_source_update/defaults/main.yml
@@ -2,4 +2,5 @@
 controller_configuration_inventory_source_update_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_inventory_source_update_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_inventory_source_update_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 ...

--- a/roles/inventory_source_update/meta/argument_specs.yml
+++ b/roles/inventory_source_update/meta/argument_specs.yml
@@ -150,6 +150,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/inventory_source_update/tasks/main.yml
+++ b/roles/inventory_source_update/tasks/main.yml
@@ -28,7 +28,7 @@
   register: __inventory_source_update_async
   changed_when: not __inventory_source_update_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Controller inventory source update | Wait for finish of the inventory source update"
   ansible.builtin.async_status:
@@ -43,5 +43,5 @@
   when: __inventory_source_update_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_inventory_source_update_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/inventory_sources/README.md
+++ b/roles/inventory_sources/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_inventory_sources_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_inventory_sources_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ### Formating Variables
 

--- a/roles/inventory_sources/defaults/main.yml
+++ b/roles/inventory_sources/defaults/main.yml
@@ -3,5 +3,6 @@ controller_inventory_sources: []
 controller_configuration_inventory_sources_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_inventory_sources_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_inventory_sources_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_inventory_sources_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/inventory_sources/meta/argument_specs.yml
+++ b/roles/inventory_sources/meta/argument_specs.yml
@@ -150,6 +150,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/inventory_sources/tasks/main.yml
+++ b/roles/inventory_sources/tasks/main.yml
@@ -45,7 +45,7 @@
   register: __inventory_source_job_async
   changed_when: not __inventory_source_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Inventory Source | Wait for finish the Inventory Source creation"
   ansible.builtin.async_status:
@@ -60,5 +60,5 @@
   when: __inventory_source_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_inventory_sources_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/job_templates/README.md
+++ b/roles/job_templates/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_job_templates_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_job_templates_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/job_templates/defaults/main.yml
+++ b/roles/job_templates/defaults/main.yml
@@ -4,5 +4,6 @@ controller_templates: []
 controller_configuration_job_templates_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_job_templates_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_job_templates_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_job_templates_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/job_templates/meta/argument_specs.yml
+++ b/roles/job_templates/meta/argument_specs.yml
@@ -265,6 +265,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/job_templates/tasks/main.yml
+++ b/roles/job_templates/tasks/main.yml
@@ -74,7 +74,7 @@
   register: __job_templates_job_async
   changed_when: not __job_templates_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Controller Job Templates | Wait for finish the job templates creation"
   ansible.builtin.async_status:
@@ -89,5 +89,5 @@
   when: __job_templates_job_async_result_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_job_templates_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/labels/README.md
+++ b/roles/labels/README.md
@@ -49,6 +49,7 @@ This also speeds up the overall role.
 |`controller_configuration_labels_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_labels_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/labels/defaults/main.yml
+++ b/roles/labels/defaults/main.yml
@@ -3,4 +3,5 @@ controller_labels: []
 controller_configuration_labels_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_labels_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_labels_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 ...

--- a/roles/labels/meta/argument_specs.yml
+++ b/roles/labels/meta/argument_specs.yml
@@ -43,6 +43,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/labels/tasks/main.yml
+++ b/roles/labels/tasks/main.yml
@@ -22,7 +22,7 @@
   register: __controller_label_job_async
   changed_when: not __controller_label_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Labels | Wait for finish the Label creation"
   ansible.builtin.async_status:
@@ -37,5 +37,5 @@
   when: __controller_label_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_labels_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/notification_templates/README.md
+++ b/roles/notification_templates/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_notification_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_notification_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/notification_templates/defaults/main.yml
+++ b/roles/notification_templates/defaults/main.yml
@@ -4,5 +4,6 @@ controller_notifications: []
 controller_configuration_notifications_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_notifications_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_notifications_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_notifications_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/notification_templates/meta/argument_specs.yml
+++ b/roles/notification_templates/meta/argument_specs.yml
@@ -64,6 +64,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       controller_configuration_notification_templates_secure_logging:

--- a/roles/notification_templates/tasks/main.yml
+++ b/roles/notification_templates/tasks/main.yml
@@ -27,7 +27,7 @@
   register: __controller_notification_job_async
   changed_when: not __controller_notification_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure notifications | Wait for finish the notifications creation"
   ansible.builtin.async_status:
@@ -42,5 +42,5 @@
   when: __controller_notification_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_notifications_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/organizations/README.md
+++ b/roles/organizations/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_organizations_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_organizations_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Organization Data Structure
 

--- a/roles/organizations/defaults/main.yml
+++ b/roles/organizations/defaults/main.yml
@@ -3,6 +3,7 @@ controller_organizations: []
 controller_configuration_organizations_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_organizations_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_organizations_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_organizations_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 assign_galaxy_credentials_to_org: true
 assign_default_ee_to_org: true

--- a/roles/organizations/meta/argument_specs.yml
+++ b/roles/organizations/meta/argument_specs.yml
@@ -91,6 +91,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/organizations/tasks/main.yml
+++ b/roles/organizations/tasks/main.yml
@@ -30,7 +30,7 @@
   register: __organizations_job_async
   changed_when: not __organizations_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Controller Organizations | Wait for finish the organization creation"
   ansible.builtin.async_status:
@@ -45,5 +45,5 @@
   when: __organizations_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_organizations_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/project_update/README.md
+++ b/roles/project_update/README.md
@@ -51,6 +51,7 @@ This also speeds up the overall role.
 |`controller_configuration_project_update_async_retries`|60|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|10|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_project_update_async_delay`|10|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/project_update/defaults/main.yml
+++ b/roles/project_update/defaults/main.yml
@@ -2,4 +2,5 @@
 controller_configuration_project_update_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_project_update_async_retries: "{{ controller_configuration_async_retries | default(60) }}"
 controller_configuration_project_update_async_delay: "{{ controller_configuration_async_delay | default(10) }}"
+controller_configuration_async_dir: null
 ...

--- a/roles/project_update/meta/argument_specs.yml
+++ b/roles/project_update/meta/argument_specs.yml
@@ -139,6 +139,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       controller_configuration_groups_secure_logging:

--- a/roles/project_update/tasks/main.yml
+++ b/roles/project_update/tasks/main.yml
@@ -28,7 +28,7 @@
   register: __project_update_job_async
   changed_when: not __project_update_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Controller Projects | Wait for finish the projects creation"
   ansible.builtin.async_status:
@@ -43,5 +43,5 @@
   when: __project_update_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_project_update_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/projects/README.md
+++ b/roles/projects/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_projects_async_retries`|`{{ controller_configuration_async_retries }}`|no|str|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|str|This sets the delay between retries for the role globally.|
 |`controller_configuration_projects_async_delay`|`controller_configuration_async_delay`|no|str|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/projects/defaults/main.yml
+++ b/roles/projects/defaults/main.yml
@@ -4,5 +4,6 @@ controller_projects: []
 controller_configuration_projects_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_projects_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_projects_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_projects_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/projects/meta/argument_specs.yml
+++ b/roles/projects/meta/argument_specs.yml
@@ -147,6 +147,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/projects/tasks/main.yml
+++ b/roles/projects/tasks/main.yml
@@ -46,7 +46,7 @@
   register: __projects_job_async
   changed_when: not __projects_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Controller Projects | Wait for finish the projects creation"
   ansible.builtin.async_status:
@@ -61,5 +61,5 @@
   when: __projects_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_projects_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/roles/README.md
+++ b/roles/roles/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_role_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_role_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/roles/defaults/main.yml
+++ b/roles/roles/defaults/main.yml
@@ -4,5 +4,6 @@ controller_roles: []
 controller_configuration_role_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_role_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_role_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_role_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/roles/meta/argument_specs.yml
+++ b/roles/roles/meta/argument_specs.yml
@@ -110,6 +110,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/roles/tasks/main.yml
+++ b/roles/roles/tasks/main.yml
@@ -40,7 +40,7 @@
   register: __controller_role_job_async
   changed_when: not __controller_role_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Roles | Wait for finish the Roles creation"
   ansible.builtin.async_status:
@@ -55,5 +55,5 @@
   when: __controller_role_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_role_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/schedules/README.md
+++ b/roles/schedules/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_schedules_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_schedules_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/schedules/defaults/main.yml
+++ b/roles/schedules/defaults/main.yml
@@ -4,5 +4,6 @@ controller_schedules: []
 controller_configuration_schedules_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_schedules_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_schedules_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_schedules_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/schedules/meta/argument_specs.yml
+++ b/roles/schedules/meta/argument_specs.yml
@@ -132,6 +132,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/schedules/tasks/main.yml
+++ b/roles/schedules/tasks/main.yml
@@ -42,7 +42,7 @@
   register: __controller_schedule_job_async
   changed_when: not __controller_schedule_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Schedules | Wait for finish the Schedules creation"
   ansible.builtin.async_status:
@@ -57,5 +57,5 @@
   when: __controller_schedule_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_schedules_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/settings/README.md
+++ b/roles/settings/README.md
@@ -49,6 +49,7 @@ This also speeds up the overall role.
 |`controller_configuration_settings_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_settings_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/settings/defaults/main.yml
+++ b/roles/settings/defaults/main.yml
@@ -4,4 +4,5 @@ controller_settings: []
 controller_configuration_settings_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_settings_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_settings_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 ...

--- a/roles/settings/meta/argument_specs.yml
+++ b/roles/settings/meta/argument_specs.yml
@@ -38,6 +38,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/settings/tasks/main.yml
+++ b/roles/settings/tasks/main.yml
@@ -23,7 +23,7 @@
   register: __controller_setting_job_async
   changed_when: not __controller_setting_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Settings | Wait for finish the Settings creation"
   ansible.builtin.async_status:
@@ -38,5 +38,5 @@
   when: __controller_setting_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_settings_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/teams/README.md
+++ b/roles/teams/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_teams_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_teams_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ### Data structure `controller_teams:` should include following vars
 

--- a/roles/teams/defaults/main.yml
+++ b/roles/teams/defaults/main.yml
@@ -4,5 +4,6 @@ controller_teams: []
 controller_configuration_teams_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_teams_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_teams_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_teams_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/teams/meta/argument_specs.yml
+++ b/roles/teams/meta/argument_specs.yml
@@ -47,6 +47,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/teams/tasks/main.yml
+++ b/roles/teams/tasks/main.yml
@@ -23,7 +23,7 @@
   register: __controller_team_job_async
   changed_when: not __controller_team_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Teams | Wait for finish the Teams creation"
   ansible.builtin.async_status:
@@ -38,5 +38,5 @@
   when: __controller_team_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_teams_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/users/README.md
+++ b/roles/users/README.md
@@ -68,6 +68,7 @@ This also speeds up the overall role.
 |`controller_configuration_users_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_users_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/users/defaults/main.yml
+++ b/roles/users/defaults/main.yml
@@ -8,5 +8,6 @@ controller_user_default_password: "change_me"
 controller_configuration_users_secure_logging: "{{ controller_configuration_secure_logging | default('true') }}"
 controller_configuration_users_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_users_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_users_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/users/meta/argument_specs.yml
+++ b/roles/users/meta/argument_specs.yml
@@ -76,6 +76,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -32,7 +32,7 @@
   register: __controller_user_accounts_job_async
   changed_when: not __controller_user_accounts_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure Users | Wait for finish the Users creation"
   ansible.builtin.async_status:
@@ -47,5 +47,5 @@
   when: __controller_user_accounts_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_users_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/workflow_job_templates/README.md
+++ b/roles/workflow_job_templates/README.md
@@ -67,6 +67,7 @@ This also speeds up the overall role.
 |`controller_configuration_workflow_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_workflow_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/roles/workflow_job_templates/defaults/main.yml
+++ b/roles/workflow_job_templates/defaults/main.yml
@@ -4,5 +4,6 @@ controller_workflows: []
 workflow_job_templates_secure_logging: "{{ controller_configuration_secure_logging | default('false') }}"
 controller_configuration_workflow_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_workflow_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 controller_configuration_workflows_enforce_defaults: "{{ controller_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/workflow_job_templates/meta/argument_specs.yml
+++ b/roles/workflow_job_templates/meta/argument_specs.yml
@@ -293,6 +293,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      controller_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 
       # No_log variables

--- a/roles/workflow_job_templates/tasks/add_workflows_schema.yml
+++ b/roles/workflow_job_templates/tasks/add_workflows_schema.yml
@@ -44,7 +44,7 @@
   register: __workflows_node_async
   changed_when: not __workflows_node_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Manage Workflows | Wait for finish the workflow creation"
   ansible.builtin.async_status:
@@ -58,7 +58,7 @@
   when: __workflows_node_async_results_item.ansible_job_id is defined
   no_log: "{{ workflow_job_templates_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 # Create links between workflow node
 - name: Create links between Workflow Nodes
@@ -88,7 +88,7 @@
   poll: 0
   register: __workflows_link_async
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Manage Workflows | Wait for finish the workflow creation"
   ansible.builtin.async_status:
@@ -103,5 +103,5 @@
   when: __workflows_link_async_results_item.ansible_job_id is defined
   no_log: "{{ workflow_job_templates_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...

--- a/roles/workflow_job_templates/tasks/main.yml
+++ b/roles/workflow_job_templates/tasks/main.yml
@@ -50,7 +50,7 @@
   register: __workflows_job_async
   changed_when: not __workflows_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Manage Workflows | Wait for finish the workflow creation"
   ansible.builtin.async_status:
@@ -65,7 +65,7 @@
   when: __workflows_job_async_results_item.ansible_job_id is defined
   no_log: "{{ workflow_job_templates_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 # Create links between workflow node
 - name: Loop over nodes in schema to add to workflow templates

--- a/tests/templated_role_example/README.md
+++ b/tests/templated_role_example/README.md
@@ -51,6 +51,7 @@ This also speeds up the overall role.
 |`controller_configuration_*******_async_retries`|`{{ controller_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`controller_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
 |`controller_configuration_*******_async_delay`|`controller_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
 ## Data Structure
 

--- a/tests/templated_role_example/defaults/main.yml
+++ b/tests/templated_role_example/defaults/main.yml
@@ -2,4 +2,5 @@
 controller_configuration_*******_secure_logging: "{{controller_configuration_secure_logging | default('false')}}"
 controller_configuration_***********_async_retries: "{{ controller_configuration_async_retries | default(30) }}"
 controller_configuration_***********_async_delay: "{{ controller_configuration_async_delay | default(1) }}"
+controller_configuration_async_dir: null
 ...

--- a/tests/templated_role_example/tasks/main.yml
+++ b/tests/templated_role_example/tasks/main.yml
@@ -24,7 +24,7 @@
   register: __controller_***********_job_async
   changed_when: not __controller_***********_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 
 - name: "Configure *********** | Wait for finish the *********** creation"
   async_status:
@@ -39,5 +39,5 @@
   when: __controller_***********_job_async_results_item.ansible_job_id is defined
   no_log: "{{ controller_configuration_*******_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ controller_configuration_async_dir }}'
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Creates a new variable `controller_configuration_async_dir` on all roles which use the async keyword on tasks, which sets the `ansible_async_dir` variable on those tasks, and sets the default to `null`, from `/tmp/.ansible_async`.

This is effectively the same change made on infra.ah_configuration in ansible/automation_hub_collection/pull/273 and ansible/automation_hub_collection/pull/276.

I haven't had the same issue with this collection as I had with infra.ah_configuration, but it has the same design, so it makes sense that it should work the same.

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

I haven't tested this thoroughly, but it seems to work OK.

# Other Relevant info, PRs, etc

See also https://github.com/redhat-cop/controller_configuration/issues/299#issuecomment-1493322272