### PR TITLE
Add controller_configuration role vars entries in CONVERSION_GUIDE

### DIFF
--- a/CONVERSION_GUIDE.md
+++ b/CONVERSION_GUIDE.md
@@ -218,7 +218,7 @@ The dispatch role has changed to use the following order:
 - controller roles
 - eda roles
 
-These loop through all the applicable roles to create objects in the AAP. They will skip the role if the variable used in that role is not defined. you can tweak each services set of roles, or only run a single services roles by using the `aap_configuration_dispatcher_roles` variables. Refer to the [Dispatch role readme](roles/eda_controller_tokens/README.md) for more information.
+These loop through all the applicable roles to create objects in the AAP. They will skip the role if the variable used in that role is not defined. you can tweak each services set of roles, or only run a single services roles by using the `aap_configuration_dispatcher_roles` variables. Refer to the [Dispatch role readme](roles/dispatch/README.md) for more information.
 
 ## Roles moved
 

--- a/CONVERSION_GUIDE.md
+++ b/CONVERSION_GUIDE.md
@@ -112,12 +112,13 @@ controller_configuration vars:
 - controller_projects
 - controller_inventories
 - controller_inventory_sources
-- controller_inventory_sources
 - controller_hosts
+- controller_groups
 - controller_bulk_hosts
 - controller_templates
 - controller_workflows
 - controller_schedules
+- controller_roles
 - controller_launch_jobs
 - controller_workflow_launch_jobs
 - aap_user_accounts <- controller_user_accounts


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->

Add controller_configuration role vars entries in CONVERSION_GUIDE.

Added `controller_roles` for:
https://github.com/redhat-cop/infra.aap_configuration/blob/d35606856bc72dbd16f8c20d5935e1c2f8a7217f/roles/controller_roles/README.md?plain=1#L26

Added `controller_groups` for:
https://github.com/redhat-cop/infra.aap_configuration/blob/d35606856bc72dbd16f8c20d5935e1c2f8a7217f/roles/controller_host_groups/README.md?plain=1#L26

(Also fixed link to dispatch role REAMDE)

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->


# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
