### PR TITLE
Fix accidentally removed usage of variables

### DIFF
--- a/changelogs/fragments/1154_retries_delay.yml
+++ b/changelogs/fragments/1154_retries_delay.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix accidentally removed usage of '*_async_delay' and '*_async_retries' variables
+...

--- a/roles/controller_applications/tasks/main.yml
+++ b/roles/controller_applications/tasks/main.yml
@@ -53,7 +53,9 @@
         label: "{{ __operation.verb }} Controller Application {{ __applications_job_async_results_item.__application_item.name }} | Wait for finish the Application {{
           __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_applications_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_applications }}"
+        cas_async_delay: "{{ controller_configuration_applications_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_applications_async_retries }}"
         cas_job_async_results_item: "{{ __applications_job_async_results_item }}"
         cas_error_list_var_name: "controller_applications_errors"
         __operation: "{{ operation_translate[__applications_job_async_results_item.__application_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_bulk_host_create/tasks/main.yml
+++ b/roles/controller_bulk_host_create/tasks/main.yml
@@ -41,7 +41,9 @@
       loop_control:
         loop_var: __controller_bulk_hosts_job_async_results_item
       vars:
-        cas_secure_logging: "{{ controller_configuration_bulk_hosts_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_bulk_hosts }}"
+        cas_async_delay: "{{ controller_configuration_bulk_hosts_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_bulk_hosts_async_retries }}"
         cas_job_async_results_item: "{{ __controller_bulk_hosts_job_async_results_item }}"
         cas_error_list_var_name: "controller_bulk_hosts_errors"
 

--- a/roles/controller_credential_input_sources/tasks/main.yml
+++ b/roles/controller_credential_input_sources/tasks/main.yml
@@ -48,7 +48,9 @@
         loop_var: __credential_input_sources_job_async_results_item
         label: "{{ __operation.verb }} Controller Credential Input Source for Credential {{ __credential_input_sources_job_async_results_item.__cred_input_src_item.target_credential }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_credential_input_sources_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_credential_input_sources }}"
+        cas_async_delay: "{{ controller_configuration_credential_input_sources_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_credential_input_sources_async_retries }}"
         cas_job_async_results_item: "{{ __credential_input_sources_job_async_results_item }}"
         cas_error_list_var_name: "controller_credential_input_sources_errors"
         __operation: "{{ operation_translate[__credential_input_sources_job_async_results_item.__cred_input_src_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_credential_types/tasks/main.yml
+++ b/roles/controller_credential_types/tasks/main.yml
@@ -49,7 +49,9 @@
         loop_var: __credentialtypes_job_async_result_item
         label: "{{ __operation.verb }} Controller Credential Type {{ __credentialtypes_job_async_result_item.__controller_credential_type_item.name }} | Wait for finish the credential type {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_credential_types_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_credential_types }}"
+        cas_async_delay: "{{ controller_configuration_credential_types_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_credential_types_async_retries }}"
         cas_job_async_results_item: "{{ __credentialtypes_job_async_result_item }}"
         cas_error_list_var_name: "controller_credential_types_errors"
         __operation: "{{ operation_translate[__credentialtypes_job_async_result_item.__controller_credential_type_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_credentials/tasks/main.yml
+++ b/roles/controller_credentials/tasks/main.yml
@@ -53,7 +53,9 @@
         loop_var: __credentials_job_async_results_item
         label: "{{ __operation.verb }} Credential {{ __credentials_job_async_results_item.__controller_credentials_item.name }} | Wait for finish the credential {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_credentials_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_credentials }}"
+        cas_async_delay: "{{ controller_configuration_credentials_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_credentials_async_retries }}"
         cas_job_async_results_item: "{{ __credentials_job_async_results_item }}"
         cas_error_list_var_name: "controller_credentials_errors"
         __operation: "{{ operation_translate[__controller_credentials_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_execution_environments/tasks/main.yml
+++ b/roles/controller_execution_environments/tasks/main.yml
@@ -54,7 +54,9 @@
         label: "{{ __operation.verb }} Controller Execution Environment {{ __execution_environments_job_async_results_item.__execution_environments_item.name }} | Wait
           for finish the Controller Execution Environment {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_execution_environments_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_execution_environments }}"
+        cas_async_delay: "{{ controller_configuration_execution_environments_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_execution_environments_async_retries }}"
         cas_job_async_results_item: "{{ __execution_environments_job_async_results_item }}"
         cas_error_list_var_name: "controller_execution_environments_errors"
         __operation: "{{ operation_translate[__execution_environments_job_async_results_item.__execution_environments_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_host_groups/tasks/main.yml
+++ b/roles/controller_host_groups/tasks/main.yml
@@ -52,7 +52,9 @@
         loop_var: __group_job_async_results_item
         label: "{{ __operation.verb }} Controller Group {{ __group_job_async_results_item.__controller_groups_item.name }} | Wait for finish the Controller Group {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_group_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_group }}"
+        cas_async_delay: "{{ controller_configuration_group_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_group_async_retries }}"
         cas_job_async_results_item: "{{ __group_job_async_results_item }}"
         cas_error_list_var_name: "controller_host_groups_errors"
         __operation: "{{ operation_translate[__group_job_async_results_item.__controller_groups_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_hosts/tasks/main.yml
+++ b/roles/controller_hosts/tasks/main.yml
@@ -49,7 +49,9 @@
         loop_var: __host_job_async_results_item
         label: "{{ __operation.verb }} Controller Host {{ __host_job_async_results_item.__controller_host_item.name }} | Wait for finish the Hosts {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_hosts_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_hosts }}"
+        cas_async_delay: "{{ controller_configuration_hosts_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_hosts_async_retries }}"
         cas_job_async_results_item: "{{ __host_job_async_results_item }}"
         cas_error_list_var_name: "controller_hosts_errors"
         __operation: "{{ operation_translate[__host_job_async_results_item.__controller_host_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_instance_groups/tasks/main.yml
