### PR TITLE
Fix Constructed Inventory colliding with defaults on controller_inventory_sources

### DIFF
--- a/roles/inventory_sources/tasks/main.yml
+++ b/roles/inventory_sources/tasks/main.yml
@@ -6,7 +6,7 @@
     description:                          "{{ __controller_source_item.description | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
     inventory:                            "{{ __controller_source_item.inventory.name | default(__controller_source_item.inventory) | mandatory }}"
     organization:                         "{{ __controller_source_item.inventory.organization.name | default(__controller_source_item.organization | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true)) }}"
-    source:                               "{{ __controller_source_item.source | default(('scm' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    source:                               "{{ omit if __controller_source_item.source is defined and __controller_source_item.source == 'constructed' else __controller_source_item.source | default(('scm' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
     source_path:                          "{{ __controller_source_item.source_path | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
     source_vars:                          "{{ __controller_source_item.source_vars | default(({} if controller_configuration_inventory_sources_enforce_defaults else omit), true) | regex_replace('[ ]{2,}', '') }}"
     enabled_var:                          "{{ __controller_source_item.enabled_var | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
@@ -46,7 +46,6 @@
   poll: 0
   register: __inventory_source_job_async
   changed_when: not __inventory_source_job_async.changed
-  when: __controller_source_item.source != "constructed"
   vars:
     __operation: "{{ operation_translate[__controller_source_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/tests/configs/inventories.yml
+++ b/tests/configs/inventories.yml
@@ -23,7 +23,7 @@ controller_inventories:
     kind: smart
     host_filter:  "name__icontains=localhost"
   - name: test_constructed
-    organization: Default
+    organization: Satellite
     kind: constructed
     input_inventories:
       - localhost

--- a/tests/configs/inventory_sources.yml
+++ b/tests/configs/inventory_sources.yml
@@ -43,4 +43,11 @@ controller_inventory_sources:
   - name: "Auto-created source for: test_constructed"
     inventory: test_constructed
     source: constructed
+    limit: localhost
+    source_vars:
+      plugin: constructed
+      use_vars_plugins: true  # https://github.com/ansible/ansible/issues/75365
+      keyed_groups:
+        - key: some_var
+          separator: ""
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Follow up to #720 references #601

this changes the behaviour to allow modifications in constructed inventories, for example if you want to set a limit or modify source_vars.

I've updated the test constructed inventory to use both features.

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Constructed inventory in [tests/configs/inventory_sources.yml](tests/configs/inventory_sources.yml) should work

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
references #601 

# Other Relevant info, PRs, etc
#720 
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
