### PR TITLE
support for defining the organization

### DIFF
--- a/changelogs/fragments/filetree_create_default_org.yml
+++ b/changelogs/fragments/filetree_create_default_org.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - filetree_create able to use defined organization for organizationless objects

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -23,6 +23,7 @@ The following variables are required for that role to work properly:
 | `flatten_output` | N/A | no | bool | Whether to flatten the output in single files per each object type instead of the normal exportation structure |
 | `show_encrypted` | N/A | no | bool | Whether to remove the string '\$encrypted\$' in credentials output (not the actual credential value) |
 | `omit_id` | N/A | no | bool | Whether to create output files without objects id.|
+| `organization`| N/A | no | str | Default organization for all objects that have not been set in the source controller.|
 
 ## Dependencies
 

--- a/roles/filetree_create/defaults/main.yml
+++ b/roles/filetree_create/defaults/main.yml
@@ -27,5 +27,5 @@ controller_configuration_filetree_create_secure_logging: "{{ controller_configur
 
 input_tag:
   - all
-
+organization: 'ORGANIZATIONLESS'
 ...

--- a/roles/filetree_create/tasks/applications.yml
+++ b/roles/filetree_create/tasks/applications.yml
@@ -53,9 +53,12 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/applications"
-      loop: "{{ (applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-                + (['ORGANIZATIONLESS'] if ((applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
-             }}"
+      loop: >-
+        {{ (applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+           map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+           + ([(organization if organization is defined else 'ORGANIZATIONLESS')] if ((applications_lookvar | map(attribute='summary_fields')
+           | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+        }}
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"

--- a/roles/filetree_create/tasks/applications.yml
+++ b/roles/filetree_create/tasks/applications.yml
@@ -27,7 +27,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_applications.j2') }}"
       vars:
-        application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
+        application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default(organization, true) }}"
         application_id: "{{ current_applications_asset_value.id }}"
         application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"
         last_application: "{{ current_application_index == ((applications_lookvar | length) - 1) }}"
@@ -56,7 +56,7 @@
       loop: >-
         {{ (applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
            map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-           + ([(organization if organization is defined else 'ORGANIZATIONLESS')] if ((applications_lookvar | map(attribute='summary_fields')
+           + ([default(organization)] if ((applications_lookvar | map(attribute='summary_fields')
            | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
         }}
       loop_control:
@@ -69,7 +69,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
+        application_organization: "{{ current_applications_asset_value.summary_fields.organization.name | default(organization, true) }}"
         application_id: "{{ current_applications_asset_value.id }}"
         application_name: "{{ current_applications_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ application_organization | regex_replace('/', '_') }}/applications/{{ (application_id ~ '_') if omit_id is not defined else '' }}{{ application_name | regex_replace('/', '_') }}.yaml"

--- a/roles/filetree_create/tasks/constructed_inventory.yml
+++ b/roles/filetree_create/tasks/constructed_inventory.yml
@@ -39,7 +39,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_inventories.j2') }}"
       vars:
-        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
         first_inventory: "{{ not (__constructed_inventories_file.stat.exists | bool) }}"
         last_inventory: "{{ current_inventory_index == ((constructed_inventory_lookvar | length) - 1) }}"
@@ -64,7 +64,7 @@
         state: directory
         mode: '0755'
       vars:
-        inventory_organization: "{{ needed_path.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+        inventory_organization: "{{ needed_path.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
         inventory_name: "{{ needed_path.name | regex_replace('/', '_') }}"
         __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
       loop: "{{ constructed_inventory_lookvar }}"
@@ -78,7 +78,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ constructed_inventory_lookvar }}"

--- a/roles/filetree_create/tasks/constructed_inventory.yml
+++ b/roles/filetree_create/tasks/constructed_inventory.yml
@@ -39,7 +39,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_inventories.j2') }}"
       vars:
-        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
         first_inventory: "{{ not (__constructed_inventories_file.stat.exists | bool) }}"
         last_inventory: "{{ current_inventory_index == ((constructed_inventory_lookvar | length) - 1) }}"
@@ -64,7 +64,7 @@
         state: directory
         mode: '0755'
       vars:
-        inventory_organization: "{{ needed_path.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+        inventory_organization: "{{ needed_path.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ needed_path.name | regex_replace('/', '_') }}"
         __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
       loop: "{{ constructed_inventory_lookvar }}"
@@ -78,7 +78,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ constructed_inventory_lookvar }}"

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -27,7 +27,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_credentials.j2') }}"
       vars:
-        credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+        credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | default(organization) }}"
         credentials_id: "{{ current_credentials_asset_value.id }}"
         credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"
         last_credential: "{{ current_credential_index == ((credentials_lookvar | length) - 1) }}"
@@ -69,7 +69,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+        credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | default(organization) }}"
         credentials_id: "{{ current_credentials_asset_value.id }}"
         credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/credentials/{{ (credentials_id ~ '_') if omit_id is not defined else '' }}{{ credentials_name | regex_replace('/', '_') }}.yaml"

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -27,7 +27,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_credentials.j2') }}"
       vars:
-        credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+        credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
         credentials_id: "{{ current_credentials_asset_value.id }}"
         credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"
         last_credential: "{{ current_credential_index == ((credentials_lookvar | length) - 1) }}"
@@ -53,9 +53,12 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path }}/credentials"
-      loop: "{{ (credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-                + (['ORGANIZATIONLESS'] if ((credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
-             }}"
+      loop: >-
+        {{ (credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+           map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+           + ([(organization if organization is defined else 'ORGANIZATIONLESS')] if ((credentials_lookvar |
+           map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+        }}
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"
@@ -66,7 +69,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+        credentials_organization: "{{ current_credentials_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
         credentials_id: "{{ current_credentials_asset_value.id }}"
         credentials_name: "{{ current_credentials_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ credentials_organization | regex_replace('/', '_') }}/credentials/{{ (credentials_id ~ '_') if omit_id is not defined else '' }}{{ credentials_name | regex_replace('/', '_') }}.yaml"

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -40,7 +40,7 @@
         marker: ''
         block: "{{ lookup('template', 'templates/current_inventories.j2') }}"
       vars:
-        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
         first_inventory: "{{ not (__inventories_file.stat.exists | bool) }}"
         last_inventory: "{{ current_inventory_index == ((inventory_lookvar | length) - 1) }}"
@@ -65,7 +65,7 @@
         state: directory
         mode: '0755'
       vars:
-        inventory_organization: "{{ needed_path.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+        inventory_organization: "{{ needed_path.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
         inventory_name: "{{ needed_path.name | regex_replace('/', '_') }}"
         __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
       loop: "{{ inventory_lookvar }}"
@@ -79,7 +79,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ inventory_lookvar }}"
@@ -91,7 +91,7 @@
   ansible.builtin.include_tasks: "inventory_sources.yml"
   when: current_inventory_sources.total_inventory_sources > 0
   vars:
-    inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+    inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
     inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
     inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
                                        if (flatten_output is not defined or (flatten_output | bool) == false)
@@ -113,7 +113,7 @@
 - name: "Set the inventory's hosts"
   ansible.builtin.include_tasks: "hosts.yml"
   vars:
-    inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+    inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
     inventory_name: "{{ current_inventory_hosts.name | regex_replace('/', '_') }}"
     hosts_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
                            if (flatten_output is not defined or (flatten_output | bool) == false)
@@ -136,7 +136,7 @@
   ansible.builtin.include_tasks: "groups.yml"
   when: current_inventory_groups.total_groups > 0
   vars:
-    inventory_organization: "{{ current_inventory_groups.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+    inventory_organization: "{{ current_inventory_groups.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
     inventory_name: "{{ current_inventory_groups.name | regex_replace('/', '_') }}"
     groups_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
                            if (flatten_output is not defined or (flatten_output | bool) == false)

--- a/roles/filetree_create/tasks/inventory.yml
+++ b/roles/filetree_create/tasks/inventory.yml
@@ -40,7 +40,7 @@
         marker: ''
         block: "{{ lookup('template', 'templates/current_inventories.j2') }}"
       vars:
-        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
         first_inventory: "{{ not (__inventories_file.stat.exists | bool) }}"
         last_inventory: "{{ current_inventory_index == ((inventory_lookvar | length) - 1) }}"
@@ -65,7 +65,7 @@
         state: directory
         mode: '0755'
       vars:
-        inventory_organization: "{{ needed_path.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+        inventory_organization: "{{ needed_path.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ needed_path.name | regex_replace('/', '_') }}"
         __path: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}"
       loop: "{{ inventory_lookvar }}"
@@ -79,7 +79,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+        inventory_organization: "{{ current_inventories_asset_value.summary_fields.organization.name | default(organization) }}"
         inventory_name: "{{ current_inventories_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ inventory_organization | regex_replace('/', '_') }}/inventories/{{ inventory_name | regex_replace('/', '_') }}/{{ (current_inventories_asset_value.id ~ '_') if omit_id is not defined else '' }}{{ inventory_name | regex_replace('/', '_') }}.yaml"
       loop: "{{ inventory_lookvar }}"
@@ -91,7 +91,7 @@
   ansible.builtin.include_tasks: "inventory_sources.yml"
   when: current_inventory_sources.total_inventory_sources > 0
   vars:
-    inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+    inventory_organization: "{{ current_inventory_sources.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_sources.name | regex_replace('/', '_') }}"
     inventory_sources_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
                                        if (flatten_output is not defined or (flatten_output | bool) == false)
@@ -113,7 +113,7 @@
 - name: "Set the inventory's hosts"
   ansible.builtin.include_tasks: "hosts.yml"
   vars:
-    inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+    inventory_organization: "{{ current_inventory_hosts.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_hosts.name | regex_replace('/', '_') }}"
     hosts_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
                            if (flatten_output is not defined or (flatten_output | bool) == false)
@@ -136,7 +136,7 @@
   ansible.builtin.include_tasks: "groups.yml"
   when: current_inventory_groups.total_groups > 0
   vars:
-    inventory_organization: "{{ current_inventory_groups.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+    inventory_organization: "{{ current_inventory_groups.summary_fields.organization.name | default(organization) }}"
     inventory_name: "{{ current_inventory_groups.name | regex_replace('/', '_') }}"
     groups_output_path: "{{   (output_path + '/' + inventory_organization | regex_replace('/', '_') + '/inventories/' + inventory_name | regex_replace('/', '_'))
                            if (flatten_output is not defined or (flatten_output | bool) == false)

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -70,9 +70,9 @@
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/job_templates"
       loop: >-
         {{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
-           map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-           + [organization] if ((job_templates_lookvar | map(attribute='summary_fields') |
-           selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+           map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
+           [organization] if (job_templates_lookvar | map(attribute='summary_fields') |
+           selectattr('organization', 'undefined') | list | flatten | length > 0) else []
         }}
       loop_control:
         loop_var: needed_path

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -29,7 +29,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_job_templates.j2') }}"
       vars:
-        job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+        job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default(organization) }}"
         job_template_id: "{{ current_job_templates_asset_value.id }}"
         job_template_name: "{{ current_job_templates_asset_value.name | regex_replace('/', '_') }}"
         query_labels: "{{ query(controller_api_plugin, current_job_templates_asset_value.related.labels,
@@ -71,9 +71,8 @@
       loop: >-
         {{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
            map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-           + ([(organization if organization is defined else 'ORGANIZATIONLESS')]
-           if ((job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') |
-           list | flatten) | length > 0) else [])
+           + [organization] if ((job_templates_lookvar | map(attribute='summary_fields') |
+           selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
         }}
       loop_control:
         loop_var: needed_path
@@ -85,7 +84,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+        job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default(organization) }}"
         job_template_id: "{{ current_job_templates_asset_value.id }}"
         job_template_name: "{{ current_job_templates_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ job_template_organization | regex_replace('/', '_') }}/job_templates/{{ (job_template_id ~ '_') if omit_id is not defined else '' }}{{ job_template_name | regex_replace('/', '_') }}.yaml"

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -29,7 +29,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_job_templates.j2') }}"
       vars:
-        job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+        job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
         job_template_id: "{{ current_job_templates_asset_value.id }}"
         job_template_name: "{{ current_job_templates_asset_value.name | regex_replace('/', '_') }}"
         query_labels: "{{ query(controller_api_plugin, current_job_templates_asset_value.related.labels,
@@ -68,9 +68,13 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/job_templates"
-      loop: "{{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-                + (['ORGANIZATIONLESS'] if ((job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
-             }}"
+      loop: >-
+        {{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+           map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+           + ([(organization if organization is defined else 'ORGANIZATIONLESS')]
+           if ((job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') |
+           list | flatten) | length > 0) else [])
+        }}
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"
@@ -81,7 +85,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+        job_template_organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
         job_template_id: "{{ current_job_templates_asset_value.id }}"
         job_template_name: "{{ current_job_templates_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ job_template_organization | regex_replace('/', '_') }}/job_templates/{{ (job_template_id ~ '_') if omit_id is not defined else '' }}{{ job_template_name | regex_replace('/', '_') }}.yaml"

--- a/roles/filetree_create/tasks/labels.yml
+++ b/roles/filetree_create/tasks/labels.yml
@@ -66,7 +66,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        label_organization: "{{ current_labels_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true) }}"
+        label_organization: "{{ current_labels_asset_value.summary_fields.organization.name | default(organization, true) }}"
         label_id: "{{ current_labels_asset_value.id }}"
         label_name: "{{ current_labels_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/labels/{{ (label_id ~ '_') if omit_id is not defined else '' }}{{ label_name | regex_replace('/', '_') }}.yaml"

--- a/roles/filetree_create/tasks/labels.yml
+++ b/roles/filetree_create/tasks/labels.yml
@@ -66,7 +66,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        label_organization: "{{ current_labels_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
+        label_organization: "{{ current_labels_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true) }}"
         label_id: "{{ current_labels_asset_value.id }}"
         label_name: "{{ current_labels_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ label_organization | regex_replace('/', '_') }}/labels/{{ (label_id ~ '_') if omit_id is not defined else '' }}{{ label_name | regex_replace('/', '_') }}.yaml"

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -66,7 +66,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        __dest: "{{ output_path }}/{{ (current_notification_templates_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}/notification_templates/{{ current_notification_templates_asset_value.name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ (current_notification_templates_asset_value.summary_fields.organization.name |default(organization, true)) | regex_replace('/', '_') }}/notification_templates/{{ current_notification_templates_asset_value.name | regex_replace('/', '_') }}.yaml"
       loop: "{{ notification_templates_lookvar }}"
       loop_control:
         loop_var: current_notification_templates_asset_value

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -53,8 +53,8 @@
       loop: >-
         {{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
             map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
-            ([organization] if ((notification_templates_lookvar | map(attribute='summary_fields') |
-            selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+            [organization] if (notification_templates_lookvar | map(attribute='summary_fields') |
+            selectattr('organization', 'undefined') | list | flatten | length > 0) else []
         }}
       loop_control:
         loop_var: needed_path

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -52,9 +52,8 @@
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/notification_templates"
       loop: >-
         {{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
-            map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-            + ([(organization if organization is defined else 'ORGANIZATIONLESS')]
-            if ((notification_templates_lookvar | map(attribute='summary_fields') |
+            map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
+            ([organization] if ((notification_templates_lookvar | map(attribute='summary_fields') |
             selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
         }}
       loop_control:

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -50,9 +50,13 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/notification_templates"
-      loop: "{{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-                + (['ORGANIZATIONLESS'] if ((notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
-             }}"
+      loop: >-
+        {{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+            map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+            + ([(organization if organization is defined else 'ORGANIZATIONLESS')]
+            if ((notification_templates_lookvar | map(attribute='summary_fields') |
+            selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+        }}
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"
@@ -63,7 +67,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        __dest: "{{ output_path }}/{{ (current_notification_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}/notification_templates/{{ current_notification_templates_asset_value.name | regex_replace('/', '_') }}.yaml"
+        __dest: "{{ output_path }}/{{ (current_notification_templates_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}/notification_templates/{{ current_notification_templates_asset_value.name | regex_replace('/', '_') }}.yaml"
       loop: "{{ notification_templates_lookvar }}"
       loop_control:
         loop_var: current_notification_templates_asset_value

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -28,7 +28,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_projects.j2') }}"
       vars:
-        project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true) }}"
+        project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | default(organization, true) }}"
         project_id: "{{ current_projects_asset_value.id }}"
         project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"
         query_notification_error: "{{ query(controller_api_plugin, current_projects_asset_value.related.notification_templates_error,
@@ -67,8 +67,8 @@
       loop: >-
         {{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
            map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
-           [organization] if ((projects_lookvar | map(attribute='summary_fields') |
-           selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+           [organization] if (projects_lookvar | map(attribute='summary_fields') |
+           selectattr('organization', 'undefined') | list | flatten | length > 0) else []
         }}"
       loop_control:
         loop_var: needed_path
@@ -80,7 +80,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true) }}"
+        project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | default(organization, true) }}"
         project_id: "{{ current_projects_asset_value.id }}"
         project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/projects/{{ (project_id ~ '_') if omit_id is not defined else '' }}{{ project_name | regex_replace('/', '_') }}.yaml"

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -66,9 +66,9 @@
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/projects"
       loop: >-
         {{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
-           map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-           + ([(organization if organization is defined else 'ORGANIZATIONLESS')] if ((projects_lookvar |
-           map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+           map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
+           [organization] if ((projects_lookvar | map(attribute='summary_fields') |
+           selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
         }}"
       loop_control:
         loop_var: needed_path

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -28,7 +28,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_projects.j2') }}"
       vars:
-        project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
+        project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true) }}"
         project_id: "{{ current_projects_asset_value.id }}"
         project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"
         query_notification_error: "{{ query(controller_api_plugin, current_projects_asset_value.related.notification_templates_error,
@@ -64,9 +64,12 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/projects"
-      loop: "{{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-                + (['ORGANIZATIONLESS'] if ((projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
-             }}"
+      loop: >-
+        {{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+           map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+           + ([(organization if organization is defined else 'ORGANIZATIONLESS')] if ((projects_lookvar |
+           map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+        }}"
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"
@@ -77,7 +80,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true) }}"
+        project_organization: "{{ current_projects_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true) }}"
         project_id: "{{ current_projects_asset_value.id }}"
         project_name: "{{ current_projects_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ project_organization | regex_replace('/', '_') }}/projects/{{ (project_id ~ '_') if omit_id is not defined else '' }}{{ project_name | regex_replace('/', '_') }}.yaml"

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -27,7 +27,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_teams.j2') }}"
       vars:
-        team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default(organization, true) | regex_replace('/', '_') }}"
+        team_organization: "{{ current_teams_asset_value.summary_fields.organization.name | default(organization, true) | regex_replace('/', '_') }}"
         team_id: "{{ current_teams_asset_value.id }}"
         team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"
         last_team: "{{ current_team_index == ((teams_lookvar | length) - 1) }}"

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -57,8 +57,8 @@
         {{
           (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
           map(attribute='organization') | map(attribute='name') | list | unique) +
-          [organization] if ((teams_lookvar | map(attribute='summary_fields') |
-          selectattr('organization', 'undefined') | list | length) > 0) else [])
+          [organization] if (teams_lookvar | map(attribute='summary_fields') |
+          selectattr('organization', 'undefined') | list | length > 0) else []
         }}
       loop_control:
         loop_var: needed_path
@@ -70,7 +70,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
+        team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default(organization, true)) | regex_replace('/', '_') }}"
         team_id: "{{ current_teams_asset_value.id }}"
         team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/teams/{{ (team_id ~ '_') if omit_id is not defined else '' }}{{ team_name | regex_replace('/', '_') }}.yaml"
