### PR TITLE
fixes an issue where spaces are stripped from variables applied to many roles

### DIFF
--- a/changelogs/fragments/var_spaces.yml
+++ b/changelogs/fragments/var_spaces.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - fixes an issue where spaces are stripped from variables applied to the inventories, inventory_sources, hosts, groups, credential_types and notification_templates roles
+...

--- a/roles/credential_types/tasks/main.yml
+++ b/roles/credential_types/tasks/main.yml
@@ -4,7 +4,7 @@
     name:                           "{{ __controller_credential_type_item.name | mandatory }}"
     new_name:                       "{{ __controller_credential_type_item.new_name | default(omit, true) }}"
     description:                    "{{ __controller_credential_type_item.description | default(('' if controller_configuration_credential_types_enforce_defaults else omit), true) }}"
-    injectors:                      "{{ __controller_credential_type_item.injectors | default(({} if controller_configuration_credential_types_enforce_defaults else omit), true) | regex_replace('[ ]{2,}', '') }}"
+    injectors:                      "{{ __controller_credential_type_item.injectors | default(({} if controller_configuration_credential_types_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
     inputs:                         "{{ __controller_credential_type_item.inputs | default(({} if controller_configuration_credential_types_enforce_defaults else omit), true) }}"
     kind:                           "{{ __controller_credential_type_item.kind | default('cloud') }}"
     state:                          "{{ __controller_credential_type_item.state | default(controller_state | default('present')) }}"

--- a/roles/groups/tasks/main.yml
+++ b/roles/groups/tasks/main.yml
@@ -7,7 +7,7 @@
     new_name:                       "{{ __controller_groups_item.new_name | default(omit, true) }}"
     description:                    "{{ __controller_groups_item.description | default(('' if controller_configuration_groups_enforce_defaults else omit), true) }}"
     inventory:                      "{{ __controller_groups_item.inventory | mandatory }}"
-    variables:                      "{{ __controller_groups_item.variables | default(({} if controller_configuration_groups_enforce_defaults else omit), true) | regex_replace('[ ]{2,}', '') }}"
+    variables:                      "{{ __controller_groups_item.variables | default(({} if controller_configuration_groups_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
     hosts:                          "{{ __controller_groups_item.hosts | default(([] if controller_configuration_groups_enforce_defaults else omit), true) }}"
     children:                       "{{ __controller_groups_item.children | default(([] if controller_configuration_groups_enforce_defaults else omit), true) }}"
     preserve_existing_hosts:        "{{ __controller_groups_item.preserve_existing_hosts | default((false if controller_configuration_groups_enforce_defaults else omit)) }}"

--- a/roles/hosts/tasks/main.yml
+++ b/roles/hosts/tasks/main.yml
@@ -7,7 +7,7 @@
     inventory:              "{{ __controller_host_item.inventory | mandatory }}"
     enabled:                "{{ __controller_host_item.enabled | default((false if controller_configuration_host_enforce_defaults else omit), true) }}"
     state:                  "{{ __controller_host_item.state | default(controller_state | default('present')) }}"
-    variables:              "{{ __controller_host_item.variables | default(({} if controller_configuration_host_enforce_defaults else omit), true) | regex_replace('[ ]{2,}', '') }}"
+    variables:              "{{ __controller_host_item.variables | default(({} if controller_configuration_host_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
 
     # Role Standard Options
     controller_host:        "{{ controller_hostname | default(omit, true) }}"

--- a/roles/inventories/tasks/main.yml
+++ b/roles/inventories/tasks/main.yml
@@ -8,7 +8,7 @@
     organization:                       "{{ __controller_inventory_item.organization.name | default(__controller_inventory_item.organization) | mandatory }}"
     instance_groups:                    "{{ __controller_inventory_item.instance_groups | default(([] if controller_configuration_inventories_enforce_defaults else omit), true) }}"
     input_inventories:                  "{{ __controller_inventory_item.input_inventories | default(([] if controller_configuration_inventories_enforce_defaults else omit), true) }}"
