### PR TITLE
Fix async logging default value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ ansible.cfg
 tests/localtest.yml
 .ansible/
 .venv
+.devcontainer
+ansible_collections/

--- a/changelogs/fragments/fix_async_variable.yaml
+++ b/changelogs/fragments/fix_async_variable.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Set async log collection default once

--- a/roles/collect_async_status/tasks/handle_error.yml
+++ b/roles/collect_async_status/tasks/handle_error.yml
@@ -2,7 +2,7 @@
 - name: handle_error | Handle Errors Block
   block:
     - name: handle_error | Show error and stop execution
-      when: not aap_configuration_collect_logs
+      when: not aap_configuration_collect_logs | default(false)
       ansible.builtin.fail:
         msg: "error: {{ __cas_job_async_result['msg'] | default('Unknown Error') }}"
 

--- a/roles/controller_applications/defaults/main.yml
+++ b/roles/controller_applications/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_applications_async_delay: "{{ aap_configuration_async_d
 controller_configuration_applications_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_applications_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_applications/tasks/main.yml
+++ b/roles/controller_applications/tasks/main.yml
@@ -44,7 +44,7 @@
     - name: Managing Controller Applications | Wait for finish the Application management
       when:
         - not ansible_check_mode
-        - not ansible_check_mode and __applications_job_async_results_item.ansible_job_id is defined
+        - __applications_job_async_results_item.ansible_job_id is defined
       ansible.builtin.include_role:
         name: infra.aap_configuration.collect_async_status
       loop: "{{ __applications_job_async.results }}"

--- a/roles/controller_bulk_host_create/defaults/main.yml
+++ b/roles/controller_bulk_host_create/defaults/main.yml
@@ -4,5 +4,4 @@ controller_configuration_bulk_hosts_async_retries: "{{ aap_configuration_async_r
 controller_configuration_bulk_hosts_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 controller_configuration_bulk_hosts_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_credential_input_sources/defaults/main.yml
+++ b/roles/controller_credential_input_sources/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_credential_input_sources_async_delay: "{{ aap_configura
 controller_configuration_credential_input_sources_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_credential_input_sources_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_credential_types/defaults/main.yml
+++ b/roles/controller_credential_types/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_credential_types_async_delay: "{{ aap_configuration_asy
 controller_configuration_credential_types_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_credential_types_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_credentials/defaults/main.yml
+++ b/roles/controller_credentials/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_credentials_async_delay: "{{ aap_configuration_async_de
 controller_configuration_credentials_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_credentials_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_execution_environments/defaults/main.yml
+++ b/roles/controller_execution_environments/defaults/main.yml
@@ -6,5 +6,4 @@ controller_configuration_execution_environments_async_delay: "{{ aap_configurati
 controller_configuration_execution_environments_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_execution_environments_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_host_groups/defaults/main.yml
+++ b/roles/controller_host_groups/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_group_async_delay: "{{ aap_configuration_async_delay | 
 controller_configuration_group_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_groups_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_hosts/defaults/main.yml
+++ b/roles/controller_hosts/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_hosts_async_delay: "{{ aap_configuration_async_delay | 
 controller_configuration_hosts_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_host_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_instance_groups/defaults/main.yml
+++ b/roles/controller_instance_groups/defaults/main.yml
@@ -6,5 +6,4 @@ controller_configuration_instance_groups_async_delay: "{{ aap_configuration_asyn
 controller_configuration_instance_groups_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_instance_groups_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_instances/defaults/main.yml
+++ b/roles/controller_instances/defaults/main.yml
@@ -6,5 +6,4 @@ controller_configuration_instances_async_delay: "{{ aap_configuration_async_dela
 controller_configuration_instances_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_instances_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_inventories/defaults/main.yml
+++ b/roles/controller_inventories/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_inventories_async_delay: "{{ aap_configuration_async_de
 controller_configuration_inventories_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_inventories_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_inventory_source_update/defaults/main.yml