@@ -82,7 +82,7 @@
 - name: "Set the team's roles"
   ansible.builtin.include_tasks: "team_roles.yml"
   vars:
-    team_organization: "{{ (current_team.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
+    team_organization: "{{ (current_team.summary_fields.organization.name | default(organization, true)) | regex_replace('/', '_') }}"
     teamname: "{{ current_team.name }}"
     teamid: "{{ current_team.id }}"
     last_team_role: "{{ current_team_index_for_roles == ((teams_lookvar | length) - 1) }}"

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -27,7 +27,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_teams.j2') }}"
       vars:
-        team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
+        team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
         team_id: "{{ current_teams_asset_value.id }}"
         team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"
         last_team: "{{ current_team_index == ((teams_lookvar | length) - 1) }}"
@@ -53,9 +53,14 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/teams"
-      loop: "{{ (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-                + (['ORGANIZATIONLESS'] if ((teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
-             }}"
+      loop: >-
+        {{
+          (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined')
+          | map(attribute='organization') | map(attribute='name') | list | unique)
+          + ([(organization if organization is defined else 'ORGANIZATIONLESS')]
+          if ((teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | length) > 0)
+          else [])
+        }}
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"
@@ -66,7 +71,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
+        team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
         team_id: "{{ current_teams_asset_value.id }}"
         team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ team_organization | regex_replace('/', '_') }}/teams/{{ (team_id ~ '_') if omit_id is not defined else '' }}{{ team_name | regex_replace('/', '_') }}.yaml"
