### PR TITLE
add `kind: constructed` in controller_inventories role document

### DIFF
--- a/changelogs/fragments/fix_doc_inventories_kind.yml
+++ b/changelogs/fragments/fix_doc_inventories_kind.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - Add `kind: constructed` in controller_inventories role document
+  - "Add `kind: constructed` in controller_inventories role document"
 ...

--- a/changelogs/fragments/fix_doc_inventories_kind.yml
+++ b/changelogs/fragments/fix_doc_inventories_kind.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Add `kind: constructed` in controller_inventories role document
+...

--- a/roles/controller_inventories/README.md
+++ b/roles/controller_inventories/README.md
@@ -101,7 +101,7 @@ The role will strip the double space between the curly bracket in order to provi
 |`instance_groups`|""|no|list|List of Instance Groups for this Inventory to run on.|
 |`input_inventories`|""|no|list|List of Inventories to use as input for Constructed Inventory.|
 |`variables`|`{}`|no|dict|Variables for the inventory.|
-|`kind`|""|no|str|The kind of inventory. Currently choices are '' and 'smart'|
+|`kind`|""|no|str|The kind of inventory. Currently choices are '', 'smart' and 'constructed'|
 |`host_filter`|""|no|str|The host filter field, useful only when 'kind=smart'|
 |`prevent_instance_group_fallback`|`false`|no|bool|Prevent falling back to instance groups set on the organization|
 |`state`|`present`|no|str|Desired state of the resource.|

--- a/roles/controller_inventories/meta/argument_specs.yml
+++ b/roles/controller_inventories/meta/argument_specs.yml
@@ -40,7 +40,8 @@ argument_specs:
         #     choices:
         #       - ""
         #       - smart
-        #     description: The kind of inventory. Currently choices are '' and 'smart'
+        #       - constructed
+        #     description: The kind of inventory. Currently choices are '', 'smart' and 'constructed'
         #   host_filter:
         #     default: false
         #     required: false

--- a/roles/controller_inventories/tests/configs/inventories.yml
+++ b/roles/controller_inventories/tests/configs/inventories.yml
@@ -8,4 +8,9 @@ controller_inventories:
     kind: smart
     host_filter: name__icontains=test
     variables: '{"key1":"val1", "key2":"val2"}'
+  - name: test3
+    organization: Default
+    kind: constructed
+    input_inventories:
+      - test1
 ...

--- a/roles/controller_inventories/tests/test.yml
+++ b/roles/controller_inventories/tests/test.yml
@@ -1,5 +1,5 @@
 ---
-- name: Add Inventies on Controller
+- name: Add Inventories on Controller
   hosts: localhost
   connection: local
   gather_facts: false


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->

add `kind: constructed` in `controller_inventories` role document.

The `kind: constructed` option of `ansible.controller.inventory` and `awx.awx.inventory` are already support.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

Document only

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A