-    variables:                          "{{ __controller_inventory_item.variables | default(({} if controller_configuration_inventories_enforce_defaults else omit), true) | regex_replace('[ ]{2,}', '') }}"
+    variables:                          "{{ __controller_inventory_item.variables | default(({} if controller_configuration_inventories_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
     kind:                               "{{ __controller_inventory_item.kind | default(('' if controller_configuration_inventories_enforce_defaults else omit), true) }}"
     host_filter:                        "{{ __controller_inventory_item.host_filter | default(('' if controller_configuration_inventories_enforce_defaults else omit), true) }}"
     prevent_instance_group_fallback:    "{{ __controller_inventory_item.prevent_instance_group_fallback | default((false if controller_configuration_inventories_enforce_defaults else omit), true) }}"

--- a/roles/inventory_sources/tasks/main.yml
+++ b/roles/inventory_sources/tasks/main.yml
@@ -8,7 +8,7 @@
     organization:                         "{{ __controller_source_item.inventory.organization.name | default(__controller_source_item.organization | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true)) }}"
     source:                               "{{ __controller_source_item.source | default(('scm' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
     source_path:                          "{{ __controller_source_item.source_path | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-    source_vars:                          "{{ __controller_source_item.source_vars | default(({} if controller_configuration_inventory_sources_enforce_defaults else omit), true) | regex_replace('[ ]{2,}', '') }}"
+    source_vars:                          "{{ __controller_source_item.source_vars | default(({} if controller_configuration_inventory_sources_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
     enabled_var:                          "{{ __controller_source_item.enabled_var | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
     enabled_value:                        "{{ __controller_source_item.enabled_value | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
     host_filter:                          "{{ __controller_source_item.host_filter | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"

--- a/roles/notification_templates/tasks/main.yml
+++ b/roles/notification_templates/tasks/main.yml
@@ -8,7 +8,7 @@
     organization:                   "{{ __controller_notification_item.organization.name | default(__controller_notification_item.organization) | mandatory }}"
     notification_type:              "{{ __controller_notification_item.notification_type | default(omit, true) | mandatory }}"
     notification_configuration:     "{{ __controller_notification_item.notification_configuration | default(({} if controller_configuration_notifications_enforce_defaults else omit), true) }}"
-    messages:                       "{{ __controller_notification_item.messages | default(({} if controller_configuration_notifications_enforce_defaults else omit), true) | regex_replace('[ ]{2,}', '') }}"
+    messages:                       "{{ __controller_notification_item.messages | default(({} if controller_configuration_notifications_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
     state:                          "{{ __controller_notification_item.state | default(controller_state | default('present')) }}"
 
     # Role Standard Options


### PR DESCRIPTION
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Fixes issue described in #849 where spaces were stripped from a variable. This was done to allow for variables to be placed within it such as `{  { myvar }}`. However the old code just stripped away any double spaces. This now looks specifically for `{  {` and replaces with `{{`.

Note that there wasn't a seemingly easy way to get that replace to work properly as it always wants to interpret `{{` as a variable and then fails out. Instead I've just captured `{  {` and replaced with a string which is highly unlikely to be used and then removed that string to set as `{{`.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Probably too edge case for CI to test but this is the code I used:

```
---
- hosts: localhost
  vars:
    controller_inventories:
      - name: my_test
        organization: Default
        variables:
          managed_ansible: |
            #######################################
            ##            DO NOT EDIT!           ##
            ## This file is managed by {  { provider }}   ##
            ##            DO NOT EDIT!           ##
            #######################################
          ansible_connection: ssh

  tasks:
    - ansible.builtin.include_role:
        name: infra.controller_configuration.dispatch
```

which provides the following in the variables for the inventory within the controller UI:

```
managed_ansible: |
  #######################################
  ##            DO NOT EDIT!           ##
  ## This file is managed by {{ provider }}   ##
  ##            DO NOT EDIT!           ##
  #######################################
ansible_connection: ssh
```
# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #849 

# Other Relevant info, PRs, etc
No