@@ -78,7 +83,7 @@
 - name: "Set the team's roles"
   ansible.builtin.include_tasks: "team_roles.yml"
   vars:
-    team_organization: "{{ (current_team.summary_fields.organization.name | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
+    team_organization: "{{ (current_team.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
     teamname: "{{ current_team.name }}"
     teamid: "{{ current_team.id }}"
     last_team_role: "{{ current_team_index_for_roles == ((teams_lookvar | length) - 1) }}"

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -27,7 +27,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_teams.j2') }}"
       vars:
-        team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS', true)) | regex_replace('/', '_') }}"
+        team_organization: "{{ (current_teams_asset_value.summary_fields.organization.name | default(organization, true) | regex_replace('/', '_') }}"
         team_id: "{{ current_teams_asset_value.id }}"
         team_name: "{{ current_teams_asset_value.name | regex_replace('/', '_') }}"
         last_team: "{{ current_team_index == ((teams_lookvar | length) - 1) }}"
@@ -55,11 +55,10 @@
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/teams"
       loop: >-
         {{
-          (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined')
-          | map(attribute='organization') | map(attribute='name') | list | unique)
-          + ([(organization if organization is defined else 'ORGANIZATIONLESS')]
-          if ((teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | length) > 0)
-          else [])
+          (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+          map(attribute='organization') | map(attribute='name') | list | unique) +
+          [organization] if ((teams_lookvar | map(attribute='summary_fields') |
+          selectattr('organization', 'undefined') | list | length) > 0) else [])
         }}
       loop_control:
         loop_var: needed_path

