### PR TITLE
Add to description of request_timeout option that awx.awx>=22.7.0 is required

### DIFF
--- a/plugins/modules/controller_export_diff.py
+++ b/plugins/modules/controller_export_diff.py
@@ -151,6 +151,7 @@ options:
       description:
       - Specify the timeout Ansible should use in requests to the controller host.
       - Defaults to 10s, but this is handled by the shared module_utils code
+      - This option requires awx.awx>=22.7.0 or equivalent ansible.controller collection
       type: float
       version_added: "2.6.0"
     controller_config_file:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
We need to have latest awx.awx if the request_timeout option is to be added to the plugin because it relies upon the module_utils from awx.awx where the option is defined. I'm pretty sure it'll spit out an error if the version isn't correct (haven't tested) and at best it'll just not do anything.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Doc change only
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->

# Other Relevant info, PRs, etc
Addition to #675 
^ This hasn't been released so the same changelog fragment is fine
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
