### PR TITLE
Remove encrypted from surveys

### DIFF
--- a/changelogs/fragments/filetree_create_survey_password_removal.yaml
+++ b/changelogs/fragments/filetree_create_survey_password_removal.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - filetree_create able to remove $encrypted$ while exporting job template and workflow

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -95,7 +95,7 @@ controller_templates:
     survey_enabled: {{ current_job_templates_asset_value.survey_enabled | bool | lower }}
 {% set survey_spec_contents = query(controller_api_plugin, current_job_templates_asset_value.related.survey_spec,
                                     host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)[0] |
-                                    from_yaml | to_nice_yaml(indent=2,width=500) | regex_replace("\n\n[ ]*", "\\\\n") | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") | replace("^$", "")
+                                    from_yaml | to_nice_yaml(indent=2,width=500) | regex_replace("\n\n[ ]*", "\\\\n") | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") | replace("^$", "") | replace("$encrypted$", "\'\'")
 -%}
 {% if current_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 3 %}
     survey_spec:

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -95,7 +95,7 @@ controller_templates:
     survey_enabled: {{ current_job_templates_asset_value.survey_enabled | bool | lower }}
 {% set survey_spec_contents = query(controller_api_plugin, current_job_templates_asset_value.related.survey_spec,
                                     host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)[0] |
-                                    from_yaml | to_nice_yaml(indent=2,width=500) | regex_replace("\n\n[ ]*", "\\\\n") | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") | replace("^$", "") | replace("$encrypted$", "\'\'")
+                                    from_yaml | to_nice_yaml(indent=2,width=500) | regex_replace("\n\n[ ]*", "\\\\n") | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") | replace("^$", "") | replace("$encrypted$", "")
 -%}
 {% if current_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 3 %}
     survey_spec:

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -79,7 +79,7 @@ controller_workflows:
     survey_enabled: {{ current_workflow_job_templates_asset_value.survey_enabled }}
 {% set survey_spec_contents = query(controller_api_plugin, current_workflow_job_templates_asset_value.related.survey_spec,
                                     host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)[0] |
-                                    from_yaml | to_nice_yaml(indent=2,width=500) | regex_replace("\n\n[ ]*", "\\\\n") | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") | replace("^$", "" ) | replace("$encrypted$", "\'\'")
+                                    from_yaml | to_nice_yaml(indent=2,width=500) | regex_replace("\n\n[ ]*", "\\\\n") | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") | replace("^$", "") | replace("$encrypted$", "\'\'")
 -%}
 {% if current_workflow_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 3 %}
     survey_spec:

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -79,7 +79,7 @@ controller_workflows:
     survey_enabled: {{ current_workflow_job_templates_asset_value.survey_enabled }}
 {% set survey_spec_contents = query(controller_api_plugin, current_workflow_job_templates_asset_value.related.survey_spec,
                                     host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)[0] |
-                                    from_yaml | to_nice_yaml(indent=2,width=500) | regex_replace("\n\n[ ]*", "\\\\n") | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") | replace("^$", "") | replace("$encrypted$", "\'\'")
+                                    from_yaml | to_nice_yaml(indent=2,width=500) | regex_replace("\n\n[ ]*", "\\\\n") | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") | replace("^$", "") | replace("$encrypted$", "")
 -%}
 {% if current_workflow_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 3 %}
     survey_spec:

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -79,7 +79,7 @@ controller_workflows:
     survey_enabled: {{ current_workflow_job_templates_asset_value.survey_enabled }}
 {% set survey_spec_contents = query(controller_api_plugin, current_workflow_job_templates_asset_value.related.survey_spec,
                                     host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs)[0] |
-                                    from_yaml | to_nice_yaml(indent=2,width=500) | regex_replace("\n\n[ ]*", "\\\\n") | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") | replace("^$", "")
+                                    from_yaml | to_nice_yaml(indent=2,width=500) | regex_replace("\n\n[ ]*", "\\\\n") | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") | replace("^$", "" ) | replace("$encrypted$", "\'\'")
 -%}
 {% if current_workflow_job_templates_asset_value.related.survey_spec is defined and survey_spec_contents | length > 3 %}
     survey_spec:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Recently, I've discovered that `$encrypted$` is exported with the job template/workflow when a password is set in the survey field. During the import, this causes an issue, and the survey is not imported.

# How should this be tested?
1) Create the job template with survey, that has a password field, and set password in default choice field.
2) Export the job template with `filetree_create`.
3) There should not be any `$encrypted$` in the export.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A
# Other Relevant info, PRs, etc
N/A