--- a/roles/filetree_create/tasks/users.yml
+++ b/roles/filetree_create/tasks/users.yml
@@ -9,7 +9,12 @@
 
 - name: "Add the users the Organizations information"  # noqa jinja[spacing]
   ansible.builtin.set_fact:
-    current_users: "{{ (current_users | default([])) + [user_lookvar_item | combine({'organizations': user_lookvar_item_organizations if (user_lookvar_item_organizations | length > 1) else ['ORGANIZATIONLESS']})] }}"
+    current_users: >-
+      {{ (current_users | default([])) +
+         [user_lookvar_item | combine({'organizations': user_lookvar_item_organizations if (user_lookvar_item_organizations | length > 1)
+         else ([organization] if organization is defined else ['ORGANIZATIONLESS'])}
+         )]
+      }}
   vars:
     user_lookvar_item_organizations: "{{ query(controller_api_plugin, user_lookvar_item.related.organizations,
                                                host=controller_hostname, oauth_token=controller_oauthtoken, verify_ssl=controller_validate_certs,

--- a/roles/filetree_create/tasks/users.yml
+++ b/roles/filetree_create/tasks/users.yml
@@ -11,9 +11,8 @@
   ansible.builtin.set_fact:
     current_users: >-
       {{ (current_users | default([])) +
-         [user_lookvar_item | combine({'organizations': user_lookvar_item_organizations if (user_lookvar_item_organizations | length > 1)
-         else ([organization] if organization is defined else ['ORGANIZATIONLESS'])}
-         )]
+         [user_lookvar_item | combine({'organizations': user_lookvar_item_organizations
+         if (user_lookvar_item_organizations | length > 1) else [organization]})]
       }}
   vars:
     user_lookvar_item_organizations: "{{ query(controller_api_plugin, user_lookvar_item.related.organizations,

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -28,7 +28,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_workflow_job_templates.j2') }}"
       vars:
