### PR TITLE
Fixed roles diff when the roles are provided as a list

### DIFF
--- a/changelogs/fragments/diff_roles_fix.yml
+++ b/changelogs/fragments/diff_roles_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixed roles diff when the roles are provided as a list, in a single entry

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -300,6 +300,24 @@ class LookupModule(LookupBase):
             for item in list_to_remove:
                 compare_list_reduced.remove(item)
             compare_list_reduced.extend(list_to_extend)
+            # Expand all compare list elements when roles is provided as list
+            list_to_extend = []
+            list_to_remove = []
+            for item in compare_list_reduced:
+                expanded = False
+                dupitems = [
+                    "roles",
+                    "role"
+                ]
+                if "roles" in item:
+                    for role in item["roles"]:
+                        list_to_extend.append(self.map_item(item, "role", role, dupitems))
+                    expanded = True
+                if expanded:
+                    list_to_remove.append(item)
+            for item in list_to_remove:
+                compare_list_reduced.remove(item)
+            compare_list_reduced.extend(list_to_extend)
         elif (
             api_list[0]["type"] != "organization"
             and api_list[0]["type"] != "user"

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -305,10 +305,7 @@ class LookupModule(LookupBase):
             list_to_remove.clear()
             for item in compare_list_reduced:
                 expanded = False
-                dupitems = [
-                    "roles",
-                    "role"
-                ]
+                dupitems = ["roles", "role"]
                 if "roles" in item:
                     for role in item["roles"]:
                         list_to_extend.append(self.map_item(item, "role", role, dupitems))

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -301,8 +301,8 @@ class LookupModule(LookupBase):
                 compare_list_reduced.remove(item)
             compare_list_reduced.extend(list_to_extend)
             # Expand all compare list elements when roles is provided as list
-            list_to_extend = []
-            list_to_remove = []
+            list_to_extend.clear()
+            list_to_remove.clear()
             for item in compare_list_reduced:
                 expanded = False
                 dupitems = [


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
The PR fixes roles diff, when the roles are provided as a list in the "roles" key, and not individually in "role".
All the elements in the compare list need to be expanded once more, for each role in the roles list.

At the moment, when using roles as a list, all the controller_roles are set to state absent.

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
