### PR TITLE
Fix arg_spec for organization for two vars

### DIFF
--- a/roles/organizations/meta/argument_specs.yml
+++ b/roles/organizations/meta/argument_specs.yml
@@ -58,21 +58,22 @@ argument_specs:
         #     type: list
         #     elements: str
         #     description: The notifications for approval to use for this organization in a list.
-        #   assign_galaxy_credentials_to_org:
-        #     default: true
-        #     required: false
-        #     type: bool
-        #     description: Boolean to indicate whether credentials should be assigned or not. It should be noted that credentials must exist before adding it.
-        #   assign_default_ee_to_org:
-        #     default: true
-        #     required: false
-        #     type: bool
-        #     description: Boolean to indicate whether default execution environment should be assigned or not. It should be noted that execution environment must exist before adding it.
         #   state:
         #     default: "{{ controller_state | default('present') }}"
         #     required: false
         #     type: str
         #     description: Desired state of the resource.
+
+      assign_galaxy_credentials_to_org:
+        default: true
+        required: false
+        type: bool
+        description: Boolean to indicate whether credentials should be assigned to the organization or not. It should be noted that credentials must exist before adding it.
+      assign_default_ee_to_org:
+        default: true
+        required: false
+        type: bool
+        description: Boolean to indicate whether default execution environment should be assigned to the organization or not. It should be noted that execution environment must exist before adding it.
 
       # Async variables
       controller_configuration_organizations_async_retries:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fix arg_spec for organization for `assign_galaxy_credentials_to_org` and `assign_default_ee_to_org`

# How should this be tested?
N/A - none required though if I majorly mess up CI will catch a broken arg_spec
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
No
<!--- Provide a link to any open issues that describe the problem you are solving. -->


# Other Relevant info, PRs, etc
related #763 
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
