### PR TITLE
BACKPORT: Add missing request_timeout option to credential role

### DIFF
--- a/changelogs/fragments/cred_request_timeout.yml
+++ b/changelogs/fragments/cred_request_timeout.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - BACKPORT - Add missing request_timeout option to credential role

--- a/roles/credentials/tasks/main.yml
+++ b/roles/credentials/tasks/main.yml
@@ -18,6 +18,7 @@
     controller_password:            "{{ controller_password | default(omit, true) }}"
     controller_oauthtoken:          "{{ controller_oauthtoken | default(omit, true) }}"
     controller_host:                "{{ controller_hostname | default(omit, true) }}"
+    request_timeout:                "{{ controller_request_timeout | default(omit, true) }}"
     controller_config_file:         "{{ controller_config_file | default(omit, true) }}"
     validate_certs:                 "{{ controller_validate_certs | default(omit) }}"
   loop: "{{ credentials if credentials is defined else controller_credentials }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Adds previously fixed missing `request_timeout` option to the credentials role

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
The option is available

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #936 

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
This is PR is against the new `controller_configuration` branch which will exist for backports like this. Releases can be done from this branch. In likelihood these will mostly be bug fixes like this and will be released as `2.11.z`
