### PR TITLE
Fixed bug with docker version 7.0.0

### DIFF
--- a/.github/workflows/ci_standalone_versioned.yml
+++ b/.github/workflows/ci_standalone_versioned.yml
@@ -43,7 +43,7 @@ jobs:
         run: sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev build-essential
 
       - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose==1.25.5 docker==6.3.1 pyyaml==5.3.1
+        run: pip3 install --upgrade docker-compose==1.25.5 docker==6.1.3 pyyaml==5.3.1
 
       - name: collect system info
         run: whoami; id; pwd; ls -al; uname -a ; df -h .; mount ; cat /etc/issue; docker --version ; ps aux | fgrep -i docker; ls -al /var/run/containerd/containerd.sock

--- a/.github/workflows/ci_standalone_versioned.yml
+++ b/.github/workflows/ci_standalone_versioned.yml
@@ -43,7 +43,7 @@ jobs:
         run: sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev build-essential
 
       - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose pyyaml==5.3.1
+        run: pip3 install --upgrade docker-compose==1.25.5 docker==6.3.1 pyyaml==5.3.1
 
       - name: collect system info
         run: whoami; id; pwd; ls -al; uname -a ; df -h .; mount ; cat /etc/issue; docker --version ; ps aux | fgrep -i docker; ls -al /var/run/containerd/containerd.sock

--- a/.github/workflows/ci_standalone_versioned.yml
+++ b/.github/workflows/ci_standalone_versioned.yml
@@ -43,7 +43,7 @@ jobs:
         run: sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev build-essential
 
       - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose==1.25.5 docker==6.1.3 pyyaml==5.3.1
+        run: pip3 install --upgrade docker-compose docker==6.1.3 pyyaml==5.3.1
 
       - name: collect system info
         run: whoami; id; pwd; ls -al; uname -a ; df -h .; mount ; cat /etc/issue; docker --version ; ps aux | fgrep -i docker; ls -al /var/run/containerd/containerd.sock

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ id_rsa*
 test
 tests/output
 .vscode
+ansible.cfg

--- a/changelogs/fragments/docker7.0.0_workaround.yml
+++ b/changelogs/fragments/docker7.0.0_workaround.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - Fixed bug with docker version 7.0.0, which includes the command `docker compose` as a replace of `docker-compose`. See https://github.com/docker/docker-py/issues/3194#issuecomment-1857356075

--- a/changelogs/fragments/docker7.0.0_workaround.yml
+++ b/changelogs/fragments/docker7.0.0_workaround.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixed bug with docker version 7.0.0, which includes the command `docker compose` as a replace of `docker-compose`. See https://github.com/docker/docker-py/issues/3194#issuecomment-1857356075

--- a/roles/filetree_create/tests/.gitignore
+++ b/roles/filetree_create/tests/.gitignore
@@ -1,3 +1,4 @@
 collections
 .vault_password_file
 vault.yml
+vars.yaml


### PR DESCRIPTION
Fixed bug with docker version 7.0.0, which includes the command `docker compose` as a replacement of `docker-compose`. See https://github.com/docker/docker-py/issues/3194\#issuecomment-1857356075

<!--- markdownlint-disable MD041 -->
# What does this PR do?

Adds a workaround to let the CI to work properly meanwhile AWX is updated to use the new `docker compose` command provided by docker 7.0.0.

Also adds some files to `.gitignore`

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?

The CI process should work as expected.

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!--- resolves #[number] -->

# Other Relevant info, PRs, etc
N/A
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
