### PR TITLE
removing controller_roles from default dispatch

### DIFF
--- a/roles/dispatch/README.md
+++ b/roles/dispatch/README.md
@@ -296,9 +296,6 @@ controller_configuration_dispatcher_roles:
   - role: controller_schedules
     var: controller_schedules
     tags: schedules
-  - role: controller_roles
-    var: controller_roles
-    tags: roles
   - role: controller_job_launch
     var: controller_launch_jobs
     tags: job_launch

--- a/roles/dispatch/defaults/main.yml
+++ b/roles/dispatch/defaults/main.yml
@@ -164,9 +164,6 @@ controller_configuration_dispatcher_roles:
   - role: controller_schedules
     var: controller_schedules
     tags: schedules
-  - role: controller_roles
-    var: controller_roles
-    tags: roles
   - role: controller_job_launch
     var: controller_launch_jobs
     tags: job_launch

--- a/roles/dispatch/meta/argument_specs.yml
+++ b/roles/dispatch/meta/argument_specs.yml
@@ -170,9 +170,6 @@ argument_specs:
           - role: controller_schedules
             var: controller_schedules
             tags: schedules
-          - role: controller_roles
-            var: controller_roles
-            tags: roles
           - role: controller_job_launch
             var: controller_launch_jobs
             tags: job_launch


### PR DESCRIPTION

<!-- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
removing controller_roles from default dispatch this should be replaced by gateway_role_definitions, gateway_role_team_assignments, gateway_role_user_assignments

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
manual

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves:
TASK [infra.aap_configuration.collect_async_status : Managing AAP Object | Wait for management to complete] *********************************************************************************************************
fatal: [localhost]: FAILED! => changed=false
 ansible_job_id: j792302844453.420
attempts: 1
finished: 1
msg: 'The host sent back a server error (HTTP Error 500: Internal Server Error): /api/controller/v2/roles/781/teams/. Please check the logs and try again later'
results_file: /home/runner/.ansible_async/j792302844453.420
started: 1
stderr: ''
stderr_lines: <omitted>
stdout: ''
stdout_lines: <omitted>
...ignoring


# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
