### PR TITLE
fix token variable name in to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Define following vars here, or in `aap_configs/controller_auth.yml`
 You can also specify authentication by a combination of either:
 
 - `aap_hostname`, `aap_username`, `aap_password`
-- `aap_hostname`, `controller_oauthtoken`
+- `aap_hostname`, `aap_token`
 
 The OAuth2 token is the preferred method. You can obtain the token through the preferred `controller_token` module, or through the
 AWX CLI [login](https://docs.ansible.com/automation-controller/latest/html/controllerapi/authentication.html)


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->

fix `controller_oauthtoken` to `aap_token`.

In README.md in each roles and [CONVERSION_GUIDE.md](https://github.com/redhat-cop/infra.aap_configuration/blob/devel/CONVERSION_GUIDE.md#connection-variables), the token variable name is `aap_token`. 

But in only top README.md was still `controller_oauthtoken`.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->


# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
