### PR TITLE
Fix misspelling of hub_ee_repository_sync

### DIFF
--- a/roles/dispatch/meta/argument_specs.yml
+++ b/roles/dispatch/meta/argument_specs.yml
@@ -132,7 +132,7 @@ argument_specs:
           - role: hub_ee_repository
             var: hub_ee_repositories
             tags: repos
-          - role: phub_ee_repository_sync
+          - role: hub_ee_repository_sync
             var: hub_ee_repository_sync
             tags: reposync
           - role: hub_ee_image


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Fix name of role.  All other similar roles all stat with `hub` and this starts with `phub` which appears to be a misspelling

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
