### PR TITLE
Fix issue with looping over always empty list

### DIFF
--- a/changelogs/fragments/filetree_create_loop_issue.yaml
+++ b/changelogs/fragments/filetree_create_loop_issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixed issue with loops that were getting always empty list of objects

--- a/roles/filetree_create/tasks/applications.yml
+++ b/roles/filetree_create/tasks/applications.yml
@@ -53,12 +53,11 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/applications"
-      loop: >-
-        {{ (applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
-           map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-           + ([default(organization)] if ((applications_lookvar | map(attribute='summary_fields')
-           | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
-        }}
+      loop: "{{ (applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+                map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+                + ([default(organization)] if ((applications_lookvar | map(attribute='summary_fields')
+                | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+            }}"
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"

--- a/roles/filetree_create/tasks/applications.yml
+++ b/roles/filetree_create/tasks/applications.yml
@@ -55,7 +55,7 @@
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/applications"
       loop: "{{ (applications_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-                + ([default(organization)] if ((applications_lookvar | map(attribute='summary_fields')
+                + ([organization] if ((applications_lookvar | map(attribute='summary_fields')
                 | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
             }}"
       loop_control:

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -55,7 +55,7 @@
         __path: "{{ output_path }}/{{ needed_path }}/credentials"
       loop: "{{ (credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-                + ([(organization if organization is defined else 'ORGANIZATIONLESS')] if ((credentials_lookvar |
+                + ([organization] if ((credentials_lookvar |
                 map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
             }}"
       loop_control:

--- a/roles/filetree_create/tasks/credentials.yml
+++ b/roles/filetree_create/tasks/credentials.yml
@@ -53,12 +53,11 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path }}/credentials"
-      loop: >-
-        {{ (credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
-           map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-           + ([(organization if organization is defined else 'ORGANIZATIONLESS')] if ((credentials_lookvar |
-           map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
-        }}
+      loop: "{{ (credentials_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+                map(attribute='organization') | map(attribute='name') | list | flatten | unique)
+                + ([(organization if organization is defined else 'ORGANIZATIONLESS')] if ((credentials_lookvar |
+                map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+            }}"
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -87,12 +87,11 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/job_templates"
-      loop: >-
-        {{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
-           map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
-           [organization] if (job_templates_lookvar | map(attribute='summary_fields') |
-           selectattr('organization', 'undefined') | list | flatten | length > 0) else []
-        }}
+      loop: "{{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+                map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
+                [organization] if (job_templates_lookvar | map(attribute='summary_fields') |
+                selectattr('organization', 'undefined') | list | flatten | length > 0) else []
+            }}"
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"

--- a/roles/filetree_create/tasks/job_templates.yml
+++ b/roles/filetree_create/tasks/job_templates.yml
@@ -89,8 +89,8 @@
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/job_templates"
       loop: "{{ (job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
-                [organization] if (job_templates_lookvar | map(attribute='summary_fields') |
-                selectattr('organization', 'undefined') | list | flatten | length > 0) else []
+                ([organization] if ((job_templates_lookvar | map(attribute='summary_fields') |
+                selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
             }}"
       loop_control:
         loop_var: needed_path

--- a/roles/filetree_create/tasks/labels.yml
+++ b/roles/filetree_create/tasks/labels.yml
@@ -54,7 +54,7 @@
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/labels"
       loop: "{{ (labels_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') | map(attribute='organization') | map(attribute='name') | list | flatten | unique)
-                + (['ORGANIZATIONLESS'] if ((labels_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+                + ([organization] if ((labels_lookvar | map(attribute='summary_fields') | selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
              }}"
       loop_control:
         loop_var: needed_path

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -52,8 +52,8 @@
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/notification_templates"
       loop: "{{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
-                [organization] if (notification_templates_lookvar | map(attribute='summary_fields') |
-                selectattr('organization', 'undefined') | list | flatten | length > 0) else []
+                ([organization] if ((notification_templates_lookvar | map(attribute='summary_fields') |
+                selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
             }}"
       loop_control:
         loop_var: needed_path

--- a/roles/filetree_create/tasks/notification_templates.yml
+++ b/roles/filetree_create/tasks/notification_templates.yml
@@ -50,12 +50,11 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/notification_templates"
-      loop: >-
-        {{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
-            map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
-            [organization] if (notification_templates_lookvar | map(attribute='summary_fields') |
-            selectattr('organization', 'undefined') | list | flatten | length > 0) else []
-        }}
+      loop: "{{ (notification_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+                map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
+                [organization] if (notification_templates_lookvar | map(attribute='summary_fields') |
+                selectattr('organization', 'undefined') | list | flatten | length > 0) else []
+            }}"
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -64,12 +64,11 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/projects"
-      loop: >-
-        {{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
-           map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
-           [organization] if (projects_lookvar | map(attribute='summary_fields') |
-           selectattr('organization', 'undefined') | list | flatten | length > 0) else []
-        }}"
+      loop: "{{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+                map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
+                [organization] if (projects_lookvar | map(attribute='summary_fields') |
+                selectattr('organization', 'undefined') | list | flatten | length > 0) else []
+            }}"
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"

--- a/roles/filetree_create/tasks/projects.yml
+++ b/roles/filetree_create/tasks/projects.yml
@@ -66,8 +66,8 @@
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/projects"
       loop: "{{ (projects_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
-                [organization] if (projects_lookvar | map(attribute='summary_fields') |
-                selectattr('organization', 'undefined') | list | flatten | length > 0) else []
+                ([organization] if ((projects_lookvar | map(attribute='summary_fields') |
+                selectattr('organization', 'undefined') | list) | flatten | length > 0) else [])
             }}"
       loop_control:
         loop_var: needed_path

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -53,13 +53,11 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/teams"
-      loop: >-
-        {{
-          (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
-          map(attribute='organization') | map(attribute='name') | list | unique) +
-          [organization] if (teams_lookvar | map(attribute='summary_fields') |
-          selectattr('organization', 'undefined') | list | length > 0) else []
-        }}
+      loop: "{{ (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+                map(attribute='organization') | map(attribute='name') | list | unique) +
+                [organization] if (teams_lookvar | map(attribute='summary_fields') |
+                selectattr('organization', 'undefined') | list | length > 0) else []
+            }}"
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"

--- a/roles/filetree_create/tasks/teams.yml
+++ b/roles/filetree_create/tasks/teams.yml
@@ -55,8 +55,8 @@
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/teams"
       loop: "{{ (teams_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
                 map(attribute='organization') | map(attribute='name') | list | unique) +
-                [organization] if (teams_lookvar | map(attribute='summary_fields') |
-                selectattr('organization', 'undefined') | list | length > 0) else []
+                ([organization] if ((teams_lookvar | map(attribute='summary_fields') |
+                selectattr('organization', 'undefined') | list) | length > 0) else [])
             }}"
       loop_control:
         loop_var: needed_path