+++ b/roles/controller_instance_groups/tasks/main.yml
@@ -56,7 +56,9 @@
         label: "{{ __operation.verb }} Controller instance group {{ __instance_groups_job_async_results_item.__controller_instance_group_item.name }} | Wait for finish
           the instance groups {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_instance_groups_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_instance_groups }}"
+        cas_async_delay: "{{ controller_configuration_instance_groups_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_instance_groups_async_retries }}"
         cas_job_async_results_item: "{{ __instance_groups_job_async_results_item }}"
         cas_error_list_var_name: "controller_instance_groups_errors"
         __operation: "{{ operation_translate[__instance_groups_job_async_results_item.__controller_instance_group_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_instances/tasks/main.yml
+++ b/roles/controller_instances/tasks/main.yml
@@ -50,7 +50,9 @@
       loop_control:
         loop_var: __instance_job_async_results_item
       vars:
-        cas_secure_logging: "{{ controller_configuration_instances_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_instances }}"
+        cas_async_delay: "{{ controller_configuration_instances_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_instances_async_retries }}"
         cas_job_async_results_item: "{{ __instance_job_async_results_item }}"
         cas_error_list_var_name: "controller_instances_errors"
 

--- a/roles/controller_inventories/tasks/main.yml
+++ b/roles/controller_inventories/tasks/main.yml
@@ -55,7 +55,9 @@
         label: "{{ __operation.verb }} Controller inventory {{ __inventories_job_async_result_item.__controller_inventory_item.name }} | Wait for finish the inventories
           {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_inventories_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_inventories }}"
+        cas_async_delay: "{{ controller_configuration_inventories_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_inventories_async_retries }}"
         cas_job_async_results_item: "{{ __inventories_job_async_result_item }}"
         cas_error_list_var_name: "controller_inventories_errors"
         __operation: "{{ operation_translate[__inventories_job_async_result_item.__controller_inventory_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_inventory_source_update/tasks/main.yml
+++ b/roles/controller_inventory_source_update/tasks/main.yml
@@ -49,7 +49,9 @@
       loop_control:
         loop_var: __inventory_source_update_async_results_item
       vars:
-        cas_secure_logging: "{{ controller_configuration_inventory_source_update_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_inventory_source_update }}"
+        cas_async_delay: "{{ controller_configuration_inventory_source_update_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_inventory_source_update_async_retries }}"
         cas_job_async_results_item: "{{ __inventory_source_update_async_results_item }}"
         cas_error_list_var_name: "controller_inventory_source_update_errors"
 

--- a/roles/controller_inventory_sources/tasks/main.yml
+++ b/roles/controller_inventory_sources/tasks/main.yml
@@ -70,7 +70,9 @@
         loop_var: __inventory_source_job_async_results_item
         label: "{{ __operation.verb }} Inventory Source {{ __inventory_source_job_async_results_item }} | Wait for finish the Inventory Source {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_inventory_sources_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_inventory_sources }}"
+        cas_async_delay: "{{ controller_configuration_inventory_sources_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_inventory_sources_async_retries }}"
         cas_job_async_results_item: "{{ __inventory_source_job_async_results_item }}"
         cas_error_list_var_name: "controller_inventory_sources_errors"
         __operation: "{{ operation_translate[__inventory_source_job_async_results_item.__controller_source_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_job_templates/tasks/main.yml
+++ b/roles/controller_job_templates/tasks/main.yml
@@ -97,7 +97,9 @@
         loop_var: __job_templates_job_async_result_item
         label: "{{ __operation.verb }} Job Template {{ __job_templates_job_async_result_item }} | Wait for finish the Job Template {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_job_templates_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_job_templates }}"
+        cas_async_delay: "{{ controller_configuration_job_templates_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_job_templates_async_retries }}"
         cas_job_async_results_item: "{{ __job_templates_job_async_result_item }}"
         cas_error_list_var_name: "controller_job_templates_errors"
         __operation: "{{ operation_translate[__job_templates_job_async_result_item.__controller_template_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_labels/tasks/main.yml
+++ b/roles/controller_labels/tasks/main.yml
@@ -46,7 +46,9 @@
         loop_var: __controller_label_job_async_results_item
         label: "{{ __operation.verb }} Label {{ __controller_label_job_async_results_item.__controller_label_item.name }} | Wait for finish the Label {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_labels_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_labels }}"
+        cas_async_delay: "{{ controller_configuration_labels_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_labels_async_retries }}"
         cas_job_async_results_item: "{{ __controller_label_job_async_results_item }}"
         cas_error_list_var_name: "controller_labels_errors"
         __operation: "{{ operation_translate[__controller_label_job_async_results_item.__controller_label_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_notification_templates/tasks/main.yml
+++ b/roles/controller_notification_templates/tasks/main.yml
@@ -52,7 +52,9 @@
         label: "{{ __operation.verb }} notification {{ __controller_notification_job_async_results_item.__controller_notification_item.name }} | Wait for finish the notifications
           {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_notifications_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_notifications }}"
+        cas_async_delay: "{{ controller_configuration_notifications_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_notifications_async_retries }}"
         cas_job_async_results_item: "{{ __controller_notification_job_async_results_item }}"
         cas_error_list_var_name: "controller_notification_templates_errors"
         __operation: "{{ operation_translate[__controller_notification_job_async_results_item.__controller_notification_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_organizations/tasks/main.yml
+++ b/roles/controller_organizations/tasks/main.yml
@@ -56,7 +56,9 @@
         label: "{{ __operation.verb }} Controller Organization {{ __organizations_job_async_results_item.__controller_organizations_item.name }} | Wait for finish the
           organization {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_organizations_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_organizations }}"
+        cas_async_delay: "{{ controller_configuration_organizations_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_organizations_async_retries }}"
         cas_job_async_results_item: "{{ __organizations_job_async_results_item }}"
         cas_error_list_var_name: "controller_organizations_errors"
         __operation: "{{ operation_translate[__organizations_job_async_results_item.__controller_organizations_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_project_update/tasks/main.yml
+++ b/roles/controller_project_update/tasks/main.yml
@@ -49,7 +49,9 @@
       loop_control:
         loop_var: __project_update_job_async_results_item
       vars:
