### PR TITLE
avoid the hosts populated by a constructed inventory to be removed

### DIFF
--- a/changelogs/fragments/issue_743.yml
+++ b/changelogs/fragments/issue_743.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Avoid the hosts populated by a constructed inventory to be removed

--- a/roles/object_diff/tasks/hosts.yml
+++ b/roles/object_diff/tasks/hosts.yml
@@ -13,7 +13,8 @@
                                             query_params={'organization': controller_organization_id.id,
                                               'has_inventory_sources': 'false',
                                               'not__total_hosts': '0',
-                                              'not__kind': 'smart'},
+                                              'not__kind': 'smart',
+                                              'not__kind': 'constructed'},
                                             host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                                             return_all=true, max_objects=query_controller_api_max_objects)
                                    }}"

--- a/tests/configs/differential_items.yml
+++ b/tests/configs/differential_items.yml
@@ -112,6 +112,27 @@ differential_items:
       - name: Test Inventory - Smart
         organization: Default
         state: absent
+  - name: hosts
+    with_present: false
+    differential_test_items:
+      - name: localhost
+        inventory: Demo Inventory
+    expected_test_result:
+      - name: "dummy"
+        inventory: "Inventory_Dummy_1"
+        state: absent
+      - name: "dummy"
+        inventory: "Inventory_Dummy_2"
+        state: absent
+      - name: "dummy"
+        inventory: "Inventory_Dummy_3"
+        state: absent
+      - name: "localhost"
+        inventory: "RHVM-01"
+        state: absent
+      - name: "localhost"
+        inventory: "localhost"
+        state: absent
   - name: teams
     with_present: false
     differential_test_items:

--- a/tests/configs/differential_items.yml
+++ b/tests/configs/differential_items.yml
@@ -118,15 +118,6 @@ differential_items:
       - name: localhost
         inventory: Demo Inventory
     expected_test_result:
-      - name: "dummy"
-        inventory: "Inventory_Dummy_1"
-        state: absent
-      - name: "dummy"
-        inventory: "Inventory_Dummy_2"
-        state: absent
-      - name: "dummy"
-        inventory: "Inventory_Dummy_3"
-        state: absent
       - name: "localhost"
         inventory: "RHVM-01"
         state: absent

--- a/tests/configure_controller.yml
+++ b/tests/configure_controller.yml
@@ -170,7 +170,7 @@
         validate_certs:          "{{ controller_validate_certs }}"
       ignore_errors: true  # noqa ignore-errors
 
-    - name: Get the organization ID
+    - name: "Get the organization ID"
       ansible.builtin.set_fact:
         controller_organization_id: "{{ lookup(controller_api_plugin, 'organizations', query_params={'name': 'Default'}, host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=false) }}"
 

--- a/tests/tasks/differential.yml
+++ b/tests/tasks/differential.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Get the API list in the Default Organization of all {{ differential_item.name }}"
   ansible.builtin.set_fact:
-    controller_api_results: "{{ query(controller_api_plugin, differential_item.name, query_params={'organization': controller_organization_id.id}, host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=false) }}"
+    controller_api_results: "{{ query(controller_api_plugin, differential_item.name, query_params=({'organization': controller_organization_id.id}) if differential_item.name is not match('hosts') else {}, host=controller_hostname, username=controller_username, password=controller_password, verify_ssl=false) }}"
 
 - name: "Find the difference between what is on the Controller versus curated list of {{ differential_item.name }}"
   ansible.builtin.set_fact:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
avoid the hosts populated by a constructed inventory to be removed, the same way it is controlled for the smart inventories and the inventories that are defining inventory sources.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Automatic tests are not controlling this kind of scenarios.
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #743

# Other Relevant info, PRs, etc
N/A
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
