### PR TITLE
adding sync option to collection_repo_sync

### DIFF
--- a/changelogs/fragments/collection_repo_sync.yml
+++ b/changelogs/fragments/collection_repo_sync.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - added a sync option to collection_repository_sync role to allow more easily skipping of specific repositories
+...

--- a/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml
+++ b/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml
@@ -96,8 +96,7 @@
         label: "{{ __workflow_loop_node_item.identifier }}"
       # Execute only the nodes that define links to the following
       when: ((__workflow_loop_node_item.always_nodes is defined and __workflow_loop_node_item.always_nodes | length > 0) or (__workflow_loop_node_item.success_nodes is
-        defined and __workflow_loop_node_item.success_nodes | length > 0) or (__workflow_loop_node_item.failure_nodes is defined and __workflow_loop_node_item.failure_nodes
-        | length > 0))
+        defined and __workflow_loop_node_item.success_nodes | length > 0) or (__workflow_loop_node_item.failure_nodes is defined and __workflow_loop_node_item.failure_nodes | length > 0))
       async: "{{ ansible_check_mode | ternary(0, 1000) }}"
       poll: 0
       register: __workflows_link_async

--- a/roles/hub_collection_repository_sync/README.md
+++ b/roles/hub_collection_repository_sync/README.md
@@ -60,6 +60,7 @@ This also speeds up the overall role.
 |`name`|""|yes|str| Collection Repository name. Probably one of community, validated, rh-certified, or one you have created.|
 |`wait`|`true`|no|bool|Wait for the Collection repository to finish syncing before returning.|
 |`interval`|1.0|no|float|The interval to request an update from Automation Hub.|
+|`sync`|true|no|bool|Whether to sync the collection_registry. By default it will sync unless this is set to false.|
 |`timeout`|""|no|int|If waiting for the repository to update this will abort after this amount of seconds.|
 |`state`|`present`|no|str|Desired state of the collection repository. Either `present` or `absent`.|
 

--- a/roles/hub_collection_repository_sync/tasks/main.yml
+++ b/roles/hub_collection_repository_sync/tasks/main.yml
@@ -22,6 +22,7 @@
         loop_var: __hub_collection_repository_sync_item
         label: "{{ __operation.verb }} the sync {{ __hub_collection_repository_sync_item.name }} in Hub"
         pause: "{{ hub_configuration_collection_repository_sync_loop_delay }}"
+      when: __hub_collection_repository_sync_item.sync | default(true)
       async: "{{ hub_configuration_collection_repository_sync_async_timeout }}"
       poll: 0
       register: __collection_repository_sync_job_async


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
added a sync option to collection_repository_sync role to allow more easily skipping of specific repositories

# How should this be tested?
manual (currently untested)

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #1045 

# Other Relevant info, PRs, etc
none
