### PR TITLE
Fix calling manifest when manifest_url is defined

### DIFF
--- a/roles/license/tasks/main.yml
+++ b/roles/license/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Use manifest file
   ansible.builtin.include_tasks: "manifest.yml"
   when:
-    - controller_license.manifest_file is defined or controller_license.manifest is defined or controller_license.manifest_content is defined
+    - controller_license.manifest_file is defined or controller_license.manifest is defined or controller_license.manifest_content is defined or controller_license.manifest_url is defined
 
 - name: Use subscription pool id or subscription lookup
   ansible.builtin.include_tasks: "subscription.yml"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

PR #704 added a fix for manifest_content, but manifest_url is still ignored. `manifest.yml` is still not included when manifest_url is defined.

# How should this be tested?

Manual test only.

# Is there a relevant Issue open for this?

No.

# Other Relevant info, PRs, etc

#704 
