### PR TITLE
Added ability to attach roles directly to objects

### DIFF
--- a/changelogs/fragments/role_apply.yml
+++ b/changelogs/fragments/role_apply.yml
@@ -1,0 +1,4 @@
+---
+major_changes:
+  - Added ability to attach roles directly to projects, credentials, inventories, instance groups, workflows and job_templates
+...

--- a/roles/controller_credential_types/README.md
+++ b/roles/controller_credential_types/README.md
@@ -81,7 +81,7 @@ This also speeds up the overall role.
 |`inputs`|""|no|Enter inputs using either JSON or YAML syntax. Refer to the Ansible controller documentation for example syntax.|
 |`kind`|"cloud"|no|The type of credential type being added. Note that only cloud and net can be used for creating credential types.|
 |`state`|`present`|no|Desired state of the resource.|
-|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
+|`register`|""|no|Variable to set based on the result of the object creation/modification|
 
 ### Formatting Injectors
 

--- a/roles/controller_credentials/README.md
+++ b/roles/controller_credentials/README.md
@@ -84,9 +84,9 @@ This also speeds up the overall role.
 |`user`|""|no|User that should own this credential. If provided, do not give either team or organization. |
 |`team`|""|no|Team that should own this credential. If provided, do not give either user or organization. |
 |`state`|`present`|no|Desired state of the resource.|
-|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
+|`register`|""|no|Variable to set based on the result of the object creation/modification|
 |`update_secrets`|true|no| true will always change password if user specifies password, even if API gives $encrypted$ for password. false will only set the password if other values change too.|
-|`roles`|""|no|obj|Controller roles to apply to the credential. See roles section below for how to apply.|
+|`roles`|""|no|Controller roles to apply to the credential. See roles section below for how to apply.|
 
 #### Applying roles to users or teams
 

--- a/roles/controller_credentials/README.md
+++ b/roles/controller_credentials/README.md
@@ -85,7 +85,7 @@ This also speeds up the overall role.
 |`team`|""|no|Team that should own this credential. If provided, do not give either user or organization. |
 |`state`|`present`|no|Desired state of the resource.|
 |`register`|""|no|Variable to set based on the result of the object creation/modification|
-|`update_secrets`|true|no| true will always change password if user specifies password, even if API gives $encrypted$ for password. false will only set the password if other values change too.|
+|`update_secrets`|true|no|true will always change password if user specifies password, even if API gives $encrypted$ for password. false will only set the password if other values change too.|
 |`roles`|""|no|Controller roles to apply to the credential. See roles section below for how to apply.|
 
 #### Applying roles to users or teams

--- a/roles/controller_credentials/README.md
+++ b/roles/controller_credentials/README.md
@@ -84,6 +84,23 @@ This also speeds up the overall role.
 |`team`|""|no|Team that should own this credential. If provided, do not give either user or organization. |
 |`state`|`present`|no|Desired state of the resource.|
 |`update_secrets`|true|no| true will always change password if user specifies password, even if API gives $encrypted$ for password. false will only set the password if other values change too.|
+|`roles`|""|no|obj|Controller roles to apply to the credential. See roles section below for how to apply.|
+
+#### Applying roles to users or teams
+
+You can apply roles to users or teams using the `roles` field. This is applied as a dictionary as follows:
+
+```yaml
+- name: my_credential
+  roles:
+    use:
+      teams:
+        - myteam1
+        - myteam2
+    admin:
+      users:
+        - sysadmin1
+```
 
 ### Credential types
 

--- a/roles/controller_credentials/tasks/main.yml
+++ b/roles/controller_credentials/tasks/main.yml
@@ -73,4 +73,23 @@
       loop_control:
         loop_var: __credentials_job_async_results_item
         label: "Cleaning up job results file: {{ __credentials_job_async_results_item.results_file | default('Unknown') }}"
+
+- name: Add roles to credentials
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.controller_roles
+  vars:
+    controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
+    _item_list: "{{ credentials if credentials is defined else controller_credentials }}"
+    _controller_roles: |
+      {% for _item in _item_list %}
+      {% if _item.roles is defined %}
+      {% for _role in _item.roles.keys() %}
+      - role: "{{ _role }}"
+        credentials:
+          - "{{ _item.name }}"
+        teams: "{{ _item.roles[_role].teams | default(omit) }}"
+        users: "{{ _item.roles[_role].users | default(omit) }}"
+      {% endfor %}
+      {% endif %}
+      {% endfor %}
 ...

