### PR TITLE
add object_ids to arguments specs

### DIFF
--- a/changelogs/fragments/1140-add-objectids-argspec.yml
+++ b/changelogs/fragments/1140-add-objectids-argspec.yml
@@ -1,0 +1,3 @@
+---
+minor_change:
+  - gateway_role_user_assignments - ansible.platform.role_user_assignment as of version 2.5.20250702 supports the objects_ids parameters and marks object_id as deprecated. pull request #1135 added support for object_ids, but the argument spec was missing. This changes sets object_id to optional (was required) and adds object_ids to argument specs.

--- a/roles/gateway_role_user_assignments/meta/argument_specs.yml
+++ b/roles/gateway_role_user_assignments/meta/argument_specs.yml
@@ -17,8 +17,13 @@ argument_specs:
           object_id:
             description:
               - Primary key of the object this assignment applies to.
-            required: true
+            required: false
             type: int
+          object_ids:
+            description:
+              - List of object IDs (Primary Key) or names this assignment applies to.
+            required: false
+            type: list
           user:
             description:
               - The name or id of the user to assign to the object.


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?

- ansible.platform as of 20250702 supports the objects_ids parameter which contains a list of ids or names assignments

- set object_id to optional as this is now deprecated and is mutual exclusive with object_ids

- #1135 added the parameter object_ids but the argument spec was missing


# How should this be tested?

use object_ids in gateway_role_user_assignments

# Is there a relevant Issue open for this?

no

# Other Relevant info, PRs, etc

PR #1135 
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
