### PR TITLE
fix: issue with variable brackets inside any string in extra_vars

### DIFF
--- a/changelogs/fragments/filetree_create_brackets_extra_vars_issue.yml
+++ b/changelogs/fragments/filetree_create_brackets_extra_vars_issue.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - filetree_create export extra_vars with escaping any variable brackets
+...

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -54,7 +54,7 @@ controller_templates:
 {% endif %}
 {% if current_job_templates_asset_value.extra_vars and current_job_templates_asset_value.extra_vars | length > 3 %}
     extra_vars:
-      {{ current_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("{{", "{% raw %}{{{% endraw %}") | replace("}}", "{% raw %}}}{% endraw %}") }}
+      {{ current_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | regex_replace('(^[^:]*): (.*){{', '\1: !unsafe \2{{')}}
 {%- endif %}
     job_tags: "{{ current_job_templates_asset_value.job_tags }}"
     force_handlers: {{ current_job_templates_asset_value.force_handlers | bool | lower }}

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -54,7 +54,7 @@ controller_templates:
 {% endif %}
 {% if current_job_templates_asset_value.extra_vars and current_job_templates_asset_value.extra_vars | length > 3 %}
     extra_vars:
-      {{ current_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | regex_replace('(^[^:]*): (.*){{', '\1: !unsafe \2{{')}}
+      {{ current_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | regex_replace('(^[^:]*): (.*){{', '\1: !unsafe \2{{', multiline=True)}}
 {%- endif %}
     job_tags: "{{ current_job_templates_asset_value.job_tags }}"
     force_handlers: {{ current_job_templates_asset_value.force_handlers | bool | lower }}

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -54,7 +54,7 @@ controller_templates:
 {% endif %}
 {% if current_job_templates_asset_value.extra_vars and current_job_templates_asset_value.extra_vars | length > 3 %}
     extra_vars:
-      {{ current_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") }}
+      {{ current_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("{{", "{% raw %}{{{% endraw %}") | replace("}}", "{% raw %}}}{% endraw %}") }}
 {%- endif %}
     job_tags: "{{ current_job_templates_asset_value.job_tags }}"
     force_handlers: {{ current_job_templates_asset_value.force_handlers | bool | lower }}

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -44,7 +44,7 @@ controller_workflows:
     webhook_service: "{{ current_workflow_job_templates_asset_value.webhook_service }}"
 {% if current_workflow_job_templates_asset_value.extra_vars and current_workflow_job_templates_asset_value.extra_vars | length > 3 %}
     extra_vars:
-      {{ current_workflow_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | regex_replace('(^[^:]*): (.*){{', '\1: !unsafe \2{{') }}
+      {{ current_workflow_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | regex_replace('(^[^:]*): (.*){{', '\1: !unsafe \2{{', multiline=True) }}
 {%- endif %}
 {% if query_labels | length > 0 %}
     labels:

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -44,7 +44,7 @@ controller_workflows:
     webhook_service: "{{ current_workflow_job_templates_asset_value.webhook_service }}"
 {% if current_workflow_job_templates_asset_value.extra_vars and current_workflow_job_templates_asset_value.extra_vars | length > 3 %}
     extra_vars:
-      {{ current_workflow_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") }}
+      {{ current_workflow_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("{{", "{% raw %}{{{% endraw %}") | replace("}}", "{% raw %}}}{% endraw %}") }}
 {%- endif %}
 {% if query_labels | length > 0 %}
     labels:

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -44,7 +44,7 @@ controller_workflows:
     webhook_service: "{{ current_workflow_job_templates_asset_value.webhook_service }}"
 {% if current_workflow_job_templates_asset_value.extra_vars and current_workflow_job_templates_asset_value.extra_vars | length > 3 %}
     extra_vars:
-      {{ current_workflow_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("{{", "{% raw %}{{{% endraw %}") | replace("}}", "{% raw %}}}{% endraw %}") }}
+      {{ current_workflow_job_templates_asset_value.extra_vars | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | regex_replace('(^[^:]*): (.*){{', '\1: !unsafe \2{{') }}
 {%- endif %}
 {% if query_labels | length > 0 %}
     labels:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
I am introducing this change to resolve the bug with brackets inside the extra_vars, I didn't find any other solution for this issue. 

# How should this be tested?
1) Create a job template or workflow with extra_vars that contains:
 `url: 'https://{{ ip }}'`
2) Export the object with filetree_create.
3) The extra_vars of exported object should look like this:

```yaml
extra_vars:
  "url": "https://{% raw %}{{{% endraw %} ip {% raw %}}}{% endraw %}'

```





# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #856

# Other Relevant info, PRs, etc
N/A