### PR TITLE
Cleanup task name

### DIFF
--- a/roles/object_diff/tasks/main.yml
+++ b/roles/object_diff/tasks/main.yml
@@ -59,7 +59,7 @@
   tags:
     - always
 
-- name: "Include Tasks to get OBJECT DIFF {{ __task_diff.name }}"
+- name: "Include Tasks to get OBJECT DIFF"
   ansible.builtin.include_tasks: "{{ __task_diff.name }}.yml"
   args:
     apply:


### PR DESCRIPTION
This jinja2 template is never evaluated. The loop is inside the task. There is only one task and it was called literally: "Include Tasks to get OBJECT DIFF {{ __task_diff.name }}"