-        workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+        workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
         workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
         workflow_job_template_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/', '_') }}"
         query_labels: "{{ query(controller_api_plugin, current_workflow_job_templates_asset_value.related.labels,
@@ -83,7 +83,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default('ORGANIZATIONLESS') }}"
+        workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
         workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
         workflow_job_template_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/workflow_job_templates/{{ (workflow_job_template_id ~ '_') if omit_id is not defined else '' }}{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -28,7 +28,7 @@
         marker: ""
         block: "{{ lookup('template', 'templates/current_workflow_job_templates.j2') }}"
       vars:
-        workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+        workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default(organization) }}"
         workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
         workflow_job_template_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/', '_') }}"
         query_labels: "{{ query(controller_api_plugin, current_workflow_job_templates_asset_value.related.labels,
@@ -70,9 +70,12 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/workflow_job_templates/"
-      loop: "{{ (workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-                + (['ORGANIZATIONLESS'] if ((workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
-             }}"
+      loop: >-
+        {{ (workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+            map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
+            ([organization] if ((workflow_job_templates_lookvar | map(attribute='summary_fields') |
+            selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+        }}
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"
@@ -83,7 +86,7 @@
         dest: "{{ __dest }}"
         mode: '0644'
       vars:
-        workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | organization | default('ORGANIZATIONLESS') }}"
+        workflow_job_template_organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default(organization) }}"
         workflow_job_template_id: "{{ current_workflow_job_templates_asset_value.id }}"
         workflow_job_template_name: "{{ current_workflow_job_templates_asset_value.name | regex_replace('/', '_') }}"
         __dest: "{{ output_path }}/{{ workflow_job_template_organization | regex_replace('/', '_') }}/workflow_job_templates/{{ (workflow_job_template_id ~ '_') if omit_id is not defined else '' }}{{ workflow_job_template_name | regex_replace('/', '_') }}.yaml"