+++ b/roles/controller_inventory_source_update/defaults/main.yml
@@ -4,5 +4,4 @@ controller_configuration_inventory_source_update_async_retries: "{{ aap_configur
 controller_configuration_inventory_source_update_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 controller_configuration_inventory_source_update_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_inventory_sources/defaults/main.yml
+++ b/roles/controller_inventory_sources/defaults/main.yml
@@ -6,5 +6,4 @@ controller_configuration_inventory_sources_async_delay: "{{ aap_configuration_as
 controller_configuration_inventory_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_inventory_sources_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_job_templates/defaults/main.yml
+++ b/roles/controller_job_templates/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_job_templates_async_delay: "{{ aap_configuration_async_
 controller_configuration_job_templates_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_job_templates_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_labels/defaults/main.yml
+++ b/roles/controller_labels/defaults/main.yml
@@ -5,5 +5,4 @@ controller_configuration_labels_async_retries: "{{ aap_configuration_async_retri
 controller_configuration_labels_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 controller_configuration_labels_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_notification_templates/defaults/main.yml
+++ b/roles/controller_notification_templates/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_notifications_async_delay: "{{ aap_configuration_async_
 controller_configuration_notifications_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_notifications_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_organizations/defaults/main.yml
+++ b/roles/controller_organizations/defaults/main.yml
@@ -10,5 +10,4 @@ assign_galaxy_credentials_to_org: true
 assign_default_ee_to_org: true
 assign_notification_templates_to_org: true
 assign_instance_groups_to_org: true
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_project_update/defaults/main.yml
+++ b/roles/controller_project_update/defaults/main.yml
@@ -4,5 +4,4 @@ controller_configuration_project_update_async_retries: "{{ aap_configuration_asy
 controller_configuration_project_update_async_delay: "{{ aap_configuration_async_delay | default(10) }}"
 controller_configuration_project_update_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_projects/defaults/main.yml
+++ b/roles/controller_projects/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_projects_async_delay: "{{ aap_configuration_async_delay
 controller_configuration_projects_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_projects_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_roles/defaults/main.yml
+++ b/roles/controller_roles/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_role_async_delay: "{{ aap_configuration_async_delay | d
 controller_configuration_role_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_role_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_schedules/defaults/main.yml
+++ b/roles/controller_schedules/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_schedules_async_delay: "{{ aap_configuration_async_dela
 controller_configuration_schedules_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_schedules_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_teams/defaults/main.yml
+++ b/roles/controller_teams/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_platform_teams_async_delay: "{{ aap_configuration_async
 controller_configuration_teams_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_platform_teams_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_users/defaults/main.yml
+++ b/roles/controller_users/defaults/main.yml
@@ -11,5 +11,4 @@ controller_configuration_users_async_delay: "{{ aap_configuration_async_delay | 
 controller_configuration_users_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_users_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_workflow_job_templates/defaults/main.yml
+++ b/roles/controller_workflow_job_templates/defaults/main.yml
@@ -7,5 +7,4 @@ controller_configuration_workflow_async_delay: "{{ aap_configuration_async_delay
 controller_configuration_workflow_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_workflows_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
-aap_configuration_collect_logs: false
 ...

--- a/roles/controller_workflow_job_templates/tasks/main.yml
+++ b/roles/controller_workflow_job_templates/tasks/main.yml
@@ -75,7 +75,7 @@
     - name: Managing Workflows | Wait for finish the workflow management
       when:
         - not ansible_check_mode
-        - not ansible_check_mode and __workflows_job_async_results_item.ansible_job_id is defined
+        - __workflows_job_async_results_item.ansible_job_id is defined
       ansible.builtin.include_role:
         name: infra.aap_configuration.collect_async_status
       loop: "{{ __workflows_job_async.results }}"

