### PR TITLE
fix: dispatch role wildcard vars

### DIFF
--- a/changelogs/fragments/fix_dispatch_wildcard_vars.yml
+++ b/changelogs/fragments/fix_dispatch_wildcard_vars.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix missing wildcard variable tasks for gateway_http_portsgateway_role_definitions, and gateway_role_team_assignments to ensure all variables defined in defaults are properly handled
+...

--- a/roles/dispatch/tasks/include_wildcard_vars.yml
+++ b/roles/dispatch/tasks/include_wildcard_vars.yml
@@ -24,6 +24,11 @@
     aap_applications: "{{ (aap_applications | default([])) + lookup('ansible.builtin.vars', item) }}"
   loop: "{{ [] if (lookup('ansible.builtin.varnames', 'aap_applications.*')) is not string else (lookup('ansible.builtin.varnames', 'aap_applications.*') | split(',')) }}"
 
+- name: include_wildcard_vars | Set fact for gateway_http_ports
+  ansible.builtin.set_fact:
+    gateway_http_ports: "{{ (gateway_http_ports | default([])) + lookup('ansible.builtin.vars', item) }}"
+  loop: "{{ [] if (lookup('ansible.builtin.varnames', 'gateway_http_ports.*')) is not string else (lookup('ansible.builtin.varnames', 'gateway_http_ports.*') | split(',')) }}"
+
 - name: include_wildcard_vars | Set fact for gateway_service_clusters
   ansible.builtin.set_fact:
     gateway_service_clusters: "{{ (gateway_service_clusters | default([])) + lookup('ansible.builtin.vars', item) }}"
@@ -54,6 +59,16 @@
     aap_user_accounts: "{{ (aap_user_accounts | default([])) + lookup('ansible.builtin.vars', item) }}"
   loop: "{{ [] if (lookup('ansible.builtin.varnames', 'aap_user_accounts.*')) is not string else (lookup('ansible.builtin.varnames', 'aap_user_accounts.*') | split(',')) }}"
 
+- name: include_wildcard_vars | Set fact for gateway_role_definitions
+  ansible.builtin.set_fact:
+    gateway_role_definitions: "{{ (gateway_role_definitions | default([])) + lookup('ansible.builtin.vars', item) }}"
+  loop: "{{ [] if (lookup('ansible.builtin.varnames', 'gateway_role_definitions.*')) is not string else (lookup('ansible.builtin.varnames', 'gateway_role_definitions.*') | split(',')) }}"
+
+- name: include_wildcard_vars | Set fact for gateway_role_team_assignments
+  ansible.builtin.set_fact:
+    gateway_role_team_assignments: "{{ (gateway_role_team_assignments | default([])) + lookup('ansible.builtin.vars', item) }}"
+  loop: "{{ [] if (lookup('ansible.builtin.varnames', 'gateway_role_team_assignments.*')) is not string else (lookup('ansible.builtin.varnames', 'gateway_role_team_assignments.*') | split(',')) }}"
+
 - name: include_wildcard_vars | Set fact for gateway_role_user_assignments
   ansible.builtin.set_fact:
     gateway_role_user_assignments: "{{ (gateway_role_user_assignments | default([])) + lookup('ansible.builtin.vars', item) }}"
@@ -63,11 +78,6 @@
   ansible.builtin.set_fact:
     gateway_routes: "{{ (gateway_routes | default([])) + lookup('ansible.builtin.vars', item) }}"
   loop: "{{ [] if (lookup('ansible.builtin.varnames', 'gateway_routes.*')) is not string else (lookup('ansible.builtin.varnames', 'gateway_routes.*') | split(',')) }}"
-
-- name: include_wildcard_vars | Set fact for http_ports
-  ansible.builtin.set_fact:
-    http_ports: "{{ (http_ports | default([])) + lookup('ansible.builtin.vars', item) }}"
-  loop: "{{ [] if (lookup('ansible.builtin.varnames', 'http_ports.*')) is not string else (lookup('ansible.builtin.varnames', 'http_ports.*') | split(',')) }}"
 
 - name: include_wildcard_vars | Set fact for hub_namespaces
   ansible.builtin.set_fact:

--- a/roles/eda_credential_types/README.md
+++ b/roles/eda_credential_types/README.md
@@ -88,7 +88,7 @@ The role will strip the double space between the curly bracket in order to provi
 
 ### Input and Injector Schema
 
-The following details the data format to use for inputs and injectors. These can be in either YAML or JSON For the most up to date information and more details see [Custom Credential Types - Ansible Controller Documentation](https://docs.ansible.com/automation-controller/latest/html/userguide/credential_plugins.html)
+The following details the data format to use for inputs and injectors. These can be in either YAML or JSON For the most up to date information and more details see [Custom Credential Types - Ansible Controller Documentation](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/configuring_automation_execution/assembly-controller-secret-management)
 
 #### Input Schema
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
- add missing tasks and fix naming
- Fix naming mismatch: rename http_ports to gateway_http_ports in wildcard vars task
- Add missing wildcard variable tasks for gateway_role_definitions and gateway_role_team_assignments
- Ensure tasks are ordered to match the sequence in defaults/main.yml
- All variables defined in dispatch defaults now have corresponding wildcard handling

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->
manually

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
no

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
none