### PR TITLE
Fix issue #1225

### DIFF
--- a/roles/dispatch/defaults/main.yml
+++ b/roles/dispatch/defaults/main.yml
@@ -16,6 +16,7 @@ gateway_configuration_dispatcher_roles:
     assign_galaxy_credentials_to_org: false
     assign_default_ee_to_org: false
     assign_notification_templates_to_org: false
+    assign_instance_groups_to_org: false
   - role: gateway_applications
     var: aap_applications
     tags: applications
@@ -128,6 +129,7 @@ controller_configuration_dispatcher_roles:
     assign_galaxy_credentials_to_org: true
     assign_default_ee_to_org: true
     assign_notification_templates_to_org: true
+    assign_instance_groups_to_org: true
   - role: controller_projects
     var: controller_projects
     tags:

--- a/roles/dispatch/tasks/main.yml
+++ b/roles/dispatch/tasks/main.yml
@@ -17,6 +17,7 @@
     assign_galaxy_credentials_to_org: "{{ __role.assign_galaxy_credentials_to_org | default(false) }}"
     assign_default_ee_to_org: "{{ __role.assign_default_ee_to_org | default(false) }}"
     assign_notification_templates_to_org: "{{ __role.assign_notification_templates_to_org | default(false) }}"
+    assign_instance_groups_to_org: "{{ __role.assign_instance_groups_to_org | default(false) }}"
 
 - name: Display errors and fail
   when:


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?

Use the provided switch `assigne_instance_groups_to_org` from the `controller_organization` role while creating the organization before the instance groups are deployed. 

https://github.com/redhat-cop/infra.aap_configuration/blob/aff0707ba30ed3ee2720795e7757c8402decaef4/roles/controller_organizations/defaults/main.yml#L12

# How should this be tested?

I didn't test if the behevior is working like expected. But while it's working for assignments of the other ressources and the implementation is the same, i expect that this change is working:

https://github.com/redhat-cop/infra.aap_configuration/blob/aff0707ba30ed3ee2720795e7757c8402decaef4/roles/controller_organizations/defaults/main.yml#L9-L11

# Is there a relevant Issue open for this?

This will close #1225 
