### PR TITLE
Omit id for objects during export with filtree_create

### DIFF
--- a/changelogs/fragments/filetree_create_omit_id.yml
+++ b/changelogs/fragments/filetree_create_omit_id.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - filetree_create able to create files without id values

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -22,6 +22,7 @@ The following variables are required for that role to work properly:
 | `input_tag` | `['all']` | no | List of Strings | The tags which are applied to the 'sub-roles'. If 'all' is in the list (the default value) then all roles will be called.  Valid tags include ['all', 'labels', 'applications', 'instance_groups', 'settings', 'inventory', 'credentials', 'credential_types', 'notification_templates', 'users', 'teams', 'roles', 'organizations', 'projects', 'execution_environments', 'job_templates', 'workflow_job_templates', 'workflow_job_template_nodes', 'schedules'] |
 | `flatten_output` | N/A | no | bool | Whether to flatten the output in single files per each object type instead of the normal exportation structure |
 | `show_encrypted` | N/A | no | bool | Whether to remove the string '\$encrypted\$' in credentials output (not the actual credential value) |
+| `omit_id` | N/A | no | bool | Whether to create output files without objects id.|
 
 ## Dependencies
 

--- a/roles/filetree_create/meta/argument_specs.yml
+++ b/roles/filetree_create/meta/argument_specs.yml
@@ -20,6 +20,11 @@ argument_specs:
         required: false
         type: int
         description: Maximum number of objects to return from the list. If a list view returns more an max_objects an exception will be raised
+      omit_id:
+        default: None
+        required: false
+        type: bool
+        description: Whether to create output files without objects id.
 
 
       # Async variables

--- a/roles/filetree_create/tasks/applications.yml
+++ b/roles/filetree_create/tasks/applications.yml
@@ -69,7 +69,7 @@
         application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
         application_id: "{{ current_applications_asset_value.id }}"
         application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/applications/{{ application_id }}_{{ application_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/applications/{{ application_id ~ '_') if omit_id is not defined else ''}}{{ application_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ applications_lookvar }}"
       loop_control:
         loop_var: current_applications_asset_value

--- a/roles/filetree_create/tasks/applications.yml
+++ b/roles/filetree_create/tasks/applications.yml
@@ -69,7 +69,7 @@
         application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
         application_id: "{{ current_applications_asset_value.id }}"
         application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/applications/{{ (application_id ~ '_') if omit_id is not defined else ''}}{{ application_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/applications/{{ (application_id ~ '_') if omit_id is not defined else '' }}{{ application_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ applications_lookvar }}"
       loop_control:
         loop_var: current_applications_asset_value

--- a/roles/filetree_create/tasks/applications.yml
+++ b/roles/filetree_create/tasks/applications.yml
@@ -69,7 +69,7 @@
         application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
         application_id: "{{ current_applications_asset_value.id }}"
         application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/applications/{{ application_id ~ '_') if omit_id is not defined else ''}}{{ application_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/applications/{{ (application_id ~ '_') if omit_id is not defined else ''}}{{ application_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ applications_lookvar }}"
       loop_control:
         loop_var: current_applications_asset_value

--- a/roles/filetree_create/tasks/constructed_inventory.yml
+++ b/roles/filetree_create/tasks/constructed_inventory.yml
@@ -80,7 +80,7 @@
       vars:
         inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ current_inventories_asset_value.id }}_{{ inventory_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ current_inventories_asset_value.id ~ '_') if omit_id is not defined else ''}}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ constructed_inventory_lookvar }}"
       loop_control:
         loop_var: current_inventories_asset_value

--- a/roles/filetree_create/tasks/constructed_inventory.yml
+++ b/roles/filetree_create/tasks/constructed_inventory.yml
@@ -80,7 +80,7 @@
       vars:
         inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ current_inventories_asset_value.id ~ '_') if omit_id is not defined else ''}}{{ inventory_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else ''}}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ constructed_inventory_lookvar }}"
       loop_control:
         loop_var: current_inventories_asset_value