--- a/roles/filetree_create/templates/current_applications.j2
+++ b/roles/filetree_create/templates/current_applications.j2
@@ -4,7 +4,7 @@ controller_applications:
 {% endif %}
   - name: "{{ current_applications_asset_value.name }}"
     description: "{{ current_applications_asset_value.description }}"
-    organization: "{{ current_applications_asset_value.summary_fields.organization.name | default('ToDo: The application \'' + current_applications_asset_value.name + '\' must have an organization') }}"
+    organization: "{{ current_applications_asset_value.summary_fields.organization.name | organization | default('ToDo: The application \'' + current_applications_asset_value.name + '\' must have an organization') }}"
     authorization_grant_type: "{{ current_applications_asset_value.authorization_grant_type }}"
     redirect_uris: "{{ current_applications_asset_value.redirect_uris }}"
     skip_authorization: "{{ current_applications_asset_value.skip_authorization }}"

--- a/roles/filetree_create/templates/current_applications.j2
+++ b/roles/filetree_create/templates/current_applications.j2
@@ -4,7 +4,7 @@ controller_applications:
 {% endif %}
   - name: "{{ current_applications_asset_value.name }}"
     description: "{{ current_applications_asset_value.description }}"
-    organization: "{{ current_applications_asset_value.summary_fields.organization.name | organization | default('ToDo: The application \'' + current_applications_asset_value.name + '\' must have an organization') }}"
+    organization: "{{ current_applications_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The application \'' + current_applications_asset_value.name + '\' must have an organization') }}"
     authorization_grant_type: "{{ current_applications_asset_value.authorization_grant_type }}"
     redirect_uris: "{{ current_applications_asset_value.redirect_uris }}"
     skip_authorization: "{{ current_applications_asset_value.skip_authorization }}"

