### PR TITLE
Idea of adding objects that are missing in the target controller

### DIFF
--- a/roles/job_templates/tasks/main.yml
+++ b/roles/job_templates/tasks/main.yml
@@ -1,4 +1,32 @@
 ---
+- name: Verify Job Templates
+  when: controller_templates is defined and (controller_state is defined and controller_state == 'exists')
+  block:
+    - name: 'Retrieve job templates from controller'
+      ansible.builtin.set_fact:
+        __t_controller_job_templates: >-
+          {{
+            query(
+              controller_api_plugin,
+              'api/v2/job_templates/',
+              host=controller_hostname,
+              oauth_token=controller_oauthtoken,
+              verify_ssl=controller_validate_certs,
+              return_all=true,
+              max_objects=query_controller_api_max_objects
+            ) |
+            map(attribute='name') |
+            ansible.builtin.flatten
+          }}
+
+    - name: 'Extract job templates which are not defined in controller'
+      ansible.builtin.set_fact:
+        job_templates: >-
+          {{
+            controller_templates |
+            rejectattr('name', 'in', __t_controller_job_templates)
+          }}
+
 - name: "Managing Controller Job Templates"
   job_template:
     name:                                 "{{ __controller_template_item.name | mandatory }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Another idea was born while implementing CasC in our environment. The code is related to job templates but can be easily added to other object types.

What if someone wants to restore only non-existing objects on the target controller?

So, I found a variable called `controller_state` to create a condition to only add objects that are missing. However, I noticed that it took forever to finish because I was still looping over the object list. Additionally, a second issue appeared: if the same object was different in some way, the object was duplicated.

I came up with the idea to get all objects and filter out the ones that already exist.

What do you think about this change? I know that this variable `controller_state` is making problem with the roles, because role can only be present or be absent, but I believe it can be easily resolved.

# How should this be tested?
1) Create job templates in source controller.
2) Export job templates with filetree_create.
3) Import job templates into target controller.
```yaml
---
- name: Playbook to configure ansible controller post installation
  hosts: localhost
  connection: local
  vars:
    controller_hostname: ansible-controller-web-svc-test-project.example.com
    controller_username: admin
    controller_password: changeme
    controller_state: exists
  pre_tasks:
    - name: Include vars from controller_configs directory
      ansible.builtin.include_vars:
        dir: ./yaml
        ignore_files: [controller_config.yml.template]
        extensions: ["yml"]
  roles:
    - infra.controller_configuration.dispatch
```
# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A