--- a/roles/filetree_create/tasks/constructed_inventory.yml
+++ b/roles/filetree_create/tasks/constructed_inventory.yml
@@ -80,7 +80,7 @@
       vars:
         inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else ''}}{{ inventory_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ constructed_inventory_lookvar }}"
       loop_control:
         loop_var: current_inventories_asset_value

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -69,7 +69,7 @@
         credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         credentials_id: "{{ current_credentials_asset_value.id }}"
         credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/credentials/{{ credentials_id }}_{{ credentials_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/credentials/{{ credentials_id ~ '_') if omit_id is not defined else ''}}{{ credentials_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ credentials_lookvar }}"
       loop_control:
         loop_var: current_credentials_asset_value

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -69,7 +69,7 @@
         credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         credentials_id: "{{ current_credentials_asset_value.id }}"
         credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/credentials/{{ credentials_id ~ '_') if omit_id is not defined else ''}}{{ credentials_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/credentials/{{ (credentials_id ~ '_') if omit_id is not defined else ''}}{{ credentials_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ credentials_lookvar }}"
       loop_control:
         loop_var: current_credentials_asset_value

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -69,7 +69,7 @@
         credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         credentials_id: "{{ current_credentials_asset_value.id }}"
         credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/credentials/{{ (credentials_id ~ '_') if omit_id is not defined else ''}}{{ credentials_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/credentials/{{ (credentials_id ~ '_') if omit_id is not defined else '' }}{{ credentials_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ credentials_lookvar }}"
       loop_control:
         loop_var: current_credentials_asset_value

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -81,7 +81,7 @@
       vars:
         inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else ''}}{{ inventory_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ inventory_lookvar }}"
       loop_control:
         loop_var: current_inventories_asset_value

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -81,7 +81,7 @@
       vars:
         inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ current_inventories_asset_value.id }}_{{ inventory_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ current_inventories_asset_value.id ~ '_') if omit_id is not defined else ''}}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ inventory_lookvar }}"
       loop_control:
         loop_var: current_inventories_asset_value

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -81,7 +81,7 @@
       vars:
         inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ current_inventories_asset_value.id ~ '_') if omit_id is not defined else ''}}{{ inventory_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else ''}}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ inventory_lookvar }}"
       loop_control:
         loop_var: current_inventories_asset_value

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -84,7 +84,7 @@
         job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         job_template_id: "{{ current_job_templates_asset_value.id }}"
         job_template_name: "{{ current_job_templates_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ job_template_organization | regex_replace('/', '_') }}/job_templates/{{ (job_template_id ~ '_') if omit_id is not defined else ''}}{{ job_template_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ job_template_organization | regex_replace('/', '_') }}/job_templates/{{ (job_template_id ~ '_') if omit_id is not defined else '' }}{{ job_template_name | regex_replace('/', '_') }}.yaml"
         query_labels: "{{ query(controller_api_plugin, current_job_templates_asset_value.related.labels,
                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -84,7 +84,7 @@
         job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         job_template_id: "{{ current_job_templates_asset_value.id }}"
         job_template_name: "{{ current_job_templates_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ job_template_organization | regex_replace('/', '_') }}/job_templates/{{ job_template_id }}_{{ job_template_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ job_template_organization | regex_replace('/', '_') }}/job_templates/{{ (job_template_id ~ '_') if omit_id is not defined else ''}}{{ job_template_name | regex_replace('/', '_') }}.yaml"
         query_labels: "{{ query(controller_api_plugin, current_job_templates_asset_value.related.labels,
                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/labels.yml
+++ b/roles/filetree_create/tasks/labels.yml
@@ -69,7 +69,7 @@
         label_organization: "{{ current_labels_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
         label_id: "{{ current_labels_asset_value.id }}"
         label_name: "{{ current_labels_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/labels/{{ (label_id ~ '_') if omit_id is not defined else ''}}{{ label_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/labels/{{ (label_id ~ '_') if omit_id is not defined else '' }}{{ label_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ labels_lookvar }}"
       loop_control:
         loop_var: current_labels_asset_value

--- a/roles/filetree_create/tasks/labels.yml
+++ b/roles/filetree_create/tasks/labels.yml
@@ -69,7 +69,7 @@
         label_organization: "{{ current_labels_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
         label_id: "{{ current_labels_asset_value.id }}"
         label_name: "{{ current_labels_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/labels/{{ label_id ~ '_') if omit_id is not defined else ''}}{{ label_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/labels/{{ (label_id ~ '_') if omit_id is not defined else ''}}{{ label_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ labels_lookvar }}"
       loop_control:
         loop_var: current_labels_asset_value