--- a/roles/filetree_create/templates/current_credentials.j2
+++ b/roles/filetree_create/templates/current_credentials.j2
@@ -8,7 +8,7 @@ controller_credentials:
 {% if current_credentials_asset_value.organization is defined and current_credentials_asset_value.organization is not none %}
     organization: "{{ current_credentials_asset_value.summary_fields.organization.name }}"
 {% else %}
-    organization: "ORGANIZATIONLESS"
+    organization: "{{ organization }}"
 {% endif %}
 {% if current_credentials_asset_value.inputs is defined and current_credentials_asset_value.inputs is not match('{}') %}
     inputs:

--- a/roles/filetree_create/templates/current_hosts.j2
+++ b/roles/filetree_create/templates/current_hosts.j2
@@ -5,7 +5,7 @@ controller_hosts:
 {% for host in current_hosts_asset_value if not host.has_inventory_sources %}
   - name: "{{ host.name }}"
     description: "{{ host.description }}"
-    inventory: "{{ host.summary_fields.inventory.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The host \'' + host.name + '\' must have an associated inventory') }}"
+    inventory: "{{ host.summary_fields.inventory.name | default('ToDo: The host \'' + host.name + '\' must have an associated inventory') }}"
 {% if host.variables and host.variables != '---' and host.variables != '' %}
     variables:
       {{ host.variables | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") }}

--- a/roles/filetree_create/templates/current_hosts.j2
+++ b/roles/filetree_create/templates/current_hosts.j2
@@ -5,7 +5,7 @@ controller_hosts:
 {% for host in current_hosts_asset_value if not host.has_inventory_sources %}
   - name: "{{ host.name }}"
     description: "{{ host.description }}"
-    inventory: "{{ host.summary_fields.inventory.name | default('ToDo: The host \'' + host.name + '\' must have an associated inventory') }}"
+    inventory: "{{ host.summary_fields.inventory.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The host \'' + host.name + '\' must have an associated inventory') }}"
 {% if host.variables and host.variables != '---' and host.variables != '' %}
     variables:
       {{ host.variables | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") }}

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -4,7 +4,7 @@ controller_templates:
 {% endif %}
   - name: "{{ current_job_templates_asset_value.name }}"
     description: "{{ current_job_templates_asset_value.description }}"
-    organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default('ToDo: The job template \'' + current_job_templates_asset_value.name + '\' must belong to an organization') }}"
+    organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | organization | default('ToDo: The job template \'' + current_job_templates_asset_value.name + '\' must belong to an organization') }}"
     project: "{{ current_job_templates_asset_value.summary_fields.project.name | default('ToDo: The job template \'' + current_job_templates_asset_value.name + '\' must have a project assigned') }}"
 {% if current_job_templates_asset_value.inventory %}
     inventory: "{{ current_job_templates_asset_value.summary_fields.inventory.name }}"

--- a/roles/filetree_create/templates/current_job_templates.j2
+++ b/roles/filetree_create/templates/current_job_templates.j2
@@ -4,7 +4,7 @@ controller_templates:
 {% endif %}
   - name: "{{ current_job_templates_asset_value.name }}"
     description: "{{ current_job_templates_asset_value.description }}"
-    organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | organization | default('ToDo: The job template \'' + current_job_templates_asset_value.name + '\' must belong to an organization') }}"
+    organization: "{{ current_job_templates_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The job template \'' + current_job_templates_asset_value.name + '\' must belong to an organization') }}"
     project: "{{ current_job_templates_asset_value.summary_fields.project.name | default('ToDo: The job template \'' + current_job_templates_asset_value.name + '\' must have a project assigned') }}"
 {% if current_job_templates_asset_value.inventory %}
     inventory: "{{ current_job_templates_asset_value.summary_fields.inventory.name }}"

