### PR TITLE
allow max_hosts to be set to 0 (infinite) if controller_configuration_organizations_enforce_defaults is true

### DIFF
--- a/roles/organizations/tasks/main.yml
+++ b/roles/organizations/tasks/main.yml
@@ -5,7 +5,7 @@
     new_name:                           "{{ __controller_organizations_item.new_name | default(omit) }}"
     description:                        "{{ __controller_organizations_item.description | default(('' if controller_configuration_organizations_enforce_defaults else omit), true) }}"
     custom_virtualenv:                  "{{ __controller_organizations_item.custom_virtualenv | default(omit, true) }}"
-    max_hosts:                          "{{ __controller_organizations_item.max_hosts | default(omit, true) }}"
+    max_hosts:                          "{{ __controller_organizations_item.max_hosts | default(( 0 if controller_configuration_organizations_enforce_defaults else omit), true) }}"
     instance_groups:                    "{{ __controller_organizations_item.instance_groups | default(([] if controller_configuration_organizations_enforce_defaults else omit), true) }}"
     default_environment:                "{{ (__controller_organizations_item.default_environment.name | default(__controller_organizations_item.default_environment | default(__controller_organizations_item.execution_environment | default(omit)))) if (assign_default_ee_to_org is defined and assign_default_ee_to_org) else omit }}"
     galaxy_credentials:                 "{{ (__controller_organizations_item.galaxy_credentials | default(([] if controller_configuration_organizations_enforce_defaults else omit), true)) if (assign_galaxy_credentials_to_org is defined and assign_galaxy_credentials_to_org) else omit }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
If max_hosts > 0 on the Controller, the user cannot set it to zero using the configuration as code.
This tweak solve this issue if `controller_configuration_organizations_enforce_defaults` is set to `true`.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Create an organization with max_hosts > 0 on the controller.
Try to set max_hosts to zero with the configuration as code. This will fail.
After applyin this PR set `controller_configuration_organizations_enforce_defaults` to `true` and re-run the configuration as code. The max_hosts will now be set to zero on the Controller.

This was tested on :
ansible [core 2.16.7]
python version = 3.11.8 (main, Feb 26 2024, 06:51:39) [GCC 8.5.0 20210514 (Red Hat 8.5.0-18)] (/opt/python/3.11/bin/python3.11)
  jinja version = 3.1.4

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