--- a/roles/dispatch/defaults/main.yml
+++ b/roles/dispatch/defaults/main.yml
@@ -202,5 +202,4 @@ aap_configuration_dispatcher_roles: >
    + controller_configuration_dispatcher_roles
    + eda_configuration_dispatcher_roles }}
 
-aap_configuration_collect_logs: false
 ...

--- a/roles/eda_controller_tokens/defaults/main.yml
+++ b/roles/eda_controller_tokens/defaults/main.yml
@@ -4,5 +4,4 @@ eda_configuration_users_token_secure_logging: "{{ aap_configuration_secure_loggi
 eda_configuration_users_token_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 eda_configuration_users_token_async_delay: "{{ aap_configuration_async_delay| default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/eda_credential_types/defaults/main.yml
+++ b/roles/eda_credential_types/defaults/main.yml
@@ -4,5 +4,4 @@ eda_configuration_credential_types_secure_logging: "{{ aap_configuration_secure_
 eda_configuration_credential_types_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 eda_configuration_credential_types_async_delay: "{{ aap_configuration_async_delay| default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/eda_credentials/defaults/main.yml
+++ b/roles/eda_credentials/defaults/main.yml
@@ -4,5 +4,4 @@ eda_configuration_credentials_secure_logging: "{{ aap_configuration_secure_loggi
 eda_configuration_credentials_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 eda_configuration_credentials_async_delay: "{{ aap_configuration_async_delay| default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/eda_decision_environments/defaults/main.yml
+++ b/roles/eda_decision_environments/defaults/main.yml
@@ -4,5 +4,4 @@ eda_configuration_decision_environments_secure_logging: "{{ aap_configuration_se
 eda_configuration_decision_environments_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 eda_configuration_decision_environments_async_delay: "{{ aap_configuration_async_delay| default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/eda_event_streams/defaults/main.yml
+++ b/roles/eda_event_streams/defaults/main.yml
@@ -4,5 +4,4 @@ eda_configuration_event_streams_secure_logging: "{{ aap_configuration_secure_log
 eda_configuration_event_streams_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 eda_configuration_event_streams_async_delay: "{{ aap_configuration_async_delay| default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/eda_projects/defaults/main.yml
+++ b/roles/eda_projects/defaults/main.yml
@@ -4,5 +4,4 @@ eda_configuration_projects_secure_logging: "{{ aap_configuration_secure_logging 
 eda_configuration_projects_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 eda_configuration_projects_async_delay: "{{ aap_configuration_async_delay| default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/eda_rulebook_activations/defaults/main.yml
+++ b/roles/eda_rulebook_activations/defaults/main.yml
@@ -4,5 +4,4 @@ eda_configuration_rulebook_activations_secure_logging: "{{ aap_configuration_sec
 eda_configuration_rulebook_activations_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 eda_configuration_rulebook_activations_async_delay: "{{ aap_configuration_async_delay| default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/eda_users/defaults/main.yml
+++ b/roles/eda_users/defaults/main.yml
@@ -4,5 +4,4 @@ eda_configuration_users_secure_logging: "{{ aap_configuration_secure_logging | d
 eda_configuration_users_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 eda_configuration_users_async_delay: "{{ aap_configuration_async_delay| default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/gateway_applications/defaults/main.yml
+++ b/roles/gateway_applications/defaults/main.yml
@@ -7,5 +7,4 @@ gateway_applications_async_delay: "{{ aap_configuration_async_delay | default(1)
 gateway_applications_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 aap_applications_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/gateway_authenticator_maps/defaults/main.yml
+++ b/roles/gateway_authenticator_maps/defaults/main.yml
@@ -15,5 +15,4 @@ gateway_authenticator_maps_async_retries: "{{ aap_configuration_async_retries | 
 gateway_authenticator_maps_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_authenticator_maps_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/gateway_authenticators/defaults/main.yml
