### PR TITLE
Fix usage of compare_list_reduced variable

### DIFF
--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -320,7 +320,7 @@ class LookupModule(LookupBase):
                 item.update({"state": "absent"})
         # Combine Lists
         if self.get_option("with_present"):
-            for item in compare_list_reduced:
+            for item in compare_list:
                 item.update({"state": "present"})
             compare_list.extend(difference)
             # Return Compare list with difference attached

--- a/tests/configs/differential_items.yml
+++ b/tests/configs/differential_items.yml
@@ -45,20 +45,20 @@ differential_items:
         organization: Default
         scm_type: git
         scm_url: https://github.com/ansible/tower-example.git
-        # state: present
+        state: present
       - description: ansible-examples
         name: Test Inventory source project
         organization: Default
         scm_type: git
         scm_url: https://github.com/ansible/ansible-examples.git
-        # state: present
+        state: present
       - credential: gitlab-personal-access-token for satqe_auto_droid
         description: ansible-examples
         name: Test Inventory source project with credential
         organization: Default
         scm_type: git
         scm_url: https://github.com/ansible/ansible-examples.git
-        # state: present
+        state: present
         wait: false
       - description: Test Project 1
         name: Test Project
@@ -67,7 +67,7 @@ differential_items:
         scm_clean: true
         scm_type: git
         scm_url: https://github.com/ansible/tower-example.git
-        # state: present
+        state: present
       - name: Demo Project
         organization: Default
         state: absent


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

The object diff plugin used the wrong variable in 1 place when using `with_present`.
When using that option, the `state: present` key is added to the `compare_list_reduced` dict, however, the `compare_list` was then extended and returned.

This also solves removing too much differences based on the if-statement on line 332 as less dict now have less than 3 keys

# How should this be tested?

Manual
1. Create list of roles to configure (for example: `{"controller_roles": [{"team": "dummy", "job_template": "dummy_template", "role": "read"}]`
2. Run the diff role with `include_present_state: true`
3. The diff output now actually contains the `state: present` key. Before it did not

# Is there a relevant Issue open for this?

# Other Relevant info, PRs, etc
