### PR TITLE
Bug: Skipping project export while exporting related objects

### DIFF
--- a/changelogs/fragments/filetree_create_related_project_export.yaml
+++ b/changelogs/fragments/filetree_create_related_project_export.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - fix project export while exporting related objects to job template

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -13,12 +13,24 @@
       order_by: 'organization,id'
   no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
-- name: "Export project related to job_template"
-  when: job_template_id is defined and project_id is not defined and (export_related_objects is defined and export_related_objects)
-  ansible.builtin.include_tasks: "projects.yml"
-  vars:
-    project_id: "job_templates_lookvar[0]['summary_fields']['project']['id'] }}"
-  no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
+- name: "Export related block"
+  when: job_template_id is defined and (export_related_objects is defined and export_related_objects)
+  block:
+    - name: Set related project id when project is not defined
+      when: project_id is not defined
+      ansible.builtin.set_fact:
+        related_project_id: "{{ job_templates_lookvar[0]['summary_fields']['project']['id'] }}"
+
+    - name: Set related project id when project is defined
+      when: project_id is defined
+      ansible.builtin.set_fact:
+        related_project_id: "{{ project_id }}"
+
+    - name: "Export project related to job template"
+      ansible.builtin.include_tasks: "projects.yml"
+      vars:
+        project_id: "{{ related_project_id }}"
+      no_log: "{{ controller_configuration_filetree_create_secure_logging }}"
 
 - name: "Block for to generate flatten output"
   when:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
This PR fixes the issue I discovered today, where the export of the project is always skipped due to the existence of the `project_id` variable within the task in when statement.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
```yaml
- name: Get the job template and related project
  hosts: all 
  tasks:
    - name: Retrieve the job_template
      vars:
        job_template_id: 1
        export_related_objects: true
      ansible.builtin.include_role: infra.controller_configuration.filetree_create
```
# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A
# Other Relevant info, PRs, etc
#854