### PR TITLE
fix: missing EE while exporting the project

### DIFF
--- a/changelogs/fragments/filetree_create_project_ee.yml
+++ b/changelogs/fragments/filetree_create_project_ee.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixed missing execution environemnt while exporting the project

--- a/roles/filetree_create/templates/current_projects.j2
+++ b/roles/filetree_create/templates/current_projects.j2
@@ -17,6 +17,9 @@ controller_projects:
     scm_update_on_launch: "{{ current_projects_asset_value.scm_update_on_launch }}"
     scm_update_cache_timeout: "{{ current_projects_asset_value.scm_update_cache_timeout }}"
 {% endif %}
+{% if is_aap and current_job_templates_asset_value.summary_fields.default_environment is defined %}
+    default_environment: "{{ current_job_templates_asset_value.summary_fields.default_environment.name }}"
+{% endif %}
     allow_override: "{{ current_projects_asset_value.allow_override }}"
     timeout: {{ current_projects_asset_value.timeout }}
 {% if query_notification_error | length > 0 %}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
I've noticed that if a project has set a default environment, it is not currently exported by the collection.

# How should this be tested?
1) Set default execution environment for a project.
2) Use filetree_create and check if the EE has been exported.

# Is there a relevant Issue open for this?
N/A

# Other Relevant info, PRs, etc
N/A