### PR TITLE
Allow to set the delay and the number of retries to attempt when creating workflow nodes

### DIFF
--- a/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml
+++ b/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml
@@ -58,7 +58,8 @@
     jid: "{{ __workflows_node_async_results_item.ansible_job_id }}"
   register: __workflows_node_async_result
   until: __workflows_node_async_result.finished
-  retries: 10
+  retries: "{{ controller_configuration_workflow_async_retries }}"
+  delay: "{{ controller_configuration_workflow_async_delay }}"
   loop: "{{ __workflows_node_async.results }}"
   loop_control:
     loop_var: __workflows_node_async_results_item


### PR DESCRIPTION


<!--- markdownlint-disable MD041 -->
# What does this PR do?

Allow to use the asynchronous retry variables when creating the workflow nodes in the `controller_workflow_job_templates` role.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Manually

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->

Before this change, the task was only attempting 10 retries, while all other synchronization tasks attempt the specified number with the variable `controller_configuration_workflow_async_delay`. 

Similarly, there was no delay, while the other tasks were waiting for the specified delay with the variable `aap_configuration_async_delay` or `controller_configuration_workflow_async_delay`