-        cas_secure_logging: "{{ controller_configuration_project_update_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_project_update }}"
+        cas_async_delay: "{{ controller_configuration_project_update_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_project_update_async_retries }}"
         cas_job_async_results_item: "{{ __project_update_job_async_results_item }}"
         cas_error_list_var_name: "controller_project_update_errors"
 

--- a/roles/controller_projects/tasks/main.yml
+++ b/roles/controller_projects/tasks/main.yml
@@ -70,7 +70,9 @@
         loop_var: __projects_job_async_results_item
         label: "{{ __operation.verb }} Project {{ __projects_job_async_results_item.__controller_project_item.name }} | Wait for finish the project {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_projects_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_projects }}"
+        cas_async_delay: "{{ controller_configuration_projects_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_projects_async_retries }}"
         cas_job_async_results_item: "{{ __projects_job_async_results_item }}"
         cas_error_list_var_name: "controller_projects_errors"
         __operation: "{{ operation_translate[__projects_job_async_results_item.__controller_project_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_roles/tasks/main.yml
+++ b/roles/controller_roles/tasks/main.yml
@@ -64,7 +64,9 @@
         loop_var: __controller_role_job_async_results_item
         label: "{{ __operation.verb }} Role {{ __controller_role_job_async_results_item.__controller_role_item.1 | default(__controller_role_job_async_results_item.__controller_role_item.role) }} | Wait for finish the Roles {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_role_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_role }}"
+        cas_async_delay: "{{ controller_configuration_role_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_role_async_retries }}"
         cas_job_async_results_item: "{{ __controller_role_job_async_results_item }}"
         cas_error_list_var_name: "controller_roles_errors"
         __operation: "{{ operation_translate[__controller_role_job_async_results_item.__controller_role_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_schedules/tasks/main.yml
+++ b/roles/controller_schedules/tasks/main.yml
@@ -67,7 +67,9 @@
         label: "{{ __operation.verb }} Schedule {{ __controller_schedule_job_async_results_item.__controller_schedule_item.name }} | Wait for finish the Schedules {{
           __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_schedules_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_schedules }}"
+        cas_async_delay: "{{ controller_configuration_schedules_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_schedules_async_retries }}"
         cas_job_async_results_item: "{{ __controller_schedule_job_async_results_item }}"
         cas_error_list_var_name: "controller_schedules_errors"
         __operation: "{{ operation_translate[__controller_schedule_job_async_results_item.__controller_schedule_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_teams/tasks/main.yml
+++ b/roles/controller_teams/tasks/main.yml
@@ -47,7 +47,9 @@
         loop_var: __controller_team_job_async_results_item
         label: "{{ __operation.verb }} Teams | Wait for finish the Teams {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_platform_teams_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_platform_teams }}"
+        cas_async_delay: "{{ controller_configuration_platform_teams_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_platform_teams_async_retries }}"
         cas_job_async_results_item: "{{ __controller_team_job_async_results_item }}"
         cas_error_list_var_name: "controller_teams_errors"
         __operation: "{{ operation_translate[__controller_team_job_asycn_results_item.__controller_team_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_users/tasks/main.yml
+++ b/roles/controller_users/tasks/main.yml
@@ -54,7 +54,9 @@
         loop_var: __controller_user_accounts_job_async_results_item
         label: "{{ __operation.verb }} User {{ __controller_user_accounts_job_async_results_item.__controller_user_accounts_item.user | default(__controller_user_accounts_job_async_results_item.__controller_user_accounts_item.username) }} | Wait for finish the Users {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ controller_configuration_users_secure_logging }}"
+        cas_secure_logging: "{{ controller_configuration_users }}"
+        cas_async_delay: "{{ controller_configuration_users_async_delay }}"
+        cas_async_retries: "{{ controller_configuration_users_async_retries }}"
         cas_job_async_results_item: "{{ __controller_user_accounts_job_async_results_item }}"
         cas_error_list_var_name: "controller_users_errors"
         __operation: "{{ operation_translate[__controller_user_accounts_job_async_results_item.__controller_user_accounts_item.state | default(platform_state) | default('present')] }}"

--- a/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml
+++ b/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml
@@ -65,7 +65,9 @@
       loop_control:
         loop_var: __workflows_node_async_results_item
       vars:
-        cas_secure_logging: "{{ workflow_job_templates_secure_logging }}"
+        cas_secure_logging: "{{ workflow_job_templates }}"
+        cas_async_delay: "{{ workflow_job_templates_async_delay }}"
+        cas_async_retries: "{{ workflow_job_templates_async_retries }}"
         cas_job_async_results_item: "{{ __workflows_node_async_results_item }}"
         cas_error_list_var_name: "controller_workflows_errors"
 
@@ -118,7 +120,9 @@
       loop_control:
         loop_var: __workflows_link_async_results_item
       vars:
-        cas_secure_logging: "{{ workflow_job_templates_secure_logging }}"
+        cas_secure_logging: "{{ workflow_job_templates }}"
+        cas_async_delay: "{{ workflow_job_templates_async_delay }}"
+        cas_async_retries: "{{ workflow_job_templates_async_retries }}"
         cas_job_async_results_item: "{{ __workflows_link_async_results_item }}"
         cas_error_list_var_name: "controller_workflows_errors"
 

--- a/roles/controller_workflow_job_templates/tasks/main.yml
+++ b/roles/controller_workflow_job_templates/tasks/main.yml
@@ -83,7 +83,9 @@
         loop_var: __workflows_job_async_results_item
         label: "{{ __operation.verb }} Workflow {{ __workflows_job_async_results_item.__workflow_loop_item.name }} | Wait for finish the workflow {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ workflow_job_templates_secure_logging }}"
+        cas_secure_logging: "{{ workflow_job_templates }}"
+        cas_async_delay: "{{ workflow_job_templates_async_delay }}"
+        cas_async_retries: "{{ workflow_job_templates_async_retries }}"
         cas_job_async_results_item: "{{ __workflows_job_async_results_item }}"
         cas_error_list_var_name: "controller_workflows_errors"
         __operation: "{{ operation_translate[__workflows_job_async_results_item.__workflow_loop_item.state | default(platform_state) | default('present')] }}"

