### PR TITLE
The 'auto_migrate_users_to' field can't be 'false' as default. Omit instead.

### DIFF
--- a/changelogs/fragments/gateway_authenticators.yaml
+++ b/changelogs/fragments/gateway_authenticators.yaml
@@ -1,4 +1,4 @@
 ---
-minor_bugs:
+bugfixes:
   - The 'auto_migrate_users_to' field can't be 'false' as default. Omit instead.
 ...

--- a/changelogs/fragments/gateway_authenticators.yaml
+++ b/changelogs/fragments/gateway_authenticators.yaml
@@ -1,0 +1,4 @@
+---
+minor_bugs:
+  - The 'auto_migrate_users_to' field can't be 'false' as default. Omit instead.
+...

--- a/roles/gateway_authenticators/tasks/main.yml
+++ b/roles/gateway_authenticators/tasks/main.yml
@@ -8,7 +8,7 @@
     create_objects: "{{ __gateway_authenticators_item.create_objects | default(omit) }}"
     remove_users: "{{ __gateway_authenticators_item.remove_users | default(omit) }}"
     configuration: "{{ __gateway_authenticators_item.configuration | default(omit) }}"
-    auto_migrate_users_to:  "{{ __gateway_authenticators_item.auto_migrate_users_to | default('false') }}"
+    auto_migrate_users_to:  "{{ __gateway_authenticators_item.auto_migrate_users_to | default(omit) }}"
     type: "{{ __gateway_authenticators_item.type | default(omit) }}"
     order: "{{ __gateway_authenticators_item.order | default(omit) }}"
     state: "{{ __gateway_authenticators_item.state | default(platform_state | default(omit, true)) }}"


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
The field `auto_migrate_users_to` expects a name of an `authenticator`, is not a boolean. So, the current default value `false` causes the module to look for the `false` authenticator, which doesn't exist.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
Manually
# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
<!--- resolves #[number] -->
N/A
# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A