### PR TITLE
Cleanup task name

### DIFF
--- a/roles/dispatch/tasks/main.yml
+++ b/roles/dispatch/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Run infra.controller_configuration.{{ __role.role }}"
+- name: "Run infra.controller_configuration roles"
   ansible.builtin.include_role:
     name: "{{ __role.role }}"
     apply:


### PR DESCRIPTION
This jinja2 template is never evaluated. The loop is inside the task. There is only one task and it was called literally: "Run infra.controller_configuration.{{ __role.role }}"


Very similar to #708


Although in this case I'm not sure if my proposed task name is the best.

Yours
  David