--- a/roles/controller_instance_groups/README.md
+++ b/roles/controller_instance_groups/README.md
@@ -105,7 +105,6 @@ You can apply roles to users or teams using the `roles` field. This is applied a
         - sysadmin1
 ```
 
-
 ### Standard Instance Group Data Structure
 
 #### Yaml Example

--- a/roles/controller_instance_groups/README.md
+++ b/roles/controller_instance_groups/README.md
@@ -85,6 +85,23 @@ This also speeds up the overall role.
 |`pod_spec_override`|""|no|str|A custom Kubernetes or OpenShift Pod specification.|
 |`instances`|""|no|list|The instances associated with this instance_group.|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`roles`|""|no|obj|Controller roles to apply to the instance group. See roles section below for how to apply.|
+
+#### Applying roles to users or teams
+
+You can apply roles to users or teams using the `roles` field. This is applied as a dictionary as follows:
+
+```yaml
+- name: my_instance_group
+  roles:
+    use:
+      teams:
+        - myteam1
+        - myteam2
+    admin:
+      users:
+        - sysadmin1
+```
 
 ### Standard Instance Group Data Structure
 

--- a/roles/controller_instance_groups/tasks/main.yml
+++ b/roles/controller_instance_groups/tasks/main.yml
@@ -76,4 +76,23 @@
       loop_control:
         loop_var: __instance_groups_job_async_results_item
         label: "Cleaning up job results file: {{ __instance_groups_job_async_results_item.results_file | default('Unknown') }}"
+
+- name: Add roles to instance groups
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.controller_roles
+  vars:
+    controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
+    _item_list: "{{ controller_instance_groups }}"
+    _controller_roles: |
+      {% for _item in _item_list %}
+      {% if _item.roles is defined %}
+      {% for _role in _item.roles.keys() %}
+      - role: "{{ _role }}"
+        instance_groups:
+          - "{{ _item.name }}"
+        teams: "{{ _item.roles[_role].teams | default(omit) }}"
+        users: "{{ _item.roles[_role].users | default(omit) }}"
+      {% endfor %}
+      {% endif %}
+      {% endfor %}
 ...

--- a/roles/controller_inventories/README.md
+++ b/roles/controller_inventories/README.md
@@ -105,6 +105,29 @@ The role will strip the double space between the curly bracket in order to provi
 |`host_filter`|""|no|str|The host filter field, useful only when 'kind=smart'|
 |`prevent_instance_group_fallback`|`false`|no|bool|Prevent falling back to instance groups set on the organization|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`roles`|""|no|obj|Controller roles to apply to the inventory. See roles section below for how to apply.|
+
+#### Applying roles to users or teams
+
+You can apply roles to users or teams using the `roles` field. This is applied as a dictionary as follows:
+
+```yaml
+- name: my_inventory
+  roles:
+    use:
+      teams:
+        - myteam1
+        - myteam2
+    admin:
+      users:
+        - sysadmin1
+    adhoc:
+      users: jim
+    update:
+      teams:
+        - myteam1
+        - myteam2
+```
 
 ### Standard Inventory Data Structure
 

--- a/roles/controller_inventories/README.md
+++ b/roles/controller_inventories/README.md
@@ -131,7 +131,6 @@ You can apply roles to users or teams using the `roles` field. This is applied a
         - myteam2
 ```
 
-
 ### Standard Inventory Data Structure
 
 #### Json Example

--- a/roles/controller_inventories/tasks/main.yml
+++ b/roles/controller_inventories/tasks/main.yml
@@ -75,4 +75,23 @@
       loop_control:
         loop_var: __inventories_job_async_result_item
         label: "Cleaning up job results file: {{ __inventories_job_async_result_item.results_file | default('Unknown') }}"
+
+- name: Add roles to inventories
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.controller_roles
+  vars:
+    controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
+    _item_list: "{{ inventory if inventory is defined else controller_inventories }}"
+    _controller_roles: |
+      {% for _item in _item_list %}
+      {% if _item.roles is defined %}
+      {% for _role in _item.roles.keys() %}
+      - role: "{{ _role }}"
+        inventories:
+          - "{{ _item.name }}"
+        teams: "{{ _item.roles[_role].teams | default(omit) }}"
+        users: "{{ _item.roles[_role].users | default(omit) }}"
+      {% endfor %}
+      {% endif %}
+      {% endfor %}
 ...

