### PR TITLE
fixes filetree_create not exporting constructed inventories when AAP < 2.4. Fixed Organization field check

### DIFF
--- a/changelogs/fragments/issue_743.yml
+++ b/changelogs/fragments/issue_743.yml
@@ -1,3 +1,4 @@
 ---
 bugfixes:
-  - Avoid the hosts populated by a constructed inventory to be removed
+  - Organization not defined when exporting some inventory sources from Tower 3.7.2
+  - Constructed inventories can only be exported when AAP version is >= 4.5.0

--- a/roles/filetree_create/tasks/all.yml
+++ b/roles/filetree_create/tasks/all.yml
@@ -1,9 +1,11 @@
 ---
-- name: "Check if the connection is to an Ansible Tower or to Automation Platform"
+- name: "Get the Tower/AAP instance version"
   ansible.builtin.set_fact:
     aap_version: "{{ lookup(controller_api_plugin, 'ping',
                        host=controller_hostname, oauth_token=controller_oauthtoken,
                        verify_ssl=controller_validate_certs).version }}"
+- name: "Check if the connection is to an Ansible Tower or to Automation Platform"
+  ansible.builtin.set_fact:
     is_aap: "{{ aap_version is version('4.0.0', '>=') }}"
     have_constructed: "{{ aap_version is version('4.5.0', '>=') }}"
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"

--- a/roles/filetree_create/tasks/all.yml
+++ b/roles/filetree_create/tasks/all.yml
@@ -1,9 +1,11 @@
 ---
 - name: "Check if the connection is to an Ansible Tower or to Automation Platform"
   ansible.builtin.set_fact:
-    is_aap: "{{ lookup(controller_api_plugin, 'ping',
+    aap_version: "{{ lookup(controller_api_plugin, 'ping',
                        host=controller_hostname, oauth_token=controller_oauthtoken,
-                       verify_ssl=controller_validate_certs).version is version('4.0.0', '>=') }}"
+                       verify_ssl=controller_validate_certs).version }}"
+    is_aap: "{{ aap_version is version('4.0.0', '>=') }}"
+    have_constructed: "{{ aap_version is version('4.5.0', '>=') }}"
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Block to get the organization_filter ID to filter all the queries"
@@ -32,7 +34,7 @@
       when: "'inventory' in input_tag or 'all' in input_tag"
     - name: "Export Constructed Inventories"
       ansible.builtin.include_tasks: "constructed_inventory.yml"
-      when: "'inventory' in input_tag or 'all' in input_tag"
+      when: "('inventory' in input_tag or 'all' in input_tag) and have_constructed"
     - name: "Export Credentials"
       ansible.builtin.include_tasks: "credentials.yml"
       when: "'credentials' in input_tag or 'all' in input_tag"

--- a/roles/filetree_create/templates/current_inventory_sources.j2
+++ b/roles/filetree_create/templates/current_inventory_sources.j2
@@ -9,7 +9,7 @@ controller_inventory_sources:
     organization: "{{ inventory_source.summary_fields.organization.name }}"
 {% endif %}
     source: "{{ inventory_source.source | default('ToDo: The source of the inventory_source was originally missing and must be specified',true) }}"
-{% if inventory_source.source_project is defined %}
+{% if inventory_source.source_project is defined and inventory_source.source_project != None %}
     source_project: "{{ inventory_source.summary_fields.source_project.name }}"
 {% endif %}
 {% if inventory_source.source_path is defined %}

--- a/roles/filetree_create/templates/current_inventory_sources.j2
+++ b/roles/filetree_create/templates/current_inventory_sources.j2
@@ -5,24 +5,24 @@ controller_inventory_sources:
 {% for inventory_source in current_inventory_sources_asset_value %}
   - name: "{{ inventory_source.name }}"
     description: "{{ inventory_source.description }}"
-{% if inventory_source.summary_fields.organization %}
+{% if inventory_source.summary_fields.organization is defined %}
     organization: "{{ inventory_source.summary_fields.organization.name }}"
 {% endif %}
     source: "{{ inventory_source.source | default('ToDo: The source of the inventory_source was originally missing and must be specified',true) }}"
-{% if inventory_source.source_project %}
+{% if inventory_source.source_project is defined %}
     source_project: "{{ inventory_source.summary_fields.source_project.name }}"
 {% endif %}
-{% if inventory_source.source_path %}
+{% if inventory_source.source_path is defined %}
     source_path: "{{ inventory_source.source_path }}"
 {% endif %}
-{% if inventory_source.source_vars and inventory_source.source_vars != '---' and inventory_source.source_vars != '' %}
+{% if inventory_source.source_vars is defined and inventory_source.source_vars != '---' and inventory_source.source_vars != '' %}
     source_vars:
       {{ inventory_source.source_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") }}
 {%- endif %}
     inventory: "{{ inventory_source.summary_fields.inventory.name }}"
     update_on_launch: "{{ inventory_source.update_on_launch }}"
     overwrite: "{{ inventory_source.overwrite }}"
-{% if inventory_source.credential %}
+{% if inventory_source.credential is defined %}
     credential: "{{ inventory_source.summary_fields.credential.name }}"
 {% endif %}
 {% set query_notification_error = query(controller_api_plugin, inventory_source.related.notification_templates_error,


### PR DESCRIPTION

<!--- markdownlint-disable MD041 -->
# What does this PR do?

Fixes two issues:

1. Tries to export constructed inventories from Tower and AAP < 2.4
2. Fails to get organization on inventory sources, when no organization is present.

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Manually tested.
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
N/A
<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!--- resolves #[number] -->

# Other Relevant info, PRs, etc
N/A
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