--- a/roles/eda_controller_tokens/tasks/main.yml
+++ b/roles/eda_controller_tokens/tasks/main.yml
@@ -38,7 +38,9 @@
         loop_var: __controller_tokens_job_async_result_item
         label: "{{ __operation.verb }} Controller token {{ __controller_tokens_job_async_result_item.__token_item.name }} | Wait for finish the Controller token {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ eda_configuration_users_token_secure_logging }}"
+        cas_secure_logging: "{{ eda_configuration_users_token }}"
+        cas_async_delay: "{{ eda_configuration_users_token_async_delay }}"
+        cas_async_retries: "{{ eda_configuration_users_token_async_retries }}"
         cas_job_async_results_item: "{{ __controller_tokens_job_async_result_item }}"
         cas_error_list_var_name: "eda_controller_tokens_errors"
         __operation: "{{ operation_translate[__controller_tokens_job_async_result_item.__controller_user_accounts_item.state | default(platform_state) | default('present')] }}"

--- a/roles/eda_credential_types/tasks/main.yml
+++ b/roles/eda_credential_types/tasks/main.yml
@@ -41,7 +41,9 @@
         loop_var: __credential_types_job_async_result_item
         label: "{{ __operation.verb }} credential {{ __credential_types_job_async_result_item.__credential_type_item.name }} | Wait for finish the credential {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ eda_configuration_credential_types_secure_logging }}"
+        cas_secure_logging: "{{ eda_configuration_credential_types }}"
+        cas_async_delay: "{{ eda_configuration_credential_types_async_delay }}"
+        cas_async_retries: "{{ eda_configuration_credential_types_async_retries }}"
         cas_job_async_results_item: "{{ __credential_types_job_async_result_item }}"
         cas_error_list_var_name: "eda_credential_types_errors"
         __operation: "{{ operation_translate[__credential_types_job_async_result_item.__credential_type_item.state | default(platform_state) | default('present')] }}"

--- a/roles/eda_credentials/tasks/main.yml
+++ b/roles/eda_credentials/tasks/main.yml
@@ -42,7 +42,9 @@
         loop_var: __credentials_job_async_result_item
         label: "{{ __operation.verb }} credential {{ __credentials_job_async_result_item.__credential_item.name }} | Wait for finish the credential {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ eda_configuration_credentials_secure_logging }}"
+        cas_secure_logging: "{{ eda_configuration_credentials }}"
+        cas_async_delay: "{{ eda_configuration_credentials_async_delay }}"
+        cas_async_retries: "{{ eda_configuration_credentials_async_retries }}"
         cas_job_async_results_item: "{{ __credentials_job_async_result_item }}"
         cas_error_list_var_name: "eda_credentials_errors"
         __operation: "{{ operation_translate[__credentials_job_async_result_item.__controller_user_accounts_item.state | default(platform_state) | default('present')] }}"

--- a/roles/eda_decision_environments/tasks/main.yml
+++ b/roles/eda_decision_environments/tasks/main.yml
@@ -43,7 +43,9 @@
         label: "{{ __operation.verb }} decision environment {{ __decision_environments_job_async_result_item.__de_item.name }} | Wait for finish the decision environment
           {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ eda_configuration_decision_environments_secure_logging }}"
+        cas_secure_logging: "{{ eda_configuration_decision_environments }}"
+        cas_async_delay: "{{ eda_configuration_decision_environments_async_delay }}"
+        cas_async_retries: "{{ eda_configuration_decision_environments_async_retries }}"
         cas_job_async_results_item: "{{ __decision_environments_job_async_result_item }}"
         cas_error_list_var_name: "eda_decision_environments_errors"
         __operation: "{{ operation_translate[__decision_environments_job_async_result_item.__de_item.state | default(platform_state) | default('present')] }}"

--- a/roles/eda_event_streams/tasks/main.yml
+++ b/roles/eda_event_streams/tasks/main.yml
@@ -42,7 +42,9 @@
         loop_var: __event_streams_job_async_result_item
         label: "{{ __operation.verb }} Event stream {{ __event_streams_job_async_result_item.__event_stream_item.name }} | Wait for finish the Event stream {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ eda_configuration_event_streams_secure_logging }}"
+        cas_secure_logging: "{{ eda_configuration_event_streams }}"
+        cas_async_delay: "{{ eda_configuration_event_streams_async_delay }}"
+        cas_async_retries: "{{ eda_configuration_event_streams_async_retries }}"
         cas_job_async_results_item: "{{ __event_streams_job_async_result_item }}"
         cas_error_list_var_name: "eda_event_streams_errors"
         __operation: "{{ operation_translate[__event_streams_job_async_result_item.__event_stream_item.state | default(platform_state) | default('present')] }}"

--- a/roles/eda_projects/tasks/main.yml
+++ b/roles/eda_projects/tasks/main.yml
@@ -43,7 +43,9 @@
         loop_var: __projects_job_async_result_item
         label: "{{ __operation.verb }} project {{ __projects_job_async_result_item.__project_item.name }} | Wait for finish the project {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ eda_configuration_projects_secure_logging }}"
+        cas_secure_logging: "{{ eda_configuration_projects }}"
+        cas_async_delay: "{{ eda_configuration_projects_async_delay }}"
+        cas_async_retries: "{{ eda_configuration_projects_async_retries }}"
         cas_job_async_results_item: "{{ __projects_job_async_result_item }}"
         cas_error_list_var_name: "eda_projects_errors"
         __operation: "{{ operation_translate[__projects_job_async_result.__projects_job_async.state | default(platform_state) | default('present')] }}"

--- a/roles/eda_rulebook_activations/tasks/main.yml
+++ b/roles/eda_rulebook_activations/tasks/main.yml
@@ -52,7 +52,9 @@
         label: "{{ __operation.verb }} rulebook activation {{ __rulebook_activations_job_async_result_item.__ra_item.name }} | Wait for finish the rulebook activation
           {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ eda_configuration_rulebook_activations_secure_logging }}"
