### PR TITLE
Adjust for doc ah_namespace

### DIFF
--- a/roles/hub_namespace/README.md
+++ b/roles/hub_namespace/README.md
@@ -89,10 +89,9 @@ hub_namespaces:
       - name: "New_Google"
         url: "http://www.google.com"
     groups:
-      - name: system:partner-engineers
-        object_roles:
-          - "change_namespace"
-          - "upload_to_namespace"
+      - system::partner-engineers
+      - Default
+
 ```
 
 ## Playbook Examples

--- a/roles/hub_namespace/README.md
+++ b/roles/hub_namespace/README.md
@@ -90,7 +90,8 @@ hub_namespaces:
         url: "http://www.google.com"
     groups:
       - system::partner-engineers
-      - Default
+      - "<organization>::<team>"
+      - "team"
 
 ```
 


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
I needed to create a namespace in the HUB associated with a team so that this team would have permission to publish collections to that namespace. I was using the infra.aap_configuration.hub_namespace collection, but in the group parameter, the documentation shows a dictionary, whereas in reality, the ansible.hub.ah_namespace collection only accepts a list of groups or teams.

# How should this be tested?
This was tested on AAP 2.5.12 using the following collections:
ansible-hub version 1.0.0
infra.aap_configuration version 3.2.0

# Is there a relevant Issue open for this?
Looking at the ansible.hub.ah_namespace collection, the file https://github.com/ansible-collections/ansible_hub/blob/b751217e98cd8240ada99e9df7fe6a5c45a12f45/plugins/modules/ah_namespace.py#L161 does not show that we can change the roles; instead, it indicates that an owner role is automatically injected into the group or team


