### PR TITLE
add extra_data to simplified_workflow_nodes in filetree_create role

### DIFF
--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -19,6 +19,10 @@ controller_workflows:
 {% endif %}
         organization: "{{ current_workflow_job_templates_asset_value.summary_fields.organization.name | default(organization if organization != 'ORGANIZATIONLESS' else 'ToDo: The WF \'' + current_workflow_job_templates_asset_value.name + '\' must belong to an organization') }}"
         all_parents_must_converge: "{{ node.all_parents_must_converge }}"
+{% if node.extra_data is defined and node.extra_data | length > 0 %}
+        extra_data:
+          {{ node.extra_data |to_nice_yaml | indent(10) | replace("'{{", "!unsafe \'{{") }}
+{%- endif %}
 {% if node.success_nodes is defined and node.success_nodes | length > 0 %}
         success_nodes:
 {% for success in node.success_nodes %}

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -21,7 +21,7 @@ controller_workflows:
         all_parents_must_converge: "{{ node.all_parents_must_converge }}"
 {% if node.extra_data is defined and node.extra_data | length > 0 %}
         extra_data:
-          {{ node.extra_data |to_nice_yaml | indent(10) | replace("'{{", "!unsafe \'{{") }}
+          {{ node.extra_data | to_nice_yaml | indent(10) | replace("'{{", "!unsafe \'{{") }}
 {%- endif %}
 {% if node.success_nodes is defined and node.success_nodes | length > 0 %}
         success_nodes:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Export extra_data from workflow_nodes using filetree_create frole

# How should this be tested?
Export, using filetree_create role, some WFJT which has to have a node with extra vars. Then, import that WFJT and WF nodes using dispatch role.

# Is there a relevant Issue open for this?
resolves #893 