+        cas_secure_logging: "{{ eda_configuration_rulebook_activations }}"
+        cas_async_delay: "{{ eda_configuration_rulebook_activations_async_delay }}"
+        cas_async_retries: "{{ eda_configuration_rulebook_activations_async_retries }}"
         cas_job_async_results_item: "{{ __rulebook_activations_job_async_result_item }}"
         cas_error_list_var_name: "eda_rulebook_activations_errors"
         __operation: "{{ operation_translate[__rulebook_activations_job_async_result.__ra_item.state | default(platform_state) | default('present')] }}"

--- a/roles/eda_users/tasks/main.yml
+++ b/roles/eda_users/tasks/main.yml
@@ -45,7 +45,9 @@
         loop_var: __users_job_async_result_item
         label: "{{ __operation.verb }} user {{ __users_job_async_result_item.__user_item.username }} | Wait for finish the rulebook activation {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ eda_configuration_users_secure_logging }}"
+        cas_secure_logging: "{{ eda_configuration_users }}"
+        cas_async_delay: "{{ eda_configuration_users_async_delay }}"
+        cas_async_retries: "{{ eda_configuration_users_async_retries }}"
         cas_job_async_results_item: "{{ __users_job_async_result_item }}"
         cas_error_list_var_name: "eda_users_errors"
         __operation: "{{ operation_translate[__users_job_async_result.__user_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_applications/tasks/main.yml
+++ b/roles/gateway_applications/tasks/main.yml
@@ -52,7 +52,9 @@
         label: "{{ __operation.verb }} AAP Platform Applications {{ __gateway_applications_job_async_results_item.__gateway_application_item.name }} | Wait for finish
           the Applications {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_applications_secure_logging }}"
+        cas_secure_logging: "{{ gateway_applications }}"
+        cas_async_delay: "{{ gateway_applications_async_delay }}"
+        cas_async_retries: "{{ gateway_applications_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_applications_job_async_results_item }}"
         cas_error_list_var_name: "gateway_applications_errors"
         __operation: "{{ operation_translate[__gateway_applications_job_async_results_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_authenticator_maps/tasks/main.yml
+++ b/roles/gateway_authenticator_maps/tasks/main.yml
@@ -50,7 +50,9 @@
         label: "{{ __operation.verb }} AAP Platform Authenticator Maps {{ __gateway_authenticator_maps_job_async_results_item.__gateway_authenticator_maps_item.name }}
           | Wait for finish the Authenticator Map {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_authenticator_maps_secure_logging }}"
+        cas_secure_logging: "{{ gateway_authenticator_maps }}"
+        cas_async_delay: "{{ gateway_authenticator_maps_async_delay }}"
+        cas_async_retries: "{{ gateway_authenticator_maps_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_authenticator_maps_job_async_results_item }}"
         cas_error_list_var_name: "gateway_authenticator_maps_errors"
         __operation: "{{ operation_translate[__gateway_authenticator_maps_job_async_results_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_authenticators/tasks/main.yml
+++ b/roles/gateway_authenticators/tasks/main.yml
@@ -49,7 +49,9 @@
         label: "{{ __operation.verb }} AAP Platform Authenticators {{ __gateway_authenticators_job_async_results_item.__gateway_authenticators_item.name }} | Wait for
           finish the Authenticators {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_authenticators_secure_logging }}"
+        cas_secure_logging: "{{ gateway_authenticators }}"
+        cas_async_delay: "{{ gateway_authenticators_async_delay }}"
+        cas_async_retries: "{{ gateway_authenticators_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_authenticators_job_async_results_item }}"
         cas_error_list_var_name: "gateway_authenticators_errors"
         __operation: "{{ operation_translate[__gateway_authenticators_job_async_results_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_http_ports/tasks/main.yml
+++ b/roles/gateway_http_ports/tasks/main.yml
@@ -44,7 +44,9 @@
         label: "{{ __operation.verb }} AAP Platform Http Ports {{ __gateway_http_ports_job_async_results_item.__gateway_http_ports_item.name }} | Wait for finish the
           Http Ports {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_http_ports_secure_logging }}"
+        cas_secure_logging: "{{ gateway_http_ports }}"
+        cas_async_delay: "{{ gateway_http_ports_async_delay }}"
+        cas_async_retries: "{{ gateway_http_ports_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_http_ports_job_async_results_item }}"
         cas_error_list_var_name: "gateway_http_ports_errors"
         __operation: "{{ operation_translate[__gateway_http_ports_job_async_results_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_organizations/tasks/main.yml
+++ b/roles/gateway_organizations/tasks/main.yml
@@ -41,7 +41,9 @@
         - not ansible_check_mode
         - __gateway_organizations_job_async_results_item.ansible_job_id is defined
       vars:
-        cas_secure_logging: "{{ gateway_organizations_secure_logging }}"
+        cas_secure_logging: "{{ gateway_organizations }}"
+        cas_async_delay: "{{ gateway_organizations_async_delay }}"
+        cas_async_retries: "{{ gateway_organizations_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_organizations_job_async_results_item }}"
         cas_error_list_var_name: "aap_organizations_errors"
         __operation: "{{ operation_translate[__gateway_organizations_job_async_results_item.state | default(platform_state) | default('present')] }}"
@@ -101,7 +103,9 @@
         label: "{{ __operation.verb }} Controller Organization {{ __organizations_job_async_results_item.__controller_organizations_item.name }} | Wait for finish the
           organization {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_organizations_secure_logging }}"
+        cas_secure_logging: "{{ gateway_organizations }}"
+        cas_async_delay: "{{ gateway_organizations_async_delay }}"
+        cas_async_retries: "{{ gateway_organizations_async_retries }}"
         cas_job_async_results_item: "{{ __organizations_job_async_results_item }}"
         cas_error_list_var_name: "aap_organizations_errors"
         __operation: "{{ operation_translate[__organizations_job_async_results_item.__controller_organizations_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_role_user_assignments/tasks/main.yml