+++ b/roles/gateway_authenticators/defaults/main.yml
@@ -15,5 +15,4 @@ gateway_authenticators_async_retries: "{{ aap_configuration_async_retries | defa
 gateway_authenticators_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_authenticators_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/gateway_http_ports/defaults/main.yml
+++ b/roles/gateway_http_ports/defaults/main.yml
@@ -20,5 +20,4 @@ gateway_http_ports_async_retries: "{{ aap_configuration_async_retries | default(
 gateway_http_ports_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_http_ports_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/gateway_organizations/defaults/main.yml
+++ b/roles/gateway_organizations/defaults/main.yml
@@ -16,7 +16,6 @@ gateway_organizations_async_delay: "{{ aap_configuration_async_delay | default(1
 gateway_organizations_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 gateway_organizations_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 
 assign_galaxy_credentials_to_org: true
 assign_default_ee_to_org: true

--- a/roles/gateway_role_user_assignments/defaults/main.yml
+++ b/roles/gateway_role_user_assignments/defaults/main.yml
@@ -15,5 +15,4 @@ gateway_role_user_assignments_async_retries: "{{ aap_configuration_async_retries
 gateway_role_user_assignments_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_role_user_assignments_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/gateway_routes/defaults/main.yml
+++ b/roles/gateway_routes/defaults/main.yml
@@ -16,5 +16,4 @@ gateway_routes_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_routes_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 gateway_routes_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/gateway_service_clusters/defaults/main.yml
+++ b/roles/gateway_service_clusters/defaults/main.yml
@@ -15,5 +15,4 @@ gateway_service_clusters_async_retries: "{{ aap_configuration_async_retries | de
 gateway_service_clusters_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_service_clusters_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/gateway_service_keys/defaults/main.yml
+++ b/roles/gateway_service_keys/defaults/main.yml
@@ -15,5 +15,4 @@ gateway_service_keys_async_retries: "{{ aap_configuration_async_retries | defaul
 gateway_service_keys_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_service_keys_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/gateway_service_nodes/defaults/main.yml
+++ b/roles/gateway_service_nodes/defaults/main.yml
@@ -15,5 +15,4 @@ gateway_service_nodes_async_retries: "{{ aap_configuration_async_retries | defau
 gateway_service_nodes_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_service_nodes_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/gateway_services/defaults/main.yml
+++ b/roles/gateway_services/defaults/main.yml
@@ -15,5 +15,4 @@ gateway_services_async_retries: "{{ aap_configuration_async_retries | default(30
 gateway_services_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_services_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/gateway_teams/defaults/main.yml
+++ b/roles/gateway_teams/defaults/main.yml
@@ -15,5 +15,4 @@ gateway_teams_async_retries: "{{ aap_configuration_async_retries | default(30) }
 gateway_teams_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_teams_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/gateway_users/defaults/main.yml
+++ b/roles/gateway_users/defaults/main.yml
@@ -30,5 +30,4 @@ gateway_users_async_retries: "{{ aap_configuration_async_retries | default(30) }
 gateway_users_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_users_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_collection/defaults/main.yml
+++ b/roles/hub_collection/defaults/main.yml
@@ -24,5 +24,4 @@ hub_configuration_collection_async_retries: "{{ aap_configuration_async_retries 
 hub_configuration_collection_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 hub_configuration_collection_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_collection_remote/defaults/main.yml
+++ b/roles/hub_collection_remote/defaults/main.yml
@@ -13,5 +13,4 @@ hub_configuration_collection_remote_async_retries: "{{ aap_configuration_async_r
 hub_configuration_collection_remote_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_collection_remote_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_collection_repository/defaults/main.yml
+++ b/roles/hub_collection_repository/defaults/main.yml
@@ -13,5 +13,4 @@ hub_configuration_collection_repository_async_retries: "{{ aap_configuration_asy
 hub_configuration_collection_repository_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_collection_repository_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_collection_repository_sync/defaults/main.yml