--- a/roles/filetree_create/tasks/workflow_job_templates.yml
+++ b/roles/filetree_create/tasks/workflow_job_templates.yml
@@ -90,12 +90,11 @@
         mode: '0755'
       vars:
         __path: "{{ output_path }}/{{ needed_path | regex_replace('/', '_') }}/workflow_job_templates/"
-      loop: >-
-        {{ (workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
-            map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
-            ([organization] if ((workflow_job_templates_lookvar | map(attribute='summary_fields') |
-            selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
-        }}
+      loop: "{{ (workflow_job_templates_lookvar | map(attribute='summary_fields') | selectattr('organization', 'defined') |
+                map(attribute='organization') | map(attribute='name') | list | flatten | unique) +
+                ([organization] if ((workflow_job_templates_lookvar | map(attribute='summary_fields') |
+                selectattr('organization', 'undefined') | list | flatten) | length > 0) else [])
+            }}"
       loop_control:
         loop_var: needed_path
         label: "{{ __path }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Hi,
In the commit:  `0c490f84f9a1b8e79712cc305d077430381188d4` were introduce changes that are breaking the loops, that are resposible to create directories of exported files, the query return always empty list.

Please check this commit ASAP  and release new version because it is unable to export anything

# How should this be tested?
It is reverting changes already tested.

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #918

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