+++ b/roles/gateway_role_user_assignments/tasks/main.yml
@@ -44,7 +44,9 @@
         loop_var: __gateway_role_user_assignments_job_async_results_item
         label: "{{ __operation.verb }} Role {{ __gateway_role_user_assignments_job_async_results_item.__gateway_role_user_assignments_item.1 | default(__gateway_role_user_assignments_job_async_results_item.__gateway_role_user_assignments_item.role_definition) }} | Wait for finish the Roles {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_role_user_assignments_secure_logging }}"
+        cas_secure_logging: "{{ gateway_role_user_assignments }}"
+        cas_async_delay: "{{ gateway_role_user_assignments_async_delay }}"
+        cas_async_retries: "{{ gateway_role_user_assignments_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_role_user_assignments_job_async_results_item }}"
         cas_error_list_var_name: "gateway_role_user_assignments_errors"
         __operation: "{{ operation_translate[__gateway_role_user_assignments_job_async_results_item.__controller_role_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_routes/tasks/main.yml
+++ b/roles/gateway_routes/tasks/main.yml
@@ -49,7 +49,9 @@
         loop_var: __gateway_routes_job_async_results_item
         label: "{{ __operation.verb }} Gateway route {{ __gateway_routes_job_async_results_item.__gateway_routes_item.name }} | Wait for finish the Gateway route {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_routes_secure_logging }}"
+        cas_secure_logging: "{{ gateway_routes }}"
+        cas_async_delay: "{{ gateway_routes_async_delay }}"
+        cas_async_retries: "{{ gateway_routes_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_routes_job_async_results_item }}"
         cas_error_list_var_name: "gateway_routes_errors"
         __operation: "{{ operation_translate[__gateway_routes_job_async_results_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_service_clusters/tasks/main.yml
+++ b/roles/gateway_service_clusters/tasks/main.yml
@@ -52,7 +52,9 @@
         label: "{{ __operation.verb }} Gateway service cluster {{ __gateway_service_clusters_job_async_results_item.__gateway_service_clusters_item.name }} | Wait for finish the Gateway service cluster
           {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_service_clusters_secure_logging }}"
+        cas_secure_logging: "{{ gateway_service_clusters }}"
+        cas_async_delay: "{{ gateway_service_clusters_async_delay }}"
+        cas_async_retries: "{{ gateway_service_clusters_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_service_clusters_job_async_results_item }}"
         cas_error_list_var_name: "gateway_service_clusters_errors"
         __operation: "{{ operation_translate[__gateway_service_clusters_job_async_results_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_service_keys/tasks/main.yml
+++ b/roles/gateway_service_keys/tasks/main.yml
@@ -46,7 +46,9 @@
         loop_var: __gateway_service_keys_job_async_results_item
         label: "{{ __operation.verb }} Gateway service key {{ __gateway_service_keys_job_async_results_item.__gateway_service_keys_item.name }} | Wait for finish the Gateway service key {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_service_keys_secure_logging }}"
+        cas_secure_logging: "{{ gateway_service_keys }}"
+        cas_async_delay: "{{ gateway_service_keys_async_delay }}"
+        cas_async_retries: "{{ gateway_service_keys_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_service_keys_job_async_results_item }}"
         cas_error_list_var_name: "gateway_service_keys_errors"
         __operation: "{{ operation_translate[__gateway_service_keys_job_async_results_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_service_nodes/tasks/main.yml
+++ b/roles/gateway_service_nodes/tasks/main.yml
@@ -43,7 +43,9 @@
         loop_var: __gateway_service_nodes_job_async_results_item
         label: "{{ __operation.verb }} Gateway service node {{ __gateway_service_nodes_job_async_results_item.__gateway_service_nodes_item.name }} | Wait for finish the Gateway service node {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_service_nodes_secure_logging }}"
+        cas_secure_logging: "{{ gateway_service_nodes }}"
+        cas_async_delay: "{{ gateway_service_nodes_async_delay }}"
+        cas_async_retries: "{{ gateway_service_nodes_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_service_nodes_job_async_results_item }}"
         cas_error_list_var_name: "gateway_service_nodes_errors"
         __operation: "{{ operation_translate[__gateway_service_nodes_job_async_results_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_services/tasks/main.yml
+++ b/roles/gateway_services/tasks/main.yml
@@ -50,7 +50,9 @@
         loop_var: __gateway_services_job_async_results_item
         label: "{{ __operation.verb }} Gateway service {{ __gateway_services_job_async_results_item.__gateway_services_item.name }} | Wait for finish the Gateway service {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_services_secure_logging }}"
+        cas_secure_logging: "{{ gateway_services }}"
+        cas_async_delay: "{{ gateway_services_async_delay }}"
+        cas_async_retries: "{{ gateway_services_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_services_job_async_results_item }}"
         cas_error_list_var_name: "gateway_services_errors"
         __operation: "{{ operation_translate[__gateway_services_job_async_results_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_teams/tasks/main.yml
+++ b/roles/gateway_teams/tasks/main.yml
@@ -43,7 +43,9 @@
         loop_var: __gateway_teams_job_async_results_item
         label: "{{ __operation.verb }} Gateway team {{ __gateway_teams_job_async_results_item.__gateway_teams_item.name }} | Wait for finish the Gateway team {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_teams_secure_logging }}"
+        cas_secure_logging: "{{ gateway_teams }}"
+        cas_async_delay: "{{ gateway_teams_async_delay }}"
+        cas_async_retries: "{{ gateway_teams_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_teams_job_async_results_item }}"
         cas_error_list_var_name: "gateway_teams_errors"
         __operation: "{{ operation_translate[__gateway_teams_job_async_results_item.state | default(platform_state) | default('present')] }}"

--- a/roles/gateway_users/tasks/main.yml
+++ b/roles/gateway_users/tasks/main.yml
@@ -49,7 +49,9 @@
         loop_var: __gateway_user_accounts_job_async_results_item
         label: "{{ __operation.verb }} Gateway user {{ __gateway_user_accounts_job_async_results_item.__gateway_user_accounts_item.username }} | Wait for finish the Gateway user {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ gateway_users_secure_logging }}"
