### PR TITLE
Provide 3 fixes for the diff plugin

### DIFF
--- a/changelogs/fragments/diff_plugin.yml
+++ b/changelogs/fragments/diff_plugin.yml
@@ -2,4 +2,5 @@
 bugfixes:
   - Fixed an issue where the usage access to instance_groups were removed
   - Fixed an issue where the diff doesn't work correctly when explicitly setting state present
+  - Fixed member removal of teams
 ...

--- a/changelogs/fragments/diff_plugin.yml
+++ b/changelogs/fragments/diff_plugin.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed an issue where the usage access to instance_groups were removed
+...

--- a/changelogs/fragments/diff_plugin.yml
+++ b/changelogs/fragments/diff_plugin.yml
@@ -1,4 +1,5 @@
 ---
 bugfixes:
   - Fixed an issue where the usage access to instance_groups were removed
+  - Fixed an issue where the diff doesn't work correctly when explicitly setting state present
 ...

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -330,6 +330,10 @@ class LookupModule(LookupBase):
         if self.get_option("set_absent"):
             for item in difference:
                 item.update({"state": "absent"})
+                if "team" in item and item["role"] == "member":
+                    item.update({"target_team": item["team"]})
+                    item.pop("team")
+
         # Combine Lists
         if self.get_option("with_present"):
             for item in compare_list_reduced:

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -223,6 +223,8 @@ class LookupModule(LookupBase):
             for item in api_list_reduced:
                 if item["resource_type"] == "organization":
                     item.update({"organizations": [item[item["resource_type"]]]})
+                if item["resource_type"] == "instance_group":
+                    item.update({"instance_groups": [item[item["resource_type"]]]})
                 item.update({"role": item["name"].lower().replace(" ", "_")})
                 # Remove the extra fields
                 item.pop("users")
@@ -231,6 +233,8 @@ class LookupModule(LookupBase):
                 item.pop("resource_type")
                 if "organization" in item:
                     item.pop("organization")
+                if "instance_group" in item:
+                    item.pop("instance_group")
                 if "type" in item:
                     item.pop("type")
             list_to_extend = []

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -120,6 +120,11 @@ class LookupModule(LookupBase):
         new_item.update({new_attribute_name: attribute_value})
         return new_item
 
+    def equal_dicts(self, d1, d2, ignore_keys):
+        d1_filtered = {k: v for k, v in d1.items() if k not in ignore_keys}
+        d2_filtered = {k: v for k, v in d2.items() if k not in ignore_keys}
+        return d1_filtered == d2_filtered
+
     def run(self, terms, variables=None, **kwargs):
         self.set_options(direct=kwargs)
 
@@ -315,7 +320,10 @@ class LookupModule(LookupBase):
         else:
             difference = []
             for item in api_list_reduced:
-                if item not in compare_list_reduced:
+                for compare_item in compare_list_reduced:
+                    if self.equal_dicts(compare_item, item, "state"):
+                        break
+                else:
                     difference.append(item)
 
         # Set


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

This PR contains 3 fixes for the diff plugin. I'll explain them one by one:

### 1. Usage access to instance_groups is removed:

When setting usage access to an instance_group (with `{"role": "use", "instance_groups": ["Dummy instance group"], "user": "test@example.com"}`) the diff plugin tries to remove it afterwards.
This is due to the API returning information in singular version, but as can been seen above, the role module requires the plural version.

```text
From API:
{
  "users": [
    "test@example.com"
  ],
  "teams": [],
  "name": "Use",
  "role": "Use",
  "type": "role",
  "resource_type": "instance_group",
  "instance_group": "Dummy instance group",
  "user": "test@example.com"
}

Diff plugin creates:
{
  "role": "use",
  "instance_group": "Dummy instance group",
  "user": "test@example.com",
  "state": "absent"
}

Should be:
{
  "role": "use",
  "instance_groups": [
    "Dummy instance group"
  ],
  "user": "test@example.com",
  "state": "absent"
}
```

This is fixed by converting the singular versions into plural.

### 2. When explicitly setting `state: present`, the plugin creates a present and absent object in some cases

In some cases (I've seen it happen with organizations, but might happen with more) when someone explicitly sets `state: present` in configuration (compare_list) the diff plugin returns 2 items, one absent and one present state.

```text
If compare list like this it works fine (no diff after first apply):
{
    "user": "test@example.com",
    "organizations": [
        "Dummy"
    ],
    "role": "admin"
},

If with explicit state present:
{
    "user": "test@example.com",
    "organizations": [
        "Dummy"
    ],
    "role": "admin",
    "state": "present"
},

Results in:
{
    "organizations": [
        "Dummy"
    ],
    "role": "admin",
    "state": "present",
    "user": "test@example.com"
},
{
    "organizations": [
        "Dummy"
    ],
    "role": "admin",
    "state": "absent",
    "user": "test@example.com"
},
```

This is fixed by changing the way the dicts are compared. A separate method is used where the `state` key is ignored.

### 3. Member rights to teams aren't removed

When a user should no longer be member of a certain team the configuration is removed. However, the diff plugin creates the wrong absent dict. Setting (or removing) membership access is done by using the `target_team` key, not `team`.

```text
Created by diff plugin:
{
    "role": "member",
    "state": "absent",
    "team": "dummy-team",
    "user": "test@example.com"
}

Should be:
{
    "role": "member",
    "state": "absent",
    "target_team": "dummy-team",
    "user": "test@example.com"
}
```
This is fixed by checking if the `team` key is present and the `role` is `member`. If both are true, update the dict to change `team` to `target_team`.

# How should this be tested?

Some items are automatically checked by the pipeline.
Otherwise tests can be performed based on the data provided in the code blocks above

# Is there a relevant Issue open for this?


# Other Relevant info, PRs, etc