--- a/roles/controller_inventory_sources/README.md
+++ b/roles/controller_inventory_sources/README.md
@@ -118,7 +118,7 @@ The role will strip the double space between the curly bracket in order to provi
 |`source_project`|""|no|Project to use as source with scm option.|
 |`scm_branch`|""|no|Project scm branch to use as source with scm option. Project must have branch override enabled.|
 |`state`|`present`|no|Desired state of the resource.|
-|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
+|`register`|""|no|Variable to set based on the result of the object creation/modification|
 |`notification_templates_started`|""|no|The notifications on started to use for this inventory source in a list.|
 |`notification_templates_success`|""|no|The notifications on success to use for this inventory source in a list.|
 |`notification_templates_error`|""|no|The notifications on error to use for this inventory source in a list.|

--- a/roles/controller_job_templates/README.md
+++ b/roles/controller_job_templates/README.md
@@ -129,6 +129,23 @@ This also speeds up the overall role.
 |`notification_templates_success`|""|no|list|The notifications on success to use for this organization in a list.|
 |`notification_templates_error`|""|no|list|The notifications on error to use for this organization in a list.|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`roles`|""|no|obj|Controller roles to apply to the job template. See roles section below for how to apply.|
+
+#### Applying roles to users or teams
+
+You can apply roles to users or teams using the `roles` field. This is applied as a dictionary as follows:
+
+```yaml
+- name: my_jt
+  roles:
+    exeute:
+      teams:
+        - myteam1
+        - myteam2
+    admin:
+      users:
+        - sysadmin1
+```
 
 ### Surveys
 

