### PR TITLE
Fix broken CI because of request_timeout added to awx

### DIFF
--- a/changelogs/fragments/add_request_timeout.yml
+++ b/changelogs/fragments/add_request_timeout.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Adds request_timeout to controller_export_diff module
+...

--- a/plugins/modules/controller_export_diff.py
+++ b/plugins/modules/controller_export_diff.py
@@ -138,7 +138,6 @@ options:
       - A dictionary structure as returned by the token module.
       - If value not set, will try environment variable C(CONTROLLER_OAUTH_TOKEN) and then config files
       type: raw
-      version_added: "3.7.0"
       aliases: [ tower_oauthtoken ]
     validate_certs:
       description:
@@ -148,6 +147,12 @@ options:
       - If value not set, will try environment variable C(CONTROLLER_VERIFY_SSL) and then config files
       type: bool
       aliases: [ tower_verify_ssl ]
+    request_timeout:
+      description:
+      - Specify the timeout Ansible should use in requests to the controller host.
+      - Defaults to 10s, but this is handled by the shared module_utils code
+      type: float
+      version_added: "2.6.0"
     controller_config_file:
       description:
       - Path to the controller config file.


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fix broken CI because of request_timeout added to awx

New release of awx.awx caused the CI to fail because the `request_timeout` in the module_utils which are used
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
CI starts passing
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
N/A
<!--- Provide a link to any open issues that describe the problem you are solving. -->


# Other Relevant info, PRs, etc
Failing CI: https://github.com/redhat-cop/controller_configuration/actions/runs/5875280508/job/15931315104#step:9:286
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
