### PR TITLE
Add missing instance arguments

### DIFF
--- a/changelogs/fragments/add_instance_arguments.yml
+++ b/changelogs/fragments/add_instance_arguments.yml
@@ -1,3 +1,3 @@
 ---
-bugfixes:
+minor_changes:
   - instance role - add missing arguments introduced in ansible.controller 4.5.0 or awx.awx 23.0.0

--- a/changelogs/fragments/add_instance_arguments.yml
+++ b/changelogs/fragments/add_instance_arguments.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - instance role - add missing arguments introduced in ansible.controller 4.5.0 or awx.awx 23.0.0

--- a/roles/instances/README.md
+++ b/roles/instances/README.md
@@ -75,12 +75,14 @@ This also speeds up the overall role.
 |Variable Name|Default Value|Required|Type|Description|
 |:---:|:---:|:---:|:---:|:---:|
 |`hostname`|""|yes|str|Hostname of this instance.|
-|`capacity_adjustment`|""|float|no|Capacity adjustment between 0 and 1. |
+|`capacity_adjustment`|""|float|no|Capacity adjustment between 0 and 1.|
 |`enabled`|False|no|bool|If true, the instance will be enabled and used.|
 |`managed_by_policy`|False|no|bool|If true, will be managed by instance group policy.|
 |`node_type`|""|no|str|Role that this node plays in the mesh. Most likely Execution. Current options are 'execution'.|
 |`node_state`|""|no|str|Indicates the current life cycle stage of this instance. Current options are 'installed' and 'deprovisioning'.|
 |`listener_port`|""|no|int|Port that Receptor will listen for incoming connections on.|
+|`peers`|[]|no|list|List of peers to connect outbound to. Only configurable for hop and execution nodes.|
+|`peers_from_control_nodes`|False|no|bool|If enabled, control plane nodes will automatically peer to this node.|
 
 ### Standard Instance Data Structure
 

--- a/roles/instances/tasks/main.yml
+++ b/roles/instances/tasks/main.yml
@@ -9,6 +9,8 @@
     node_type:                      "{{ __controller_instance_item.node_type | default(omit, true) }}"
     node_state:                     "{{ __controller_instance_item.node_state | default(omit, true) }}"
     listener_port:                  "{{ __controller_instance_item.listener_port | default((27199 if controller_configuration_instances_enforce_defaults else omit), true) }}"
+    peers:                          "{{ __controller_instance_item.peers | default(([] if controller_configuration_instances_enforce_defaults else omit), true) }}"
+    peers_from_control_nodes:       "{{ __controller_instance_item.peers_from_control_nodes | default((false if controller_configuration_instances_enforce_defaults else omit), true) }}"
 
     # Role Standard Options
     controller_username:            "{{ controller_username | default(omit, true) }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Add 2 options (`peers` and `peers_from_control_nodes`) to the instance role

# How should this be tested?

Automated (by creating instances)


# Other Relevant info, PRs, etc

The arguments were added in ansible.controller>=4.5.0 ([release notes](https://docs.ansible.com/automation-controller/latest/html/release-notes/relnotes.html#automation-controller-version-4-5-0) (as "hop node support")) and awx.awx>=23.0.0 ([release note](https://github.com/ansible/awx/releases/tag/23.0.0) and [feature PR](https://github.com/ansible/awx/pull/13904/files))