### PR TITLE
rectified misspelled variable in job_templates

### DIFF
--- a/changelogs/fragments/filetree_create_job_templates.yml
+++ b/changelogs/fragments/filetree_create_job_templates.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - filetree_create - Fixed the misspelled variable name that caused exported job_templates yaml files containing incorrect name.
+...

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -36,7 +36,7 @@ controller_templates:
     ask_execution_environment_on_launch: {{ current_job_templates_asset_value.ask_execution_environment_on_launch | bool }}
 {% endif %}
 {% if current_job_templates_asset_value.ask_labels_on_launch is defined %}
-    ask_labels_on_launc: {{ current_job_templates_asset_value.ask_labels_on_launch | bool }}
+    ask_labels_on_launch: {{ current_job_templates_asset_value.ask_labels_on_launch | bool }}
 {% endif %}
 {% if current_job_templates_asset_value.ask_forks_on_launch is defined %}
     ask_forks_on_launch: {{ current_job_templates_asset_value.ask_forks_on_launch | bool }}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
This should fix the variable naming for the `ask_labels_on_launch` within job_templates that causes all the templates to be exported with erroneous naming.
<!--- Brief explanation of the code or documentation change you've made -->
Rectified misspelled variable that breaks the dispatch role while importing the yaml for job_templates
# How should this be tested?

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
