### PR TITLE
Reverts the aap_token being applied to hub roles. 

### DIFF
--- a/changelogs/fragments/hub_token.yml
+++ b/changelogs/fragments/hub_token.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Reverts the aap_token being applied to hub roles. Instead hub_token is now used.
+...

--- a/roles/hub_collection/README.md
+++ b/roles/hub_collection/README.md
@@ -99,7 +99,7 @@ hub_collections:
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_collection/meta/argument_specs.yml
+++ b/roles/hub_collection/meta/argument_specs.yml
@@ -73,7 +73,7 @@ argument_specs:
         required: false
         description: Controller Admin User's password on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at vars/controller-secrets.yml or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.
         type: str
-      aap_token:
+      hub_token:
         default: None
         required: false
         description: Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.

--- a/roles/hub_collection/tasks/main.yml
+++ b/roles/hub_collection/tasks/main.yml
@@ -16,7 +16,7 @@
     ah_host: "{{ aap_hostname | default(omit) }}"
     ah_username: "{{ aap_username | default(omit) }}"
     ah_password: "{{ aap_password | default(omit) }}"
-    ah_token: "{{ aap_token | default(omit) }}"
+    ah_token: "{{ hub_token | default(omit) }}"
     ah_path_prefix: "{{ hub_path_prefix | default(ah_path_prefix | default(omit)) }}"
     validate_certs: "{{ aap_validate_certs | default(omit) }}"
     request_timeout: "{{ aap_request_timeout | default(omit) }}"

--- a/roles/hub_collection/tests/test.yml
+++ b/roles/hub_collection/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_collection_remote/meta/argument_specs.yml
+++ b/roles/hub_collection_remote/meta/argument_specs.yml
@@ -69,7 +69,7 @@ argument_specs:
         required: false
         description: Controller Admin User's password on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at vars/controller-secrets.yml or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.
         type: str
-      aap_token:
+      hub_token:
         default: None
         required: false
         description: Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.

--- a/roles/hub_collection_remote/tests/test.yml
+++ b/roles/hub_collection_remote/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_collection_repository/meta/argument_specs.yml
+++ b/roles/hub_collection_repository/meta/argument_specs.yml
@@ -57,7 +57,7 @@ argument_specs:
         required: false
         description: Controller Admin User's password on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at vars/controller-secrets.yml or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.
         type: str
-      aap_token:
+      hub_token:
         default: None
         required: false
         description: Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.

--- a/roles/hub_collection_repository/tests/test.yml
+++ b/roles/hub_collection_repository/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_collection_repository_sync/meta/argument_specs.yml
+++ b/roles/hub_collection_repository_sync/meta/argument_specs.yml
@@ -57,7 +57,7 @@ argument_specs:
         required: false
         description: Controller Admin User's password on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at vars/controller-secrets.yml or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.
         type: str
-      aap_token:
+      hub_token:
         default: None
         required: false
         description: Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.

--- a/roles/hub_collection_repository_sync/tests/test.yml
+++ b/roles/hub_collection_repository_sync/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_ee_image/tests/test.yml
+++ b/roles/hub_ee_image/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_ee_registry/tests/test.yml
+++ b/roles/hub_ee_registry/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_ee_registry_index/tests/test.yml
+++ b/roles/hub_ee_registry_index/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_ee_registry_sync/tests/test.yml
+++ b/roles/hub_ee_registry_sync/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_ee_repository/tests/test.yml
+++ b/roles/hub_ee_repository/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_ee_repository_sync/tests/test.yml
+++ b/roles/hub_ee_repository_sync/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_group/tests/test.yml
+++ b/roles/hub_group/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_group_roles/tests/test.yml
+++ b/roles/hub_group_roles/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_namespace/README.md
+++ b/roles/hub_namespace/README.md
@@ -11,7 +11,7 @@ An Ansible Role to create Namespaces in Automation Hub.
 |`aap_hostname`|""|yes|URL to the Ansible Automation Platform Server.|127.0.0.1|
 |`aap_username`|""|no|Admin User on the Ansible Automation Platform Server. Either username / password or oauthtoken need to be specified.||
 |`aap_password`|""|no|Platform Admin User's password on the Server.  This should be stored in an Ansible Vault at vars/platform-secrets.yml or elsewhere and called from a parent playbook.||