+        cas_secure_logging: "{{ gateway_users }}"
+        cas_async_delay: "{{ gateway_users_async_delay }}"
+        cas_async_retries: "{{ gateway_users_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_user_accounts_job_async_results_item }}"
         cas_error_list_var_name: "gateway_users_errors"
         __operation: "{{ operation_translate[__gateway_user_accounts_job_async_results_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_collection/tasks/main.yml
+++ b/roles/hub_collection/tasks/main.yml
@@ -52,7 +52,9 @@
         loop_var: __collections_job_async_result_item
         label: "{{ __operation.verb }} Collection {{ __collections_job_async_result_item.__hub_collection_item.name }} | Wait for finish the Collection {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_collection_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_collection }}"
+        cas_async_delay: "{{ hub_configuration_collection_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_collection_async_retries }}"
         cas_job_async_results_item: "{{ __collections_job_async_result_item }}"
         cas_error_list_var_name: "hub_collections_errors"
         __operation: "{{ operation_translate[__collections_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_collection_remote/tasks/main.yml
+++ b/roles/hub_collection_remote/tasks/main.yml
@@ -62,7 +62,9 @@
         label: "{{ __operation.verb }} Collection remote {{ __collection_remote_job_async_result_item.__hub_collection_remote_item.name }} | Wait for finish the Collection
           remote {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_collection_remote_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_collection_remote }}"
+        cas_async_delay: "{{ hub_configuration_collection_remote_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_collection_remote_async_retries }}"
         cas_job_async_results_item: "{{ __collection_remote_job_async_result_item }}"
         cas_error_list_var_name: "hub_collection_remote_errors"
         __operation: "{{ operation_translate[__collection_remote_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_collection_repository/tasks/main.yml
+++ b/roles/hub_collection_repository/tasks/main.yml
@@ -49,7 +49,9 @@
         label: "{{ __operation.verb }} Collection repository {{ __collection_repository_job_async_result_item.__hub_collection_repository_item.name }} | Wait for finish
           the Collection repository {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_collection_repository_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_collection_repository }}"
+        cas_async_delay: "{{ hub_configuration_collection_repository_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_collection_repository_async_retries }}"
         cas_job_async_results_item: "{{ __collection_repository_job_async_result_item }}"
         cas_error_list_var_name: "hub_collection_repository_errors"
         __operation: "{{ operation_translate[__collection_repository_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_collection_repository_sync/tasks/main.yml
+++ b/roles/hub_collection_repository_sync/tasks/main.yml
@@ -41,7 +41,9 @@
         label: "{{ __operation.verb }} Collection repository sync {{ __collection_repository_sync_job_async_result_item.__hub_collection_repository_sync_item.name }}
           | Wait to finish the Repository sync"
       vars:
-        cas_secure_logging: "{{ hub_configuration_collection_repository_sync_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_collection_repository_sync }}"
+        cas_async_delay: "{{ hub_configuration_collection_repository_sync_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_collection_repository_sync_async_retries }}"
         cas_job_async_results_item: "{{ __collection_repository_sync_job_async_result_item }}"
         cas_error_list_var_name: "hub_collection_repository_sync_errors"
         __operation: "{{ operation_translate[__collection_repository_sync_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_ee_image/tasks/main.yml
+++ b/roles/hub_ee_image/tasks/main.yml
@@ -41,7 +41,9 @@
         loop_var: __ee_images_job_async_result_item
         label: "{{ __operation.verb }} EE Image {{ __ee_images_job_async_result_item.__ee_image_item.name }} | Wait for finish the EE image {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_ee_image_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_ee_image }}"
+        cas_async_delay: "{{ hub_configuration_ee_image_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_ee_image_async_retries }}"
         cas_job_async_results_item: "{{ __ee_images_job_async_result_item }}"
         cas_error_list_var_name: "hub_ee_image_errors"
         __operation: "{{ operation_translate[__ee_images_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_ee_registry/tasks/main.yml
+++ b/roles/hub_ee_registry/tasks/main.yml
@@ -47,7 +47,9 @@
         loop_var: __ee_registries_job_async_result_item
         label: "{{ __operation.verb }} EE Registry {{ __ee_registries_job_async_result_item.__hub_ee_registry_item.name }} | Wait for finish the EE Registry {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_ee_registry_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_ee_registry }}"
+        cas_async_delay: "{{ hub_configuration_ee_registry_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_ee_registry_async_retries }}"
         cas_job_async_results_item: "{{ __ee_registries_job_async_result_item }}"
         cas_error_list_var_name: "hub_ee_registry_errors"
         __operation: "{{ operation_translate[__ee_registries_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_ee_registry_index/tasks/main.yml
+++ b/roles/hub_ee_registry_index/tasks/main.yml
@@ -41,7 +41,9 @@
         loop_var: __ee_registry_indexes_job_async_result_item
         label: "{{ __operation.verb }} EE registry index {{ __ee_registry_indexes_job_async_result_item.__hub_ee_registry_index_item.name }} | Wait for finish the EE registry index {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_ee_registry_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_ee_registry }}"
+        cas_async_delay: "{{ hub_configuration_ee_registry_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_ee_registry_async_retries }}"
         cas_job_async_results_item: "{{ __ee_registry_indexes_job_async_result_item }}"
         cas_error_list_var_name: "hub_ee_registry_index_errors"
         __operation: "{{ operation_translate[__ee_registry_indexes_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_ee_registry_sync/tasks/main.yml
+++ b/roles/hub_ee_registry_sync/tasks/main.yml
@@ -41,7 +41,9 @@
         loop_var: __ee_registry_syncs_job_async_result_item
         label: "{{ __operation.verb }} EE registry sync {{ __ee_registry_syncs_job_async_result_item.__hub_ee_registry_sync_item.name }} | Wait for finish the EE registry sync {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_ee_registry_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_ee_registry }}"
+        cas_async_delay: "{{ hub_configuration_ee_registry_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_ee_registry_async_retries }}"
         cas_job_async_results_item: "{{ __ee_registry_syncs_job_async_result_item }}"
         cas_error_list_var_name: "hub_ee_registry_sync_errors"
         __operation: "{{ operation_translate[__ee_registry_syncs_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_ee_repository/tasks/main.yml
