### PR TITLE
[#685] Fix organization creation with instance group

### DIFF
--- a/changelogs/fragments/instancegroups_org.yml
+++ b/changelogs/fragments/instancegroups_org.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed issue with organization creation with instance group. Execute instance and instance_group before organizations.
+...

--- a/roles/dispatch/defaults/main.yml
+++ b/roles/dispatch/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 controller_configuration_dispatcher_roles:
   - {role: settings, var: controller_settings, tags: settings}
+  - {role: instances, var: controller_instances, tags: instances}
+  - {role: instance_groups, var: controller_instance_groups, tags: instance_groups}
   - {role: organizations, var: controller_organizations, tags: organizations}
   - {role: labels, var: controller_labels, tags: labels}
   - {role: users, var: controller_user_accounts, tags: users}
@@ -15,8 +17,6 @@ controller_configuration_dispatcher_roles:
   - {role: inventory_source_update, var: controller_inventory_sources, tags: inventory_sources}
   - {role: execution_environments, var: controller_execution_environments, tags: execution_environments}
   - {role: applications, var: controller_applications, tags: applications}
-  - {role: instances, var: controller_instances, tags: instances}
-  - {role: instance_groups, var: controller_instance_groups, tags: instance_groups}
   - {role: hosts, var: controller_hosts, tags: hosts}
   - {role: bulk_host_create, var: controller_bulk_hosts, tags: bulk_hosts}
   - {role: groups, var: controller_groups, tags: inventories}

--- a/roles/object_diff/defaults/main.yml
+++ b/roles/object_diff/defaults/main.yml
@@ -38,7 +38,6 @@ controller_configuration_object_diff_tasks:
   - {name: user_accounts, var: controller_user_accounts, tags: users}
   - {name: groups, var: controller_groups, tags: groups}
   - {name: hosts, var: controller_hosts, tags: hosts}
-  - {name: instance_groups, var: controller_instance_groups, tags: instance_groups}
   - {name: applications, var: controller_applications, tags: applications}
   - {name: execution_environments, var: controller_execution_environments, tags: execution_environments}
   - {name: inventory_sources, var: controller_inventory_sources, tags: inventory_sources}
@@ -48,6 +47,7 @@ controller_configuration_object_diff_tasks:
   - {name: credentials, var: controller_credentials, tags: credentials}
   - {name: credential_types, var: controller_credential_types, tags: credential_types}
   - {name: organizations, var: controller_organizations, tags: organizations}
+  - {name: instance_groups, var: controller_instance_groups, tags: instance_groups}
 
 controller_configuration_object_diff_secure_logging: "{{ controller_configuration_secure_logging | default(true) }}"
 


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

If an organization has instance_groups defined, it has to be created beforehand. With this PR, instance and instance_group will be executed before organizations in the dispatch role.

# How should this be tested?

Create organizations with instance_groups

# Is there a relevant Issue open for this?

#685 
