### PR TITLE
Fixed the object creation order for the gateway staf.

### DIFF
--- a/changelogs/fragments/dispatcher_gateway_order.yml
+++ b/changelogs/fragments/dispatcher_gateway_order.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixed the object creation order for the gateway staf.

--- a/roles/dispatch/defaults/main.yml
+++ b/roles/dispatch/defaults/main.yml
@@ -9,15 +9,15 @@ gateway_configuration_dispatcher_roles:
   - role: gateway_settings
     var: gateway_settings
     tags: settings
+  - role: gateway_organizations
+    var: aap_organizations
+    tags: organizations
   - role: gateway_applications
     var: aap_applications
     tags: applications
   - role: gateway_http_ports
     var: http_ports_list
     tags: http_ports
-  - role: gateway_organizations
-    var: aap_organizations
-    tags: organizations
   - role: gateway_service_clusters
     var: gateway_service_clusters
     tags: service_clusters
@@ -30,18 +30,18 @@ gateway_configuration_dispatcher_roles:
   - role: gateway_services
     var: gateway_services
     tags: services
-  - role: gateway_role_user_assignments
-    var: gateway_role_user_assignments
-    tags: role_user_assignments
-  - role: gateway_routes
-    var: gateway_routes
-    tags: routes
   - role: gateway_teams
     var: aap_teams
     tags: teams
   - role: gateway_users
     var: aap_user_accounts
     tags: users
+  - role: gateway_role_user_assignments
+    var: gateway_role_user_assignments
+    tags: role_user_assignments
+  - role: gateway_routes
+    var: gateway_routes
+    tags: routes
 
 hub_configuration_dispatcher_roles:
   - role: hub_namespace


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
This PR is fixing the order of the gateway objects creation, for example, team roles cannot be assigned before the team has been created.
# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Manually tested during the development of https://github.com/redhat-cop/aap_configuration_extended/issues/44
# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!--- resolves #[number] -->

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A