+++ b/roles/hub_collection_repository_sync/defaults/main.yml
@@ -13,5 +13,4 @@ hub_configuration_collection_repository_sync_async_retries: "{{ aap_configuratio
 hub_configuration_collection_repository_sync_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_collection_repository_sync_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_ee_image/defaults/main.yml
+++ b/roles/hub_ee_image/defaults/main.yml
@@ -25,5 +25,4 @@ hub_configuration_ee_image_async_retries: "{{ aap_configuration_async_retries | 
 hub_configuration_ee_image_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_ee_image_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_ee_registry/defaults/main.yml
+++ b/roles/hub_ee_registry/defaults/main.yml
@@ -29,5 +29,4 @@ hub_configuration_ee_registry_async_retries: "{{ aap_configuration_async_retries
 hub_configuration_ee_registry_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_ee_registry_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_ee_registry_index/defaults/main.yml
+++ b/roles/hub_ee_registry_index/defaults/main.yml
@@ -22,5 +22,4 @@ hub_configuration_ee_registry_index_async_retries: "{{ aap_configuration_async_r
 hub_configuration_ee_registry_index_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_ee_registry_index_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_ee_registry_sync/defaults/main.yml
+++ b/roles/hub_ee_registry_sync/defaults/main.yml
@@ -22,5 +22,4 @@ hub_configuration_ee_registry_sync_async_retries: "{{ aap_configuration_async_re
 hub_configuration_ee_registry_sync_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_ee_registry_sync_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_ee_repository/defaults/main.yml
+++ b/roles/hub_ee_repository/defaults/main.yml
@@ -22,5 +22,4 @@ hub_configuration_ee_repository_async_retries: "{{ aap_configuration_async_retri
 hub_configuration_ee_repository_sync_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_ee_repository_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_ee_repository_sync/defaults/main.yml
+++ b/roles/hub_ee_repository_sync/defaults/main.yml
@@ -22,5 +22,4 @@ hub_configuration_ee_repository_sync_async_retries: "{{ aap_configuration_async_
 hub_configuration_ee_repository_sync_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_ee_repository_sync_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_group/defaults/main.yml
+++ b/roles/hub_group/defaults/main.yml
@@ -20,5 +20,4 @@ hub_configuration_group_async_retries: "{{ aap_configuration_async_retries | def
 hub_configuration_group_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_group_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_group_roles/defaults/main.yml
+++ b/roles/hub_group_roles/defaults/main.yml
@@ -19,5 +19,4 @@ hub_configuration_group_roles_async_retries: "{{ aap_configuration_async_retries
 hub_configuration_group_roles_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_group_roles_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_namespace/defaults/main.yml
+++ b/roles/hub_namespace/defaults/main.yml
@@ -31,5 +31,4 @@ hub_configuration_namespace_async_retries: "{{ aap_configuration_async_retries |
 hub_configuration_namespace_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_namespace_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_publish/defaults/main.yml
+++ b/roles/hub_publish/defaults/main.yml
@@ -28,5 +28,4 @@ hub_configuration_publish_async_retries: "{{ aap_configuration_async_retries | d
 hub_configuration_publish_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_publish_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_role/defaults/main.yml
+++ b/roles/hub_role/defaults/main.yml
@@ -21,5 +21,4 @@ hub_configuration_role_async_retries: "{{ aap_configuration_async_retries | defa
 hub_configuration_role_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_role_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...

--- a/roles/hub_user/defaults/main.yml
+++ b/roles/hub_user/defaults/main.yml
@@ -27,5 +27,4 @@ hub_configuration_user_async_retries: "{{ aap_configuration_async_retries | defa
 hub_configuration_user_accounts_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 hub_configuration_user_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 aap_configuration_async_dir:
-aap_configuration_collect_logs: false
 ...


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->

Removes setting the default for the `aap_configuration_collect_logs` in every role and sets the default in the only location the variable is used.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

Manually

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->

No

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