+++ b/roles/hub_ee_repository/tasks/main.yml
@@ -45,7 +45,9 @@
         loop_var: __ee_repositories_job_async_result_item
         label: "{{ __operation.verb }} EE Repository {{ __ee_repositories_job_async_result_item.__hub_ee_repository_sync_item.name }} | Wait for finish the EE Repository {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_ee_repository_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_ee_repository }}"
+        cas_async_delay: "{{ hub_configuration_ee_repository_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_ee_repository_async_retries }}"
         cas_job_async_results_item: "{{ __ee_repositories_job_async_result_item }}"
         cas_error_list_var_name: "hub_ee_repository_errors"
         __operation: "{{ operation_translate[__ee_repositories_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_ee_repository_sync/tasks/main.yml
+++ b/roles/hub_ee_repository_sync/tasks/main.yml
@@ -41,7 +41,9 @@
         loop_var: __ee_repository_syncs_job_async_result_item
         label: "{{ __operation.verb }} EE repository sync {{ __ee_repository_syncs_job_async_result_item.__hub_ee_repository_sync_item.name }} | Wait for finish the EE repository sync {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_ee_repository_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_ee_repository }}"
+        cas_async_delay: "{{ hub_configuration_ee_repository_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_ee_repository_async_retries }}"
         cas_job_async_results_item: "{{ __ee_repository_syncs_job_async_result_item }}"
         cas_error_list_var_name: "hub_ee_repository_sync_errors"
         __operation: "{{ operation_translate[__ee_repository_syncs_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_group/tasks/main.yml
+++ b/roles/hub_group/tasks/main.yml
@@ -39,7 +39,9 @@
         loop_var: __groups_job_async_result_item
         label: "{{ __operation.verb }} Group {{ __groups_job_async_result_item.__hub_group_item.name }} | Wait for finish the Group {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_group_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_group }}"
+        cas_async_delay: "{{ hub_configuration_group_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_group_async_retries }}"
         cas_job_async_results_item: "{{ __groups_job_async_result_item }}"
         cas_error_list_var_name: "hub_group_errors"
         __operation: "{{ operation_translate[__groups_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_group_roles/tasks/main.yml
+++ b/roles/hub_group_roles/tasks/main.yml
@@ -39,7 +39,9 @@
         loop_var: __group_roles_job_async_result_item
         label: "{{ __operation.verb }} Group roles {{ __group_roles_job_async_result_item.__hub_group_roles_item.groups }} | Wait for finish the Group roles {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_group_roles_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_group_roles }}"
+        cas_async_delay: "{{ hub_configuration_group_roles_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_group_roles_async_retries }}"
         cas_job_async_results_item: "{{ __group_roles_job_async_result_item }}"
         cas_error_list_var_name: "hub_group_roles_errors"
         __operation: "{{ operation_translate[__group_roles_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_namespace/tasks/main.yml
+++ b/roles/hub_namespace/tasks/main.yml
@@ -60,7 +60,9 @@
         loop_var: __namespaces_job_async_result_item
         label: "{{ __operation.verb }} Namespace {{ __namespaces_job_async_result_item.__hub_namespace_item.name }} | Wait for finish the Namespace {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_namespace_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_namespace }}"
+        cas_async_delay: "{{ hub_configuration_namespace_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_namespace_async_retries }}"
         cas_job_async_results_item: "{{ __namespaces_job_async_result_item }}"
         cas_error_list_var_name: "hub_namespace_errors"
         __operation: "{{ operation_translate[__namespaces_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_publish/tasks/main.yml
+++ b/roles/hub_publish/tasks/main.yml
@@ -114,7 +114,9 @@
       loop_control:
         loop_var: __publish_job_async_result_item
       vars:
-        cas_secure_logging: "{{ hub_configuration_publish_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_publish }}"
+        cas_async_delay: "{{ hub_configuration_publish_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_publish_async_retries }}"
         cas_job_async_results_item: "{{ __publish_job_async_result_item }}"
         cas_error_list_var_name: "hub_publish_errors"
 

--- a/roles/hub_role/tasks/main.yml
+++ b/roles/hub_role/tasks/main.yml
@@ -40,7 +40,9 @@
         loop_var: __roles_job_async_result_item
         label: "{{ __operation.verb }} Role {{ __roles_job_async_result_item.__hub_role_item.name }} | Wait for finish the Role {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_role_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_role }}"
+        cas_async_delay: "{{ hub_configuration_role_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_role_async_retries }}"
         cas_job_async_results_item: "{{ __roles_job_async_result_item }}"
         cas_error_list_var_name: "hub_role_errors"
         __operation: "{{ operation_translate[__roles_job_async_result_item.state | default(platform_state) | default('present')] }}"

--- a/roles/hub_user/tasks/main.yml
+++ b/roles/hub_user/tasks/main.yml
@@ -46,7 +46,9 @@
         loop_var: __users_job_async_result_item
         label: "{{ __operation.verb }} User {{ __users_job_async_result_item.__hub_user_item.username }} | Wait for finish the User {{ __operation.action }}"
       vars:
-        cas_secure_logging: "{{ hub_configuration_user_secure_logging }}"
+        cas_secure_logging: "{{ hub_configuration_user }}"
+        cas_async_delay: "{{ hub_configuration_user_async_delay }}"
+        cas_async_retries: "{{ hub_configuration_user_async_retries }}"
         cas_job_async_results_item: "{{ __users_job_async_result_item }}"
         cas_error_list_var_name: "hub_user_errors"
         __operation: "{{ operation_translate[__users_job_async_result_item.state | default(platform_state) | default('present')] }}"


### PR DESCRIPTION
Fix accidentally removed usage of '*_async_delay' and '*_async_retries' variables

<!-- markdownlint-disable -->
# What does this PR do?
Adds in the logic to make use of the variables for each role which set the async delay and retries.

# How should this be tested?
variables such as `hub_configuration_collection_repository_sync_async_delay` will work again

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #1154 

# Other Relevant info, PRs, etc
None