### PR TITLE
Give the user the possibility to deactivate dependency check

### DIFF
--- a/changelogs/fragments/dependency_check_control.yml
+++ b/changelogs/fragments/dependency_check_control.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add ability to disable dependency check
+...

--- a/roles/meta_dependency_check/README.md
+++ b/roles/meta_dependency_check/README.md
@@ -1,6 +1,6 @@
 # infra.controller_configuration.meta_dependency_check
 
-This role is designed to eb run before any roles in this collection to check that the underlying awx.awx or ansible.controller collection is installed. This is a dependency of together roles and does not need to be explicitly called.
+This role is designed to be run before any roles in this collection to check that the underlying awx.awx or ansible.controller collection is installed. This is a dependency of together roles and does not need to be explicitly called.
 
 ## License
 

--- a/roles/meta_dependency_check/defaults/main.yml
+++ b/roles/meta_dependency_check/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+controller_dependency_check: true
+...

--- a/roles/meta_dependency_check/tasks/main.yml
+++ b/roles/meta_dependency_check/tasks/main.yml
@@ -1,23 +1,33 @@
 ---
 # tasks file for meta_dependency_check
 
-- name: Check awx.awx is installed
-  ansible.builtin.command: ansible-galaxy collection verify awx.awx
-  failed_when: false
-  changed_when: false
-  register: upstream_dep
+- name: Print dependency check status
+  ansible.builtin.debug:
+    msg: "{{ controller_dependency_check | bool | ternary(__depdency_check_active_msg, __depdency_check_inactive_msg) }}"
+  vars:
+    __depdency_check_active_msg: 'Dependency check is active. Required collections presence will be verified.'
+    __depdency_check_inactive_msg: 'Dependency check is deactivated. Required collections presence will not be verified. This might cause failure in the next tasks.'
 
-- name: Check ansible.controller is installed
-  ansible.builtin.command: ansible-galaxy collection verify ansible.controller
-  failed_when: false
-  changed_when: false
-  register: downstream_dep
+- name: Dependency check block
+  when: controller_dependency_check | bool
+  block:
+    - name: Check awx.awx is installed
+      ansible.builtin.command: ansible-galaxy collection verify awx.awx
+      failed_when: false
+      changed_when: false
+      register: upstream_dep
 
-- name: Ensure one is installed
-  ansible.builtin.fail:
-    msg: One of awx.awx or ansible.controller must be installed
-  when:
-    - "'ERROR!' in upstream_dep.stderr"
-    - "'ERROR!' in downstream_dep.stderr"
+    - name: Check ansible.controller is installed
+      ansible.builtin.command: ansible-galaxy collection verify ansible.controller
+      failed_when: false
+      changed_when: false
+      register: downstream_dep
+
+    - name: Ensure one is installed
+      ansible.builtin.fail:
+        msg: One of awx.awx or ansible.controller must be installed
+      when:
+        - "'ERROR!' in upstream_dep.stderr"
+        - "'ERROR!' in downstream_dep.stderr"
 
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

The dependency check runs the `ansible-galaxy verify` commands which takes a while.
This PR gives the user the possibility to deactivate the dependecy check by setting the new flag `controller_dependency_check` to `false`. By default, it is set to `true`

# How should this be tested?

Run any role with dependecy to the `meta_dependency_check` role.
Set the `controller_dependency_check` to `true` (default value) --> The dependecy check will be executed normally
Set the `controller_dependency_check` to `false` --> The dependecy check will be skipped
In both cases a message will be displayed showing the dependecy check status (active or inactive) with a warning if it is deactivated.

# Is there a relevant Issue open for this?

No

# Other Relevant info, PRs, etc

N/A