--- a/roles/controller_job_templates/README.md
+++ b/roles/controller_job_templates/README.md
@@ -149,7 +149,6 @@ You can apply roles to users or teams using the `roles` field. This is applied a
         - sysadmin1
 ```
 
-
 ### Surveys
 
 Refer to the [controller Api Guide](https://docs.ansible.com/ansible-tower/latest/html/towerapi/api_ref.html#/Job_Templates/Job_Templates_job_templates_survey_spec_create) for more information about forming surveys

--- a/roles/controller_job_templates/tasks/main.yml
+++ b/roles/controller_job_templates/tasks/main.yml
@@ -117,4 +117,23 @@
       loop_control:
         loop_var: __job_templates_job_async_result_item
         label: "Cleaning up job results file: {{ __job_templates_job_async_result_item.results_file | default('Unknown') }}"
+
+- name: Add roles to job templates
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.controller_roles
+  vars:
+    controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
+    _item_list: "{{ job_templates if job_templates is defined else controller_templates }}"
+    _controller_roles: |
+      {% for _item in _item_list %}
+      {% if _item.roles is defined %}
+      {% for _role in _item.roles.keys() %}
+      - role: "{{ _role }}"
+        job_templates:
+          - "{{ _item.name }}"
+        teams: "{{ _item.roles[_role].teams | default(omit) }}"
+        users: "{{ _item.roles[_role].users | default(omit) }}"
+      {% endfor %}
+      {% endif %}
+      {% endfor %}
 ...

--- a/roles/controller_projects/README.md
+++ b/roles/controller_projects/README.md
@@ -101,6 +101,27 @@ This also speeds up the overall role.
 |`wait`|""|no|bool|Provides option to wait for completed project sync before returning.|
 |`update_project`|`false`|no|bool|Force project to update after changes.Used in conjunction with wait, interval, and timeout.|
 |`interval`|`controller_configuration_projects_async_delay`|no|float|The interval to request an update from controller. Requires wait.|
+|`roles`|""|no|obj|Controller roles to apply to the project. See roles section below for how to apply.|
+
+#### Applying roles to users or teams
+
+You can apply roles to users or teams using the `roles` field. This is applied as a dictionary as follows:
+
+```yaml
+- name: my_project
+  roles:
+    use:
+      teams:
+        - myteam1
+        - myteam2
+    admin:
+      users:
+        - sysadmin1
+    update:
+      teams:
+        - myteam1
+        - myteam2
+```
 
 ### Standard Project Data Structure
 

--- a/roles/controller_projects/tasks/main.yml
+++ b/roles/controller_projects/tasks/main.yml
@@ -90,4 +90,23 @@
       loop_control:
         loop_var: __projects_job_async_results_item
         label: "Cleaning up job results file: {{ __projects_job_async_results_item.results_file | default('Unknown') }}"
+
+- name: Add roles to projects
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.controller_roles
+  vars:
+    controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
+    _item_list: "{{ projects if projects is defined else controller_projects }}"
+    _controller_roles: |
+      {% for _item in _item_list %}
+      {% if _item.roles is defined %}
+      {% for _role in _item.roles.keys() %}
+      - role: "{{ _role }}"
+        projects:
+          - "{{ projects if projects is defined else controller_projects }}"
+        teams: "{{ _item.roles[_role].teams | default(omit) }}"
+        users: "{{ _item.roles[_role].users | default(omit) }}"
+      {% endfor %}
+      {% endif %}
+      {% endfor %}
 ...

--- a/roles/controller_settings/README.md
+++ b/roles/controller_settings/README.md
@@ -61,7 +61,7 @@ There are two choices for entering settings. Either provide as a single dict und
 |`settings`|{}|no|Dict of key-value pairs of settings|
 |`name`|""|no|Name of the setting to set.|
 |`value`|""|no|Value of the setting.|
-|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
+|`register`|""|no|Variable to set based on the result of the object creation/modification|
 
 ### Standard Setting Data Structure - as a dict
 

--- a/roles/controller_workflow_job_templates/README.md
+++ b/roles/controller_workflow_job_templates/README.md
@@ -105,6 +105,25 @@ This also speeds up the overall role.
 |`survey`|""|no|dict|JSON/YAML dict formatted survey definition. Alias of survey_spec|
 |`webhook_service`|""|no|str|Service that webhook requests will be accepted from (github, gitlab)|
 |`webhook_credential`|""|no|str|Personal Access Token for posting back the status to the service API|
+|`roles`|""|no|obj|Controller roles to apply to the workflow job template. See roles section below for how to apply.|
+
+#### Applying roles to users or teams
+
+You can apply roles to users or teams using the `roles` field. This is applied as a dictionary as follows:
+
+```yaml
+- name: my_wjt
+  roles:
+    execute:
+      teams:
+        - myteam1
+        - myteam2
+    admin:
+      users:
+        - sysadmin1
+    approve:
+      users: manager1
+```
 
 ### Variables For Workflow Job Template Node
 

--- a/roles/controller_workflow_job_templates/tasks/main.yml
+++ b/roles/controller_workflow_job_templates/tasks/main.yml
@@ -114,4 +114,23 @@
       loop_control:
         loop_var: __workflows_job_async_results_item
         label: "Cleaning up job results file: {{ __workflows_job_async_results_item.results_file | default('Unknown') }}"
+
+- name: Add roles to job templates
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.controller_roles
+  vars:
+    controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
+    _item_list: "{{ workflow_job_templates if workflow_job_templates is defined else controller_workflows }}"
+    _controller_roles: |
+      {% for _item in _item_list %}
+      {% if _item.roles is defined %}
+      {% for _role in _item.roles.keys() %}
+      - role: "{{ _role }}"
+        workflows:
+          - "{{ _item.name }}"
+        teams: "{{ _item.roles[_role].teams | default(omit) }}"
+        users: "{{ _item.roles[_role].users | default(omit) }}"
+      {% endfor %}
+      {% endif %}
+      {% endfor %}
 ...

--- a/roles/gateway_applications/README.md
+++ b/roles/gateway_applications/README.md
@@ -87,7 +87,6 @@ Options for the `aap_applications` variable:
 | `state`                     |      `present`      |    no    | str  | Desired state of the application.                                                      |
 |`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
-
 ### Standard Application Data Structure
 
 #### Json Example


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
We discussed this *ages* ago. This gives the user the ability to define the roles for a JT/WJT/inv/proj/IG/cred directly on the object.

I'm not completely set the the data structure and open to changing it depending on what we think is the most usable structure.

# How should this be tested?
```
---
- name: Create JT with roles
  hosts: localhost
  vars:
    aap_teams:
      - name: team1
        organization: Default
    controller_templates:
      - name: myjt1
        project: Demo Project
        playbook: install_product_demos.yml
        inventory: Demo Inventory
        roles:
          execute:
            teams:
              - team1
      - name: myjt2
        project: Demo Project
        playbook: install_product_demos.yml
        inventory: Demo Inventory
        roles:
          execute:
            teams:
              - team1

  roles:
    - infra.aap_configuration.gateway_teams
    - infra.aap_configuration.controller_job_templates
...
```

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #1040 

