### PR TITLE
Update README.md

### DIFF
--- a/roles/gateway_role_user_assignments/README.md
+++ b/roles/gateway_role_user_assignments/README.md
@@ -55,7 +55,7 @@ Options for the `role_user_assignments` variable:
 | Variable Name       | Default Value | Required | Type | Description                                                                                           |
 |:--------------------|:-------------:|:--------:|:----:|:------------------------------------------------------------------------------------------------------|
 | `role_definition`   |      N/A      |   yes    | str  | The name or id of the role definition to assign to the user.                                          |
-| `user`              |      N/A      |    no    | str  | The username or id of the user to assign to the object.                                               |
+| `user`              |      N/A      |    no    | str  | The username of the user to assign to the object.                                                     |
 | `user_ansible_id`   |      N/A      |    no    | str  | Resource id of the user who will receive permissions from this assignment. Alternative to user field. |
 | `object_id`         |      N/A      |    no    | int  | Primary key of the object this assignment applies to.                                                 |
 | `object_ansible_id` |      N/A      |    no    | str  | Resource id of the object this role applies to. Alternative to the object_id field.                   |


### PR DESCRIPTION
The field `user` in the `gateway_role_user_assignements` role is not handling well the `id` of the user, so, only the user's `username` is working correctly

Working OK:
```
ok: [localhost] => (item=Create/Update Role Organization Member | Wait for finish the Roles creation) => {
    "__gateway_role_user_assignments_job_async_results_item": {
        "__gateway_role_user_assignments_item": {
            "object_id": "2",
            "role_definition": "Organization Member",
            "user": "test_user_1"
        },
        "ansible_job_id": "j820885315526.537903",
        "ansible_loop_var": "__gateway_role_user_assignments_item",
        "changed": false,
        "failed": 0,
        "finished": 0,
        "results_file": "/home/ivan/.ansible_async/j820885315526.537903",
        "started": 1
    },
    "ansible_job_id": "j820885315526.537903",
    "ansible_loop_var": "__gateway_role_user_assignments_job_async_results_item",
    "attempts": 1,
    "changed": false,
    "finished": 1,
    "invocation": {
        "module_args": {
            "gateway_hostname": "aap25.iam.lab",
            "gateway_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "gateway_request_timeout": null,
            "gateway_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "gateway_username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "gateway_validate_certs": false,
            "object_ansible_id": null,
            "object_id": 2,
            "role_definition": "Organization Member",
            "state": "present",
            "user": "test_user_1",
            "user_ansible_id": null
        }
    },
    "results_file": "/home/ivan/.ansible_async/j820885315526.537903",
    "started": 1,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "",
    "stdout_lines": []
}

```

Failing:
```
failed: [localhost] (item=Create/Update Role 2 | Wait for finish the Roles creation) => {
    "__gateway_role_user_assignments_job_async_results_item": {
        "__gateway_role_user_assignments_item": {
            "object_id": "1",
            "role_definition": "2",
            "user": "3"
        },
        "ansible_job_id": "j374059080902.537920",
        "ansible_loop_var": "__gateway_role_user_assignments_item",
        "changed": false,
        "failed": 0,
        "finished": 0,
        "results_file": "/home/ivan/.ansible_async/j374059080902.537920",
        "started": 1
    },
    "ansible_job_id": "j374059080902.537920",
    "ansible_loop_var": "__gateway_role_user_assignments_job_async_results_item",
    "attempts": 1,
    "changed": false,
    "finished": 1,
    "invocation": {
        "module_args": {
            "gateway_hostname": "aap25.iam.lab",
            "gateway_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "gateway_request_timeout": null,
            "gateway_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "gateway_username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "gateway_validate_certs": false,
            "object_ansible_id": null,
            "object_id": 1,
            "role_definition": "2",
            "state": "present",
            "user": "3",
            "user_ansible_id": null
        }
    },
    "msg": "c{'user': 'Provide exactly one of user or user_ansible_id', 'user_ansible_id': 'Provide exactly one of user or user_ansible_id'}",
    "results_file": "/home/ivan/.ansible_async/j374059080902.537920",
    "started": 1,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "",
    "stdout_lines": []
}

```

<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Fixes the documentation to reflect only the `username` option, and not the `id`.
# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
I'm testing this manually as part of https://github.com/redhat-cop/aap_configuration_extended/issues/44
# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!--- 
resolves #[number]
-->
# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A