### PR TITLE
fix: issue when password is in a survey of WF node and schedule

### DIFF
--- a/changelogs/fragments/filetree_create_node_survey.yml
+++ b/changelogs/fragments/filetree_create_node_survey.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - filetree_create able export WF nodes without encrypted value in survey

--- a/changelogs/fragments/filetree_create_node_survey.yml
+++ b/changelogs/fragments/filetree_create_node_survey.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - filetree_create able export WF nodes without encrypted value in survey

--- a/changelogs/fragments/filetree_node_schedule_survey.yml
+++ b/changelogs/fragments/filetree_node_schedule_survey.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - filetree_create able export WF/schedule nodes without encrypted value in survey
+  - filetree_create able export WF nodes and schedules without encrypted value in survey

--- a/changelogs/fragments/filetree_node_schedule_survey.yml
+++ b/changelogs/fragments/filetree_node_schedule_survey.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - filetree_create able export WF/schedule nodes without encrypted value in survey

--- a/roles/filetree_create/templates/current_schedules.j2
+++ b/roles/filetree_create/templates/current_schedules.j2
@@ -34,7 +34,7 @@ controller_schedules:
 {% endif %}
 {% if current_schedules_asset_value.extra_data is defined %}
     extra_data:
-      {{ current_schedules_asset_value.extra_data | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") }}
+      {{ current_schedules_asset_value.extra_data | from_yaml | to_nice_yaml(indent=2) | indent(width=6, first=False) | replace("'{{", "!unsafe \'{{") | replace("$encrypted$", "") }}
 {%- endif -%}
 {% if query_credentials | length > 0 %}
     credentials:

--- a/roles/filetree_create/templates/current_workflow_job_templates.j2
+++ b/roles/filetree_create/templates/current_workflow_job_templates.j2
@@ -21,7 +21,7 @@ controller_workflows:
         all_parents_must_converge: "{{ node.all_parents_must_converge }}"
 {% if node.extra_data is defined and node.extra_data | length > 0 %}
         extra_data:
-          {{ node.extra_data | to_nice_yaml | indent(10) | replace("'{{", "!unsafe \'{{") }}
+          {{ node.extra_data | to_nice_yaml | indent(10) | replace("'{{", "!unsafe \'{{") }} | replace("$encrypted$", "")
 {%- endif %}
 {% if node.success_nodes is defined and node.success_nodes | length > 0 %}
         success_nodes:


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Today I've notice encrypted value inside the extra_data, when there is a value inside the workflow node, then when the object is imported the dispatch is failing.

# How should this be tested?
1) Create a JT with survey that has required password variable.
2) Create a WF and add JT to the WF, fill the variable password as it is required value.
3) Export the objects.
4) Import the objects

# Is there a relevant Issue open for this?
N/A

# Other Relevant info, PRs, etc
N/A