### PR TITLE
Fix changed_when statement in all roles to show correct state and dis…

### DIFF
--- a/changelogs/fragments/check_state.yml
+++ b/changelogs/fragments/check_state.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix changed_when statement in all roles to show correct state
+...

--- a/roles/applications/tasks/main.yml
+++ b/roles/applications/tasks/main.yml
@@ -28,7 +28,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __applications_job_async
-  changed_when: not __applications_job_async.changed
+  changed_when: "(__applications_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__application_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/bulk_host_create/tasks/main.yml
+++ b/roles/bulk_host_create/tasks/main.yml
@@ -20,7 +20,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __controller_bulk_hosts_job_async
-  changed_when: not __controller_bulk_hosts_job_async.changed
+  changed_when: "(__controller_bulk_hosts_job_async.changed if ansible_check_mode else false)"
   vars:
     ansible_async_dir: '{{ controller_configuration_async_dir }}'
 

--- a/roles/credential_input_sources/tasks/main.yml
+++ b/roles/credential_input_sources/tasks/main.yml
@@ -24,7 +24,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __credential_input_sources_job_async
-  changed_when: not __credential_input_sources_job_async.changed
+  changed_when: "(__credential_input_sources_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__cred_input_src_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/credential_types/tasks/main.yml
+++ b/roles/credential_types/tasks/main.yml
@@ -25,7 +25,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __credentialtypes_job_async
-  changed_when: not __credentialtypes_job_async.changed
+  changed_when: "(__credentialtypes_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_credential_type_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/credentials/tasks/main.yml
+++ b/roles/credentials/tasks/main.yml
@@ -28,7 +28,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __credentials_job_async
-  changed_when: not __credentials_job_async.changed
+  changed_when: "(__credentials_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_credentials_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/execution_environments/tasks/main.yml
+++ b/roles/execution_environments/tasks/main.yml
@@ -28,7 +28,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __execution_environments_job_async
-  changed_when: not __execution_environments_job_async.changed
+  changed_when: "(__execution_environments_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__execution_environments_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/groups/tasks/main.yml
+++ b/roles/groups/tasks/main.yml
@@ -30,7 +30,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __group_job_async
-  changed_when: not __group_job_async.changed
+  changed_when: "(__group_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_groups_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/hosts/tasks/main.yml
+++ b/roles/hosts/tasks/main.yml
@@ -25,7 +25,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __host_job_async
-  changed_when: not __host_job_async.changed
+  changed_when: "(__host_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_host_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/instance_groups/tasks/main.yml
+++ b/roles/instance_groups/tasks/main.yml
@@ -31,7 +31,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __instance_groups_job_async
-  changed_when: not __instance_groups_job_async.changed
+  changed_when: "(__instance_groups_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_instance_group_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/instances/tasks/main.yml
+++ b/roles/instances/tasks/main.yml
@@ -29,7 +29,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __instance_job_async
-  changed_when: not __instance_job_async.changed
+  changed_when: "(__instance_job_async.changed if ansible_check_mode else false)"
   vars:
     ansible_async_dir: '{{ controller_configuration_async_dir }}'
 

--- a/roles/inventories/tasks/main.yml
+++ b/roles/inventories/tasks/main.yml
@@ -30,7 +30,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __inventories_job_async
-  changed_when: not __inventories_job_async.changed
+  changed_when: "(__inventories_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_inventory_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/inventory_sources/tasks/main.yml
+++ b/roles/inventory_sources/tasks/main.yml
@@ -45,7 +45,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __inventory_source_job_async
-  changed_when: not __inventory_source_job_async.changed
+  changed_when: "(__inventory_source_job_async.changed if ansible_check_mode else false)"
   when: (__controller_source_item.source | default(('scm' if controller_configuration_inventory_sources_enforce_defaults else omit), true)) != "constructed"
   vars:
     __operation: "{{ operation_translate[__controller_source_item.state | default(controller_state) | default('present')] }}"

