### PR TITLE
Add playbooks to manage configuration files

### DIFF
--- a/changelogs/fragments/add_playbooks.yml
+++ b/changelogs/fragments/add_playbooks.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add two playbooks to simplify management of Configuration as Code files

--- a/playbooks/rename_objects.yaml
+++ b/playbooks/rename_objects.yaml
@@ -1,0 +1,25 @@
+---
+- name: "Play to rename an object to every other object that is using it"
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: "get all the files using this object from the specified path"
+      ansible.builtin.find:
+        paths: "{{ path }}"
+        file_type: file
+        recurse: true
+        read_whole_file: true
+        contains: "{{ current_name | regex_escape() }}"
+      register: __list_files
+
+    - name: "Update the name into the found files"
+      ansible.builtin.replace:
+        path: "{{ __file.path }}"
+        regexp: '^(.*){{ current_name | regex_escape() }}(.*)$'
+        replace: '\1{{ new_name }}\2'
+      loop: "{{ __list_files.files }}"
+      loop_control:
+        loop_var: __file
+...
+# ansible-playbook rename_objects.yaml -e '{path: /home/ivan/tmp, current_name: "Current Name", new_name: "New Name"}'

--- a/playbooks/rename_objects.yaml
+++ b/playbooks/rename_objects.yaml
@@ -4,7 +4,7 @@
   connection: local
   gather_facts: false
   tasks:
-    - name: "get all the files using this object from the specified path"
+    - name: "Get all the files using this object from the specified path"
       ansible.builtin.find:
         paths: "{{ path }}"
         file_type: file
@@ -21,5 +21,6 @@
       loop: "{{ __list_files.files }}"
       loop_control:
         loop_var: __file
-...
+
 # ansible-playbook rename_objects.yaml -e '{path: /home/ivan/tmp, current_name: "Current Name", new_name: "New Name"}'
+...

--- a/playbooks/set_organization.yaml
+++ b/playbooks/set_organization.yaml
@@ -1,0 +1,23 @@
+---
+- name: "Play to set given organization to every object found in the search path"
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: "Get all the files from the specified path"
+      ansible.builtin.find:
+        paths: "{{ path }}"
+        file_type: file
+        recurse: true
+      register: __list_files
+
+    - name: "Update the organization into the found files"
+      ansible.builtin.replace:
+        path: "{{ __file.path }}"
+        regexp: '^(.*)organization: (.*)$'
+        replace: '\1organization: {{ new_organization }}'
+      loop: "{{ __list_files.files }}"
+      loop_control:
+        loop_var: __file
+...
+# ansible-playbook set_organization.yaml -e '{path: /home/ivan/tmp, new_organization: "Linux_Squad[ORG]"}'

--- a/playbooks/set_organization.yaml
+++ b/playbooks/set_organization.yaml
@@ -19,5 +19,6 @@
       loop: "{{ __list_files.files }}"
       loop_control:
         loop_var: __file
-...
+
 # ansible-playbook set_organization.yaml -e '{path: /home/ivan/tmp, new_organization: "Linux_Squad[ORG]"}'
+...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Adds two playbooks to ease the management of the configuration files:

- `rename_objects.yaml`: If there's a need of renaming one credential (for example), this playbook can be used to rename the credential itself and update all the Job Templates / Workflows / Organizations... that are using the old credential name to the new one.
- `set_organization.yaml`: If you need to set the organization name for all the objects contained in a path, this playbook will do the job easy.

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?

This can be applied to any path populated with CasC content. Each playbook has an execution example in the last line of the file.

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
N/A
<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!--- resolves #[number] -->

# Other Relevant info, PRs, etc
N/A
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
