### PR TITLE
Added an example credential with HashiCorp Vault source

### DIFF
--- a/roles/credential_input_sources/README.md
+++ b/roles/credential_input_sources/README.md
@@ -78,12 +78,12 @@ This also speeds up the overall role.
 |:---:|:---:|:---:|:---:|:---:|
 |`target_credential`|""|yes|str|Name of credential to have the input source applied|
 |`input_field_name`|""|yes|str|Name of field which will be written by the input source|
-|`source_credential`|""|no|str|Name of the source credential which points to a credential source|
+|`source_credential`|""|no|str|Name of the source credential which points to an external secret lookup credential |
 |`metadata`|""|no|dict|The metadata applied to the source.|
 |`description`|""|no|str|Description to use for the credential input source.|
 |`state`|`present`|no|str|Desired state of the resource.|
 
-For further details on fields see <https://docs.ansible.com/automation-controller/latest/html/userguide/credential_plugins.html>
+For further details on fields see <https://docs.ansible.com/automation-controller/latest/html/userguide/credential_plugins.html>. The input accepted by the `metadata` field will differ depending on the credential plugin being used.
 
 ### Standard Credential Input Source Data Structure
 

--- a/roles/credential_input_sources/README.md
+++ b/roles/credential_input_sources/README.md
@@ -101,6 +101,19 @@ For further details on fields see <https://docs.ansible.com/automation-controlle
           "object_query_format": "Exact"
         },
         "description": "Fill the gitlab credential from CyberArk"
+      },
+      {
+        "source_credential": "hashivault",
+        "target_credential": "gitlab",
+        "input_field_name": "password",
+        "metadata": {
+          "secret_backend": "mykv",
+          "secret_path": "vault/path/to/gitlab/secret",
+          "auth_path": "approle",
+          "secret_key": "GITLAB_PASSWORD_FROM_HASHI_VAULT",
+          "secret_version": "v2"
+        },
+        "description": "Fill the gitlab credential from HashiCorp Vault"
       }
     ]
 }
@@ -111,6 +124,16 @@ For further details on fields see <https://docs.ansible.com/automation-controlle
 ```yaml
 ---
 controller_credential_input_sources:
+  - source_credential: hashivault
+    target_credential: gitlab
+    input_field_name: password
+    metadata:
+      secret_backend: mykv
+      secret_path: vault/path/to/gitlab/secret
+      auth_path: approle
+      secret_key: GITLAB_PASSWORD_FROM_HASHI_VAULT
+      secret_version
+    description: Fill the gitlab credential from HashiCorp Vault
   - source_credential: cyberark
     target_credential: gitlab
     input_field_name: password

--- a/roles/credentials/README.md
+++ b/roles/credentials/README.md
@@ -126,6 +126,15 @@ controller_credentials:
   inputs:
     username: person
     password: password
+- name: hashivault
+  description: HashiCorp Vault Secret Lookup example using token auth
+  organization: Default
+  credential_type: HashiCorp Vault Secret Lookup
+  inputs:
+    url: https://vault.example.com:8243
+    token: token
+    cacert: "{{ lookup('ansible.builtin.file', '/path/to/ca-certificates.crt') }}"
+    api_version: v2
 - name: localuser
   description: Machine Credential example with become_method input
   credential_type: Machine


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Currently, the documentation for the `credential_input_sources` role does not provide an example for HashiCorp Vault, which requires different `metadata` fields from the provided CyberArk example. 
- This PR adds an example of using HashiCorp Vault as a credential input source. 
- This PR also adds an example of creating the HashiCorp Vault source credential using the `credentials` role.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
This should be tested by comparing the provided example with working config as code implementations that use HashiCorp Vault as a credential input source

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
No

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
- We used roles within this collection with HashiCorp Vault credentials and had a hard time finding documentation. Ideally, all supported credential plugins would be documented and this gets us one step closer.
- It is debatable whether adding the source credential is in scope for this PR. Those changes are contained in b69ee64dcaf70ad0c50d31f34beae19f49baee7c if it's decided to remove them from the PR.