### PR TITLE
Fix organization wide permissions in roles object diff

### DIFF
--- a/changelogs/fragments/diff_roles_orga_wide.yml
+++ b/changelogs/fragments/diff_roles_orga_wide.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixed roles diff when the role is set at the organization level for an user/team

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -338,6 +338,11 @@ class LookupModule(LookupBase):
                 for compare_item in compare_list_reduced:
                     if self.equal_dicts(compare_item, item, "state"):
                         break
+                    elif (("organization" in compare_item) # permission applies to all objects in orga
+                            and (len(compare_item) == 3) # we only have orga, team/user, and role
+                            and self.equal_dicts(compare_item, item, ["organization"] + list(item.keys() - compare_item.keys()))
+                            ):
+                        break
                 else:
                     difference.append(item)
 

--- a/plugins/lookup/controller_object_diff.py
+++ b/plugins/lookup/controller_object_diff.py
@@ -338,10 +338,11 @@ class LookupModule(LookupBase):
                 for compare_item in compare_list_reduced:
                     if self.equal_dicts(compare_item, item, "state"):
                         break
-                    elif (("organization" in compare_item) # permission applies to all objects in orga
-                            and (len(compare_item) == 3) # we only have orga, team/user, and role
-                            and self.equal_dicts(compare_item, item, ["organization"] + list(item.keys() - compare_item.keys()))
-                            ):
+                    elif (
+                        ("organization" in compare_item)  # permission applies to all objects in orga
+                        and (len(compare_item) == 3)  # we only have orga, team/user, and role
+                        and self.equal_dicts(compare_item, item, ["organization"] + list(item.keys() - compare_item.keys()))
+                    ):
                         break
                 else:
                     difference.append(item)


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Attempts to fix role diff, when role is defined without specific resource_type - the role applies to all organization objects.
Sample controller_roles:

```---
controller_roles:
  - team: Ansible
    organization: Acme
    role: execute
```
When this is applied, it will add the "execute" permissions for all job templates, therefore, when object_diff runs, it should not remove those roles, returned by the api as individual roles, one per job template.


<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
