### PR TITLE
Prevent an empty automatic release

### DIFF
--- a/.github/files/calculate_change.sh
+++ b/.github/files/calculate_change.sh
@@ -1,3 +1,9 @@
+if [ -z "$(ls changelogs/fragments/*.yml changelogs/fragments/*.yaml)" ]; then
+  echo "change_present=false" >> "$GITHUB_OUTPUT"
+else
+  echo "change_present=true" >> "$GITHUB_OUTPUT"
+fi
+
 grep -RE '(major_changes|breaking_changes)' changelogs/fragments;
 MAJOR=$?;
 grep -R minor_changes changelogs/fragments;

--- a/.github/workflows/release_auto.yml
+++ b/.github/workflows/release_auto.yml
@@ -10,40 +10,50 @@ on:
 
 jobs:
   calculate_version:
+    name: Calculate Collection Version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions-ecosystem/action-get-latest-tag@v1
+      - name: Get the most recent tag
+        uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag
         with:
           semver_only: true
 
-      - name: calculate bump level
+      - name: Calculate bump level
         id: bump_level
         shell: bash
         run: .github/files/calculate_change.sh
 
-      - uses: actions-ecosystem/action-bump-semver@v1
+      - name: Bump version
+        uses: actions-ecosystem/action-bump-semver@v1
         id: bump-semver
         with:
           current_version: ${{ steps.get-latest-tag.outputs.tag }}
           level: ${{ steps.bump_level.outputs.level }}
-
-      - name: Release
-        if: steps.bump_level.outputs.level != 'major' || github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-          tag_name: ${{ steps.bump-semver.outputs.new_version }}
-          generate_release_notes: true
     outputs:
       collection_version: ${{ steps.bump-semver.outputs.new_version }}
       change_level: ${{ steps.bump_level.outputs.level }}
+      change_present: ${{ steps.bump_level.outputs.change_present }}
+
+  create_github_release:
+    name: Create GitHub Release
+    needs: calculate_version
+    runs-on: ubuntu-latest
+    if: (needs.calculate_version.outputs.change_level != 'major' && needs.calculate_version.outputs.change_present != 'false') || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Create Github Release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ needs.calculate_version.outputs.collection_version }}
+          generate_release_notes: true
 
   release:
-    needs: calculate_version
-    if: needs.calculate_version.outputs.change_level != 'major' || github.event_name == 'workflow_dispatch'
+    name: Release Collection to galaxy/AH
+    needs: create_github_release
+    if: (needs.calculate_version.outputs.change_level != 'major' && needs.calculate_version.outputs.change_present != 'false') || github.event_name == 'workflow_dispatch'
     uses: "redhat-cop/ansible_collections_tooling/.github/workflows/release_pipeline_dual.yml@main"
     with:
       # Galaxy Publish


### PR DESCRIPTION


<!-- markdownlint-disable -->
# What does this PR do?
I realised that at present if no changes had been made we would still create a new patch release. This shouldn't be the case. I've made it so that it is still possible to perform a release that has no changelogs (we may need to do this in some circumstances), this is possible when we perform a manual release.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
See it stopping the release here when no changes: https://github.com/Tompage1994/controller_configuration/actions/runs/15344682751 

and continuing here when there are: https://github.com/Tompage1994/controller_configuration/actions/runs/15344892665 (I cancelled it doing the actual deployment to galaxy/AH, but it still proves it out)

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #1114 

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
Related to #1100 
