### PR TITLE
fix controller_license argument_spec

### DIFF
--- a/roles/controller_license/meta/argument_specs.yml
+++ b/roles/controller_license/meta/argument_specs.yml
@@ -9,9 +9,9 @@ argument_specs:
         type: dict
         options:
           manifest_file:
-#            required: false
-#            type: str
-#            description: File path to a Red Hat subscription manifest (a .zip file)
+            required: false
+            type: str
+            description: File path to a Red Hat subscription manifest (a .zip file)
 #          manifest_url:
 #            required: false
 #            type: str


### PR DESCRIPTION
fix #1217

Seems to have been broken in https://github.com/redhat-cop/infra.aap_configuration/pull/1197/files#diff-12a52c1071b3250dac8f0e7dd7ebdc79767fa78a0ddebfd860a5b71b5ca839a5

This fixes #1217 for me. I tested locally.
