### PR TITLE
Issue with incorrectly exported approval role name

### DIFF
--- a/changelogs/fragments/filetree_create_role_approve_bug.yml
+++ b/changelogs/fragments/filetree_create_role_approve_bug.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - filetree_create able export proper approval role

--- a/roles/filetree_create/templates/current_team_roles.j2
+++ b/roles/filetree_create/templates/current_team_roles.j2
@@ -22,7 +22,7 @@ controller_roles:
 {% elif role.summary_fields.resource_type is match('credential') %}
     credential: "{{ role.summary_fields.resource_name }}"
 {% endif %}
-    role: "{{ role.name | lower }}"
+    role: "{% if role.name | lower == 'approve' %}approval{% else %}{{ role.name | lower }}{% endif %}"
 {% endif %}
 {% endfor %}
 {% if last_team_role | default(true) | bool %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
While restoring objects with dispatch, I've encountered an issue: the role `approval` is called `approve` in the controller, but the API requires `approval`. As a result, when the `filetree_create` exports the roles, it uses the wrong role name. I've added an if statement to check if the role name is `approve`, and if it is, it uses the `approval` role name.

# How should this be tested?
1) Create workflow job template.
2) Assign approve role to team.
3) Export objects with `filetree_create`.
4) Import objects with `filetree_read` and `dispatch`.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
N/A