--- a/roles/job_templates/tasks/main.yml
+++ b/roles/job_templates/tasks/main.yml
@@ -73,7 +73,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __job_templates_job_async
-  changed_when: not __job_templates_job_async.changed
+  changed_when: "(__job_templates_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_template_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/labels/tasks/main.yml
+++ b/roles/labels/tasks/main.yml
@@ -22,7 +22,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __controller_label_job_async
-  changed_when: not __controller_label_job_async.changed
+  changed_when: "(__controller_label_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_label_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/notification_templates/tasks/main.yml
+++ b/roles/notification_templates/tasks/main.yml
@@ -27,7 +27,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __controller_notification_job_async
-  changed_when: not __controller_notification_job_async.changed
+  changed_when: "(__controller_notification_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_notification_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/organizations/tasks/main.yml
+++ b/roles/organizations/tasks/main.yml
@@ -31,7 +31,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __organizations_job_async
-  changed_when: not __organizations_job_async.changed
+  changed_when: "(__organizations_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_organizations_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/project_update/tasks/main.yml
+++ b/roles/project_update/tasks/main.yml
@@ -28,7 +28,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __project_update_job_async
-  changed_when: not __project_update_job_async.changed
+  changed_when: "(__project_update_job_async.changed if ansible_check_mode else false)"
   vars:
     ansible_async_dir: '{{ controller_configuration_async_dir }}'
 

--- a/roles/projects/tasks/main.yml
+++ b/roles/projects/tasks/main.yml
@@ -46,7 +46,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __projects_job_async
-  changed_when: not __projects_job_async.changed
+  changed_when: "(__projects_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_project_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/roles/tasks/main.yml
+++ b/roles/roles/tasks/main.yml
@@ -40,7 +40,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __controller_role_job_async
-  changed_when: not __controller_role_job_async.changed
+  changed_when: "(__controller_role_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_role_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/schedules/tasks/main.yml
+++ b/roles/schedules/tasks/main.yml
@@ -42,7 +42,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __controller_schedule_job_async
-  changed_when: not __controller_schedule_job_async.changed
+  changed_when: "(__controller_schedule_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_schedule_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/settings/tasks/main.yml
+++ b/roles/settings/tasks/main.yml
@@ -23,7 +23,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __controller_setting_job_async
-  changed_when: not __controller_setting_job_async.changed
+  changed_when: "(__controller_setting_job_async.changed if ansible_check_mode else false)"
   vars:
     ansible_async_dir: '{{ controller_configuration_async_dir }}'
 

--- a/roles/teams/tasks/main.yml
+++ b/roles/teams/tasks/main.yml
@@ -23,7 +23,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __controller_team_job_async
-  changed_when: not __controller_team_job_async.changed
+  changed_when: "(__controller_team_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_team_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -32,7 +32,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __controller_user_accounts_job_async
-  changed_when: not __controller_user_accounts_job_async.changed
+  changed_when: "(__controller_user_accounts_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__controller_user_accounts_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'

--- a/roles/workflow_job_templates/tasks/main.yml
+++ b/roles/workflow_job_templates/tasks/main.yml
@@ -49,7 +49,7 @@
   async: "{{ ansible_check_mode | ternary(0, 1000) }}"
   poll: 0
   register: __workflows_job_async
-  changed_when: not __workflows_job_async.changed
+  changed_when: "(__workflows_job_async.changed if ansible_check_mode else false)"
   vars:
     __operation: "{{ operation_translate[__workflow_loop_item.state | default(controller_state) | default('present')] }}"
     ansible_async_dir: '{{ controller_configuration_async_dir }}'


### PR DESCRIPTION
# What does this PR do?

In order to display diff output and correct changed state, `changed_when` statement needs to be set properly.

Currently `changed` is just inverted with the `not` operator, which doesn't make sense.

# How should this be tested?
We tested this in our environment. Please let me know if I can help you in adding automated tests.

# Is there a relevant Issue open for this?
No

# Other Relevant info, PRs, etc

In order to support diff mode I also raised the following issue and pull request:
- https://github.com/ansible/awx/pull/15118
- https://github.com/ansible/awx/issues/14903

These are related to to underlying `awx.awx` (= `ansible.controller`) modules, used in the `infra.controller_configuration` roles
