### PR TITLE
replace default GH token with fine grained access token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     secrets:
       collection_api_key_1: ${{ secrets.GALAXY_INFRA_KEY }}
       collection_api_key_2: ${{ secrets.CRC_PUBLISH_KEY }}
-      git_token: ${{ secrets.GITHUB_TOKEN }}
+      git_token: ${{ secrets.GH_WORKFLOW_KEY }}
       quay_token: ${{ secrets.quay_token }}
       matrix_token: ${{ secrets.matrix_token }}
 ...

--- a/.github/workflows/update_pre_commit.yml
+++ b/.github/workflows/update_pre_commit.yml
@@ -14,5 +14,5 @@ jobs:
     with:
       github_actor: ${{ github.actor }}
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.GH_WORKFLOW_KEY }}
 ...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
The standard GH token isn't able to create PRs any more so I replaced it in the manual release and it works. This will fix it for the rest of the workflows.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Try it

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
