### PR TITLE
Bugfix: Allow to omit "source" parameter for role inventory_sources

### DIFF
--- a/roles/inventory_sources/tasks/main.yml
+++ b/roles/inventory_sources/tasks/main.yml
@@ -46,7 +46,7 @@
   poll: 0
   register: __inventory_source_job_async
   changed_when: not __inventory_source_job_async.changed
-  when: __controller_source_item.source != "constructed"
+  when: (__controller_source_item.source | default(('scm' if controller_configuration_inventory_sources_enforce_defaults else omit), true)) != "constructed"
   vars:
     __operation: "{{ operation_translate[__controller_source_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

https://github.com/redhat-cop/controller_configuration/commit/a79f987765ae7d6ba5763c6d45c56ea7d325ec3f had a bug: It does not allow to omit the source parameter anymore, because it is evaluated before applying the default.
This PR fixes that by applying the same default as above a few lines above.

Honestly: A cleaner solution would be to revert https://github.com/redhat-cop/controller_configuration/commit/a79f987765ae7d6ba5763c6d45c56ea7d325ec3f and then take the time to implement this in a better way. Because with my PR the default is redundant. It is still better than having a bug in the code, I should say.

# How should this be tested?

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

resolves #738

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
