### PR TITLE
adding version in readme to be clear what version is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ collections:
   - name: ansible.platform
   - name: ansible.hub
   - name: ansible.controller
+    version: ">=4.6.0"
   - name: ansible.eda
   - name: infra.aap_configuration
 ...


### PR DESCRIPTION
updates the readme to be more clear on what version of ansible.controller is required