--- a/roles/filetree_create/tasks/labels.yml
+++ b/roles/filetree_create/tasks/labels.yml
@@ -69,7 +69,7 @@
         label_organization: "{{ current_labels_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
         label_id: "{{ current_labels_asset_value.id }}"
         label_name: "{{ current_labels_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/labels/{{ label_id }}_{{ label_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/labels/{{ label_id ~ '_') if omit_id is not defined else ''}}{{ label_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ labels_lookvar }}"
       loop_control:
         loop_var: current_labels_asset_value

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -80,7 +80,7 @@
         project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
         project_id: "{{ current_projects_asset_value.id }}"
         project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/projects/{{ project_id }}_{{ project_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/projects/{{ project_id ~ '_') if omit_id is not defined else ''}}{{ project_name | regex_replace('/', '_') }}.yaml"
         query_notification_error: "{{ query(controller_api_plugin, current_projects_asset_value.related.notification_templates_error,
                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -80,7 +80,7 @@
         project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
         project_id: "{{ current_projects_asset_value.id }}"
         project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/projects/{{ project_id ~ '_') if omit_id is not defined else ''}}{{ project_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/projects/{{ (project_id ~ '_') if omit_id is not defined else ''}}{{ project_name | regex_replace('/', '_') }}.yaml"
         query_notification_error: "{{ query(controller_api_plugin, current_projects_asset_value.related.notification_templates_error,
                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -80,7 +80,7 @@
         project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
         project_id: "{{ current_projects_asset_value.id }}"
         project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/projects/{{ (project_id ~ '_') if omit_id is not defined else ''}}{{ project_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/projects/{{ (project_id ~ '_') if omit_id is not defined else '' }}{{ project_name | regex_replace('/', '_') }}.yaml"
         query_notification_error: "{{ query(controller_api_plugin, current_projects_asset_value.related.notification_templates_error,
                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/schedules.yml
+++ b/roles/filetree_create/tasks/schedules.yml
@@ -64,7 +64,7 @@
       vars:
         label_id: "{{ current_schedules_asset_value.id }}"
         label_name: "{{ current_schedules_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/schedules/{{ (label_id ~ '_') if omit_id is not defined else ''}}{{ label_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/schedules/{{ (label_id ~ '_') if omit_id is not defined else '' }}{{ label_name | regex_replace('/', '_') }}.yaml"
         query_credentials: "{{ query(controller_api_plugin, current_schedules_asset_value.related.credentials,
                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) if current_schedules_asset_value.related.credentials is defined else [] }}"

--- a/roles/filetree_create/tasks/schedules.yml
+++ b/roles/filetree_create/tasks/schedules.yml
@@ -64,7 +64,7 @@
       vars:
         label_id: "{{ current_schedules_asset_value.id }}"
         label_name: "{{ current_schedules_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/schedules/{{ label_id ~ '_') if omit_id is not defined else ''}}{{ label_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/schedules/{{ (label_id ~ '_') if omit_id is not defined else ''}}{{ label_name | regex_replace('/', '_') }}.yaml"
         query_credentials: "{{ query(controller_api_plugin, current_schedules_asset_value.related.credentials,
                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) if current_schedules_asset_value.related.credentials is defined else [] }}"

--- a/roles/filetree_create/tasks/schedules.yml
+++ b/roles/filetree_create/tasks/schedules.yml
@@ -64,7 +64,7 @@
       vars:
         label_id: "{{ current_schedules_asset_value.id }}"
         label_name: "{{ current_schedules_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/schedules/{{ label_id }}_{{ label_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/schedules/{{ label_id ~ '_') if omit_id is not defined else ''}}{{ label_name | regex_replace('/', '_') }}.yaml"
         query_credentials: "{{ query(controller_api_plugin, current_schedules_asset_value.related.credentials,
                      host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                      return_all=true, max_objects=query_controller_api_max_objects) if current_schedules_asset_value.related.credentials is defined else [] }}"

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -69,7 +69,7 @@
         team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
         team_id: "{{ current_teams_asset_value.id }}"
         team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/teams/{{ team_id ~ '_') if omit_id is not defined else '' }}{{ team_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/teams/{{ (team_id ~ '_') if omit_id is not defined else '' }}{{ team_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ teams_lookvar }}"
       loop_control:
         loop_var: current_teams_asset_value

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -69,7 +69,7 @@
         team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
         team_id: "{{ current_teams_asset_value.id }}"
         team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/teams/{{ team_id }}_{{ team_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/teams/{{ team_id ~ '_') if omit_id is not defined else '' }}{{ team_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ teams_lookvar }}"
       loop_control:
         loop_var: current_teams_asset_value

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -86,7 +86,7 @@
         workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
         workflow_job_template_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/workflow_job_templates/{{ (workflow_job_template_id ~ '_') if omit_id is not defined else ''}}{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/workflow_job_templates/{{ (workflow_job_template_id ~ '_') if omit_id is not defined else '' }}{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"
         query_labels: "{{ query(controller_api_plugin, current_workflow_job_templates_asset_value.related.labels,
                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -86,7 +86,7 @@
         workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
         workflow_job_template_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/workflow_job_templates/{{ workflow_job_template_id }}_{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/workflow_job_templates/{{ workflow_job_template_id ~ '_') if omit_id is not defined else ''}}{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"
         query_labels: "{{ query(controller_api_plugin, current_workflow_job_templates_asset_value.related.labels,
                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -86,7 +86,7 @@
         workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
         workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
         workflow_job_template_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/', '_') }}"
-        __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/workflow_job_templates/{{ workflow_job_template_id ~ '_') if omit_id is not defined else ''}}{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/workflow_job_templates/{{ (workflow_job_template_id ~ '_') if omit_id is not defined else ''}}{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"
         query_labels: "{{ query(controller_api_plugin, current_workflow_job_templates_asset_value.related.labels,
                          host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,
                          return_all=true, max_objects=query_controller_api_max_objects) }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Propose a solution that allows exporting objects without IDs.

Background: In our environment, the inclusion of IDs in the filenames is causing a slight mess in our GitHub repositories. Imagine the following situation:

1. I exported a project with job templates from the DEV environment.
2. I imported it into the TEST environment.
3. I created a new job template in the TEST environment for this project.
4. I exported the project with job templates again, but this time from the TEST environment.
5. I discovered in the repository that there are files of job templates with both DEV and TEST IDs.

# How should this be tested?
```yaml
- name: Get objects
  hosts: all 
  roles:
    - role: infra.controller_configuration.filetree_create
      vars:
        omit_id: true
```

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A
# Other Relevant info, PRs, etc
N/A
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
