### PR TITLE
Prevent Failure on jid Not Defined

### DIFF
--- a/changelogs/fragments/workflow_schema_job_id.yml
+++ b/changelogs/fragments/workflow_schema_job_id.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixes issue when adding workflow schemas where the job_id is not defined because a failure state has occured

--- a/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml
+++ b/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml
@@ -124,6 +124,9 @@
 
   always:
     - name: add_workflows_schema | Cleanup async results files
+      when:
+        - not ansible_check_mode
+        - __workflows_schema_results_item.ansible_job_id is defined
       ansible.builtin.async_status:
         jid: "{{ __workflows_schema_results_item.ansible_job_id }}"
         mode: cleanup

--- a/roles/eda_credentials/README.md
+++ b/roles/eda_credentials/README.md
@@ -78,7 +78,7 @@ eda_credentials:
     organization: "Default"
     inputs:
       host: "https://aap.example.io"
-      password: "Ala-ma-kota-12" 
+      password: "Ala-ma-kota-12"
       username: "admin"
       verify_ssl: true
 ```


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
This PR prevents failure of async file cleanup when a jid file is not defined when setting up nodes in a controller workflow

# How should this be tested?
Attempt to create a workflow:
```yaml
---
controller_workflows:
  - name: Setup AD Forest
    organization: Example
    simplified_workflow_nodes:
      - identifier: Wait for Connectivity
        unified_job_template: Wait for Connectivity
        success_nodes:
          - Set Base Configurations
      - identifier: Set Base Configurations
        unified_job_template: Set Base Configurations
```

Run simple playbook:
```yaml
---
- name: Configure Ansible Controller
  hosts:
    - all
  gather_facts: false
  connection: local
  vars:
    controller_configuration_secure_logging: false
    aap_configuration_secure_logging: false
  pre_tasks:
    - name: Import variables from /runner/variables
      ansible.builtin.include_vars:
        dir: /runner/variables
  roles:
    - infra.aap_configuration.controller_license
    - infra.aap_configuration.dispatch
```

Without this commit, the playbook will fail:
```
fatal: [it_automation_service]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'ansible_job_id'. 'dict object' has no attribute 'ansible_job_id'\n\nThe error appears to be in '/usr/share/ansible/collections/ansible_collections/infra/aap_configuration/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml': line 126, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  always:\n    - name: add_workflows_schema | Cleanup async results files\n      ^ here\n"}
```

This mirrors logic introduced in the [main task file](https://github.com/redhat-cop/infra.aap_configuration/blob/devel/roles/controller_workflow_job_templates/tasks/main.yml#L104-L106) of the role.

# Is there a relevant Issue open for this?
N/A

# Other Relevant info, PRs, etc
N/A
