### PR TITLE
Update current_inventory_sources.j2 to fix the empty credential scenario

### DIFF
--- a/changelogs/fragments/empty-inventory-source-credential.yaml
+++ b/changelogs/fragments/empty-inventory-source-credential.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed the empty credential scenario where the playbook looks for credential names and fails with undefied value.
+...

--- a/roles/filetree_create/templates/current_inventory_sources.j2
+++ b/roles/filetree_create/templates/current_inventory_sources.j2
@@ -22,7 +22,7 @@ controller_inventory_sources:
     inventory: "{{ inventory_source.summary_fields.inventory.name }}"
     update_on_launch: "{{ inventory_source.update_on_launch }}"
     overwrite: "{{ inventory_source.overwrite }}"
-{% if inventory_source.credential is defined %}
+{% if inventory_source.credential is defined and inventory_source.summary_fields.credential is defined %}
     credential: "{{ inventory_source.summary_fields.credential.name }}"
 {% endif %}
 {% set query_notification_error = query(controller_api_plugin, inventory_source.related.notification_templates_error,

--- a/roles/filetree_create/templates/current_inventory_sources.j2
+++ b/roles/filetree_create/templates/current_inventory_sources.j2
@@ -22,7 +22,7 @@ controller_inventory_sources:
     inventory: "{{ inventory_source.summary_fields.inventory.name }}"
     update_on_launch: "{{ inventory_source.update_on_launch }}"
     overwrite: "{{ inventory_source.overwrite }}"
-{% if inventory_source.credential is defined and inventory_source.summary_fields.credential is defined %}
+{% if inventory_source.summary_fields.credential is defined %}
     credential: "{{ inventory_source.summary_fields.credential.name }}"
 {% endif %}
 {% set query_notification_error = query(controller_api_plugin, inventory_source.related.notification_templates_error,


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
This is related to the issue #811.

<!--- Brief explanation of the code or documentation change you've made -->
If no credential is assigned to the inventory sources, still the `inventory_source.credential` will be defined but with `[]` value. Which will cause an issue as the actual `inventory_source.summary_fields.credential` will be empty. So need to ensure the `inventory_source.summary_fields.credential` is also defined and not empty. 

# How should this be tested?

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
Resolves #811.

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->

# Changelog
- Fix the empty credential scenario where the playbook is looking for credential names and failed with `undefied` value.
