### PR TITLE
fix tag for users role

### DIFF
--- a/roles/dispatch/defaults/main.yml
+++ b/roles/dispatch/defaults/main.yml
@@ -41,7 +41,7 @@ gateway_configuration_dispatcher_roles:
     tags: teams
   - role: gateway_users
     var: aap_user_accounts
-    tags: teams
+    tags: users
 
 hub_configuration_dispatcher_roles:
   - role: hub_namespace


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes the tag for the users role

# How should this be tested?
Execute role with the `users` tag instead of the `teams` tag

# Is there a relevant Issue open for this?
N/A

# Other Relevant info, PRs, etc
N/A
