### PR TITLE
Add enabled and disabled actions in global_vars

### DIFF
--- a/roles/global_vars/defaults/main.yml
+++ b/roles/global_vars/defaults/main.yml
@@ -10,4 +10,10 @@ operation_translate:
   exists:
     verb: Already Exists
     action: exists
+  enabled:
+    verb: Enabled
+    action: enabled
+  disabled:
+    verb: Disabled
+    action: disabled
 ...


### PR DESCRIPTION
This PR adds `enabled` and `disabled` actions in global vars to align
with the states supported by `eda.rulebook_activation`:
https://github.com/ansible/event-driven-ansible/blob/main/plugins/modules/rulebook_activation.py#L151-L161