--- a/roles/filetree_create/templates/current_labels.j2
+++ b/roles/filetree_create/templates/current_labels.j2
@@ -3,7 +3,7 @@
 controller_labels:
 {% endif %}
   - name: "{{ current_labels_asset_value.name }}"
-    organization: "{{ current_labels_asset_value.summary_fields.organization.name | default('ToDo: The label \'' + current_labels_asset_value.name + '\' must have an organization') }}"
+    organization: "{{ current_labels_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The label \'' + current_labels_asset_value.name + '\' must have an organization') }}"
 {% if last_label | default(true) | bool %}
 ...
 {% endif %}

--- a/roles/filetree_create/templates/current_projects.j2
+++ b/roles/filetree_create/templates/current_projects.j2
@@ -4,7 +4,7 @@ controller_projects:
 {% endif %}
   - name: "{{ current_projects_asset_value.name }}"
     description: "{{ current_projects_asset_value.description }}"
-    organization: "{{ current_projects_asset_value.summary_fields.organization.name | default('ToDo: The project \'' + current_projects_asset_value.name + '\' must have an organization') }}"
+    organization: "{{ current_projects_asset_value.summary_fields.organization.name | organization | default('ToDo: The project \'' + current_projects_asset_value.name + '\' must have an organization') }}"
 {% if current_projects_asset_value.scm_type %}
     scm_type: "{{ current_projects_asset_value.scm_type }}"
     scm_url: "{{ current_projects_asset_value.scm_url }}"

--- a/roles/filetree_create/templates/current_projects.j2
+++ b/roles/filetree_create/templates/current_projects.j2
@@ -4,7 +4,7 @@ controller_projects:
 {% endif %}
   - name: "{{ current_projects_asset_value.name }}"
     description: "{{ current_projects_asset_value.description }}"
-    organization: "{{ current_projects_asset_value.summary_fields.organization.name | organization | default('ToDo: The project \'' + current_projects_asset_value.name + '\' must have an organization') }}"
+    organization: "{{ current_projects_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The project \'' + current_projects_asset_value.name + '\' must have an organization') }}"
 {% if current_projects_asset_value.scm_type %}
     scm_type: "{{ current_projects_asset_value.scm_type }}"
     scm_url: "{{ current_projects_asset_value.scm_url }}"

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -4,7 +4,7 @@ controller_workflows:
 {% endif %}
   - name: "{{ current_workflow_job_templates_asset_value.name }}"
     description: "{{ current_workflow_job_templates_asset_value.description }}"
-    organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default('ToDo: The WF \'' + current_workflow_job_templates_asset_value.name + '\' must belong to an organization') }}"
+    organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | organization | default('ToDo: The WF \'' + current_workflow_job_templates_asset_value.name + '\' must belong to an organization') }}"
     state: "present"
     simplified_workflow_nodes:
 {% for node in query(controller_api_plugin, 'api/v2/workflow_job_template_nodes/',

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -4,7 +4,7 @@ controller_workflows:
 {% endif %}
   - name: "{{ current_workflow_job_templates_asset_value.name }}"
     description: "{{ current_workflow_job_templates_asset_value.description }}"
-    organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | organization | default('ToDo: The WF \'' + current_workflow_job_templates_asset_value.name + '\' must belong to an organization') }}"
+    organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The WF \'' + current_workflow_job_templates_asset_value.name + '\' must belong to an organization') }}"
     state: "present"
     simplified_workflow_nodes:
 {% for node in query(controller_api_plugin, 'api/v2/workflow_job_template_nodes/',
@@ -17,7 +17,7 @@ controller_workflows:
 {% if node.job_type %}
         job_type: "{{ node.job_type }}"
 {% endif %}
-        organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default('ToDo: The WF \'' + current_workflow_job_templates_asset_value.name + '\' must belong to an organization') }}"
+        organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The WF \'' + current_workflow_job_templates_asset_value.name + '\' must belong to an organization') }}"
         all_parents_must_converge: "{{ node.all_parents_must_converge }}"
 {% if node.success_nodes is defined and node.success_nodes | length > 0 %}
         success_nodes:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Sometimes, it happens that an object does not have an organization set. When creating the export, it is marked as 'organizationless' or just given some text. However, if there is only one organization, we should be able to set a variable for this, so that every object can be matched to the defined organization

# How should this be tested?
```yaml
- name: Get objects
  hosts: all 
  roles:
    - role: infra.controller_configuration.filetree_create
      vars:
        organization: 'organization_name'
```
# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
N/A