-|`aap_token`|""|yes|Tower Admin User's token on the Automation Hub Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||
+|`hub_token`|""|yes|Tower Admin User's token on the Automation Hub Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
@@ -109,7 +109,7 @@ hub_namespaces:
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_namespace/meta/argument_specs.yml
+++ b/roles/hub_namespace/meta/argument_specs.yml
@@ -73,7 +73,7 @@ argument_specs:
         required: false
         description: Controller Admin User's password on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at vars/controller-secrets.yml or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.
         type: str
-      aap_token:
+      hub_token:
         default: None
         required: false
         description: Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.

--- a/roles/hub_namespace/tasks/main.yml
+++ b/roles/hub_namespace/tasks/main.yml
@@ -28,7 +28,7 @@
     ah_host: "{{ aap_hostname | default(omit) }}"
     ah_username: "{{ aap_username | default(omit) }}"
     ah_password: "{{ aap_password | default(omit) }}"
-    ah_token: "{{ aap_token | default(omit) }}"
+    ah_token: "{{ hub_token | default(omit) }}"
     ah_path_prefix: "{{ hub_path_prefix | default(ah_path_prefix | default(omit)) }}"
     validate_certs: "{{ aap_validate_certs | default(omit) }}"
     request_timeout: "{{ aap_request_timeout | default(omit) }}"

--- a/roles/hub_namespace/tests/test.yml
+++ b/roles/hub_namespace/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_publish/README.md
+++ b/roles/hub_publish/README.md
@@ -11,7 +11,7 @@ An Ansible Role to publish collections to Automation Hub or Galaxies.
 |`aap_hostname`|""|yes|URL to the Ansible Automation Platform Server.|127.0.0.1|
 |`aap_username`|""|no|Admin User on the Ansible Automation Platform Server. Either username / password or oauthtoken need to be specified.||
 |`aap_password`|""|no|Platform Admin User's password on the Server.  This should be stored in an Ansible Vault at vars/platform-secrets.yml or elsewhere and called from a parent playbook.||
-|`aap_token`|""|no|Admin User's token on the Automation Hub Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||
+|`hub_token`|""|no|Admin User's token on the Automation Hub Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
@@ -92,7 +92,7 @@ ah_auto_approve: true
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_publish/tasks/main.yml
+++ b/roles/hub_publish/tasks/main.yml
@@ -78,7 +78,7 @@
     validate_certs: "{{ aap_validate_certs | default(omit) }}"
     request_timeout: "{{ aap_request_timeout | default(omit) }}"
   when:
-    - aap_token is not defined
+    - hub_token is not defined
     - lookup("ansible.builtin.env", "AH_API_TOKEN") == ""
     - ah_collection_list | length > 1
 
@@ -93,7 +93,7 @@
     ah_host: "{{ aap_hostname | default(omit) }}"
     ah_username: "{{ aap_username | default(omit) }}"
     ah_password: "{{ aap_password | default(omit) }}"
-    ah_token: "{{ aap_token | default(omit) }}"
+    ah_token: "{{ hub_token | default(omit) }}"
     ah_path_prefix: "{{ hub_path_prefix | default(ah_path_prefix | default(omit)) }}"
     validate_certs: "{{ aap_validate_certs | default(omit) }}"
     request_timeout: "{{ aap_request_timeout | default(omit) }}"
@@ -131,7 +131,7 @@
     ah_host: "{{ aap_hostname | default(omit) }}"
     ah_username: "{{ aap_username | default(omit) }}"
     ah_password: "{{ aap_password | default(omit) }}"
-    ah_token: "{{ aap_token | default(omit) }}"
+    ah_token: "{{ hub_token | default(omit) }}"
     ah_path_prefix: "{{ hub_path_prefix | default(ah_path_prefix | default(omit)) }}"
     validate_certs: "{{ aap_validate_certs | default(omit) }}"
     request_timeout: "{{ aap_request_timeout | default(omit) }}"

--- a/roles/hub_publish/tests/test.yml
+++ b/roles/hub_publish/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_role/tests/test.yml
+++ b/roles/hub_role/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/hub_user/tests/test.yml
+++ b/roles/hub_user/tests/test.yml
@@ -7,7 +7,7 @@
     aap_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # aap_token: changeme
+  # hub_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
Reverts the aap_token being applied to hub roles. 
Instead hub_token is now used.
# How should this be tested?
The API requires a token created by hub. This works with that. The best way to get the token is to use the ah_token module.
# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #1122 

# Other Relevant info, PRs, etc
N/A
