### PR TITLE
fix: missing double quote @filetree_create

### DIFF
--- a/changelogs/fragments/filetree_create_scm_refspec.yml
+++ b/changelogs/fragments/filetree_create_scm_refspec.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - filetree_create able to export scm_refspec of project
+  - filetree_create is missing double quote

--- a/roles/filetree_create/templates/current_projects.j2
+++ b/roles/filetree_create/templates/current_projects.j2
@@ -16,7 +16,7 @@ controller_projects:
     scm_delete_on_update: "{{ current_projects_asset_value.scm_delete_on_update }}"
     scm_update_on_launch: "{{ current_projects_asset_value.scm_update_on_launch }}"
     scm_update_cache_timeout: "{{ current_projects_asset_value.scm_update_cache_timeout }}"
-    scm_refspec: "{{ current_projects_asset_value.scm_refspec }}
+    scm_refspec: "{{ current_projects_asset_value.scm_refspec }}"
 {% endif %}
 {% if is_aap and current_job_templates_asset_value.summary_fields.default_environment is defined %}
     default_environment: "{{ current_job_templates_asset_value.summary_fields.default_environment.name }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Hi, I am very sorry I did notice missing quote, please merge it asap, and push another release
# How should this be tested?
N/A
# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A
# Other Relevant info, PRs, etc
N/A