### PR TITLE
feat: allow to export project with update_project flag

### DIFF
--- a/changelogs/fragments/filetree_create_update_project.yml
+++ b/changelogs/fragments/filetree_create_update_project.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - filetree_create able to export project with update_project state

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -26,6 +26,7 @@ The following variables are required for that role to work properly:
 | `omit_id` | N/A | no | bool | Whether to create output files without objects id.|
 | `organization`| N/A | no | str | Default organization for all objects that have not been set in the source controller.|
 | `export_related_objects` | False | no | bool | Whether to export related objects (job templates related to certain workflows and the projects associated with these job templates) when a single JT or a single WFJT are being exported. |
+| `update_project_state` | False | no | bool | Wheter the project should be updated after import to the target controller |
 
 ## Dependencies
 

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -26,7 +26,7 @@ The following variables are required for that role to work properly:
 | `omit_id` | N/A | no | bool | Whether to create output files without objects id.|
 | `organization`| N/A | no | str | Default organization for all objects that have not been set in the source controller.|
 | `export_related_objects` | False | no | bool | Whether to export related objects (job templates related to certain workflows and the projects associated with these job templates) when a single JT or a single WFJT are being exported. |
-| `update_project_state` | False | no | bool | Wheter the project should be updated after import to the target controller |
+| `update_project_state` | False | no | bool | Whether the project should be updated after import to the target controller |
 
 ## Dependencies
 

--- a/roles/filetree_create/README.md
+++ b/roles/filetree_create/README.md
@@ -26,7 +26,7 @@ The following variables are required for that role to work properly:
 | `omit_id` | N/A | no | bool | Whether to create output files without objects id.|
 | `organization`| N/A | no | str | Default organization for all objects that have not been set in the source controller.|
 | `export_related_objects` | False | no | bool | Whether to export related objects (job templates related to certain workflows and the projects associated with these job templates) when a single JT or a single WFJT are being exported. |
-| `update_project_state` | False | no | bool | Whether the project should be updated after import to the target controller |
+| `update_project_state` | False | no | bool | Whether the project should be updated after import to the target controller. |
 
 ## Dependencies
 

--- a/roles/filetree_create/templates/current_projects.j2
+++ b/roles/filetree_create/templates/current_projects.j2
@@ -18,6 +18,7 @@ controller_projects:
     scm_update_cache_timeout: "{{ current_projects_asset_value.scm_update_cache_timeout }}"
 {% endif %}
     allow_override: "{{ current_projects_asset_value.allow_override }}"
+    update_project: "{{ update_project_state | default(false) }}"
     timeout: {{ current_projects_asset_value.timeout }}
 {% if query_notification_error | length > 0 %}
     notification_templates_error:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
We would like to have a flag in the collection that allows exporting the project with the update_project variable set to true. I have set it to false by default to avoid altering the default behavior.

# How should this be tested?
1. Export project.
2. Import project.

# Is there a relevant Issue open for this?
N/A

# Other Relevant info, PRs, etc
N/A