### PR TITLE
fixing: improve eda docs

### DIFF
--- a/roles/controller_credentials/README.md
+++ b/roles/controller_credentials/README.md
@@ -86,7 +86,7 @@ This also speeds up the overall role.
 
 ### Credential types
 
-To get a list of all the available builtin credential types, [checkout the ansible doc's link here](https://docs.ansible.com/automation-controller/latest/html/userguide/credentials.html#credential-types)
+To get a list of all the available builtin credential types, [checkout the ansible doc's link here](https://docs.ansible.com/automation-controller/4.5/html/userguide/credential_types.html)
 
 ### Standard Credential Data Structure
 

--- a/roles/eda_credentials/README.md
+++ b/roles/eda_credentials/README.md
@@ -61,6 +61,10 @@ This also speeds up the overall role.
 |`credential_type`|"GitHub Personal Access Token"|yes|str|The type of the credential.|
 |`state`|`present`|no|str|Desired state of the credential.|
 
+### Credential types
+
+To get a list of all the available builtin credential types, [checkout the ansible doc's link here](https://docs.ansible.com/automation-controller/4.5/html/userguide/credential_types.html)
+
 ### Standard Credential Data Structure
 
 #### Yaml Example
@@ -68,11 +72,15 @@ This also speeds up the overall role.
 ```yaml
 ---
 eda_credentials:
-  - name: my_github_user
-    description: my GitHub Credential
-    credential_type: 'GitHub Personal Access Token'
-    username: githubuser
-    secret: GITHUBTOKEN
+  - name: control-tower
+    description: AAP credentials
+    credential_type: 'Red Hat Ansible Automation Platform'
+    organization: "Default"
+    inputs:
+      host: "https://aap.example.io"
+      password: "Ala-ma-kota-12" 
+      username: "admin"
+      verify_ssl: true
 ```
 
 ## Playbook Examples

--- a/roles/eda_projects/README.md
+++ b/roles/eda_projects/README.md
@@ -74,6 +74,7 @@ eda_projects:
     url: https://github.com/ansible/ansible-rulebook.git
     tls_validation: true
     credential: test_token
+    organization: Default
 ```
 
 ## Playbook Examples


### PR DESCRIPTION
<!-- markdownlint-disable -->

- Corrects the link to builtin `credential_types`
- Provides a working example of `eda_credentials`
- Links to automation-controller as some credential types overlap; however, I wasn't able to find the correct list. Maybe we can build one somewhere?
- `eda_projects` requires an `organization` field when it's new (default state: present)

# How should this be tested?
Not tested, rather read. 

# Is there a relevant Issue open for this?
Nope.

# Other Relevant info, PRs, etc
No issues, requests.
