### PR TITLE
Fix calling manifest when manifest_content is defined

### DIFF
--- a/roles/license/tasks/main.yml
+++ b/roles/license/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Use manifest file
   ansible.builtin.include_tasks: "manifest.yml"
   when:
-    - controller_license.manifest_file is defined or controller_license.manifest is defined
+    - controller_license.manifest_file is defined or controller_license.manifest is defined or controller_license.manifest_content is defined
 
 - name: Use subscription pool id or subscription lookup
   ansible.builtin.include_tasks: "subscription.yml"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->

When users define manifest content like this

```
controller_license:
  manifest_content: "{{ lookup(...) }}"
```

It correctly calls the manifest.yml file and installs the license

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?

I've tested locally and manually, unsure if I need to add in automated tests.

# Is there a relevant Issue open for this?

No

# Other Relevant info, PRs, etc

N/A
