### PR TITLE
Adds ability to set a var to register values for each item, or as a whole

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,58 @@ fatal: [localhost]: FAILED! => {
 }
 ```
 
+### Registering values
+
+As of version 4.0.0 of this collection, you can now collect information from the items which are created or modified by this collection. You can either add `register: <var>` to any item which is created to capture the outputs of that item, or set a value for `aap_configuration_register` which will capture all objects created. This fuinctionality may be particularly useful for capturing IDs of objects to enable performing further actions.
+
+Below is an example for adding a register to a signle item:
+
+```yaml
+controller_templates:
+  - name: myjt1
+    project: Demo Project
+    playbook: install_product_demos.yml
+    inventory: Demo Inventory
+    register: register_var
+```
+
+The resulting varaible from setting `aap_configuration_register` will be as follows:
+
+```json
+"aap_register_var": {
+        "job_templates": [
+            {
+                "ansible_job_id": "j994617402834.25953",
+                "attempts": 4,
+                "changed": false,
+                "failed": false,
+                "finished": 1,
+                "id": 11,
+                "results_file": "/Users/tpage/.ansible_async/j994617402834.25953",
+                "started": 1,
+                "stderr": "",
+                "stderr_lines": [],
+                "stdout": "",
+                "stdout_lines": []
+            },
+            {
+                "ansible_job_id": "j666467675004.25976",
+                "attempts": 1,
+                "changed": false,
+                "failed": false,
+                "finished": 1,
+                "id": 12,
+                "results_file": "/Users/tpage/.ansible_async/j666467675004.25976",
+                "started": 1,
+                "stderr": "",
+                "stderr_lines": [],
+                "stdout": "",
+                "stdout_lines": []
+            }
+        ]
+    }
+```
+
 ### Automate the Automation
 
 Every Ansible Controller instance has it's own particularities and needs. Every administrator team has it's own practices and customs. This collection allows adaptation to every need, from small to large scale, having the objects distributed across multiple environments and leveraging Automation Webhook that can be used to link a Git repository and Ansible automation natively.

--- a/changelogs/fragments/register_values.yml
+++ b/changelogs/fragments/register_values.yml
@@ -1,0 +1,4 @@
+---
+major_changes:
+  - Adds ability to set a var to register values for each item, or as a whole by setting `aap_configuration_register`.
+...

--- a/roles/collect_async_status/README.md
+++ b/roles/collect_async_status/README.md
@@ -12,6 +12,7 @@ This is an internal role that is not meant to be called directly by users of thi
 |:---|:---:|:---:|:---|
 |`cas_job_async_results_item`||yes|The asynchronous item to check the status of. This must be from the registered `async` task|
 |`cas_error_list_var_name`||yes|The name of the dictionary key to use when collecting errors|
+|`cas_register_subvar`||yes|The name of the dictionary key to use when registering values|
 |`aap_configuration_collect_logs`|`false`|no|When enabled collects error messages and continues execution. Messages are collected in a variable called `aap_configuration_role_errors`|
 
 ### Secure Logging Variables

--- a/roles/collect_async_status/tasks/main.yml
+++ b/roles/collect_async_status/tasks/main.yml
@@ -11,6 +11,16 @@
       delay: "{{ cas_async_delay }}"
       ignore_errors: true
 
+    - name: Register value
+      when: aap_configuration_register is defined or _register_var is defined
+      vars:
+        _register_var: "{{ cas_job_async_results_item[cas_job_async_results_item.ansible_loop_var]['register'] | default('_') }}"
+        _register_value: "{{ lookup('vars', aap_configuration_register | default('_'), default={}) }}"
+        _appended_value: "{{ _register_value[cas_register_subvar] | default([]) + [__cas_job_async_result] }}"
+      ansible.builtin.set_fact:
+        "{{ _register_var }}": "{{ __cas_job_async_result }}"
+        "{{ aap_configuration_register | default('_') }}": "{{ _register_value | combine({cas_register_subvar: _appended_value}) }}"
+
     - name: Handle Async Job Failure
       when: __cas_job_async_result is failed
       ansible.builtin.include_tasks:

--- a/roles/controller_applications/README.md
+++ b/roles/controller_applications/README.md
@@ -20,6 +20,8 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
+
 |`aap_applications`|`see below`|yes|Data structure describing your applications, described below. Alias: applications ||
 
 ### Enforcing defaults
@@ -82,6 +84,7 @@ This also speeds up the overall role.
 |`redirect_uris`|""|no|str|Allowed urls list, space separated. Required with "authorization-code" grant type|
 |`skip_authorization`|"false"|yes|bool|Set true to skip authorization step for completely trusted applications.|
 |`state`|`present`|no|str|Desired state of the application.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Application Data Structure
 

--- a/roles/controller_applications/tasks/main.yml
+++ b/roles/controller_applications/tasks/main.yml
@@ -57,6 +57,7 @@
         cas_async_delay: "{{ controller_configuration_applications_async_delay }}"
         cas_async_retries: "{{ controller_configuration_applications_async_retries }}"
         cas_job_async_results_item: "{{ __applications_job_async_results_item }}"
+        cas_register_subvar: controller_applications
         cas_error_list_var_name: "controller_applications_errors"
         __operation: "{{ operation_translate[__applications_job_async_results_item.__application_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Controller Application {{ __applications_job_async_results_item.__application_item.name }} | Wait for finish the Application {{ __operation.action }}"

--- a/roles/controller_bulk_host_create/README.md
+++ b/roles/controller_bulk_host_create/README.md
@@ -19,6 +19,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`controller_oauthtoken`|""|no|Controller Admin User's token on the Ansible Controller Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`controller_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_bulk_hosts`|`see below`|yes|Data structure describing the hosts to bulk create Described below.||
 
 ### Secure Logging Variables
@@ -58,6 +59,7 @@ This also speeds up the overall role.
 |:---:|:---:|:---:|:---:|:---:|
 |`hosts`|""|yes|list|List of hosts and host options to add to inventory. Documented below|
 |`inventory`|""|yes|str|Inventory name or ID the hosts should be made a member of.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Bulk Host Sub Options
 

--- a/roles/controller_bulk_host_create/tasks/main.yml
+++ b/roles/controller_bulk_host_create/tasks/main.yml
@@ -45,6 +45,7 @@
         cas_async_delay: "{{ controller_configuration_bulk_hosts_async_delay }}"
         cas_async_retries: "{{ controller_configuration_bulk_hosts_async_retries }}"
         cas_job_async_results_item: "{{ __controller_bulk_hosts_job_async_results_item }}"
+        cas_register_subvar: controller_bulk_hosts
         cas_error_list_var_name: "controller_bulk_hosts_errors"
         cas_object_label: "Waiting for bulk host creation in inventory {{ __controller_bulk_hosts_job_async_results_item.__controller_bulk_hosts_item.inventory }} to complete"
 

--- a/roles/controller_credential_input_sources/README.md
+++ b/roles/controller_credential_input_sources/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_credential_input_sources`|`see below`|yes|Data structure describing your credential input sources Described below.||
 
 ### Enforcing defaults
@@ -79,6 +80,7 @@ This also speeds up the overall role.
 |`metadata`|""|no|dict|The metadata applied to the source.|
 |`description`|""|no|str|Description to use for the credential input source.|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 For further details on fields see <https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.6/html/configuring_automation_execution/assembly-controller-secret-management>. The input accepted by the `metadata` field will differ depending on the credential plugin being used.
 

--- a/roles/controller_credential_input_sources/tasks/main.yml
+++ b/roles/controller_credential_input_sources/tasks/main.yml
@@ -52,6 +52,7 @@
         cas_async_delay: "{{ controller_configuration_credential_input_sources_async_delay }}"
         cas_async_retries: "{{ controller_configuration_credential_input_sources_async_retries }}"
         cas_job_async_results_item: "{{ __credential_input_sources_job_async_results_item }}"
+        cas_register_subvar: controller_credential_input_sources
         cas_error_list_var_name: "controller_credential_input_sources_errors"
         __operation: "{{ operation_translate[__credential_input_sources_job_async_results_item.__cred_input_src_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Controller Credential Input Source for Credential {{ __credential_input_sources_job_async_results_item.__cred_input_src_item.target_credential }}"

--- a/roles/controller_credential_types/README.md
+++ b/roles/controller_credential_types/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_credential_types`|`see below`|yes|Data structure describing your credential types Described below. Alias: credential_types ||
 
 ### Enforcing defaults
@@ -80,6 +81,7 @@ This also speeds up the overall role.
 |`inputs`|""|no|Enter inputs using either JSON or YAML syntax. Refer to the Ansible controller documentation for example syntax.|
 |`kind`|"cloud"|no|The type of credential type being added. Note that only cloud and net can be used for creating credential types.|
 |`state`|`present`|no|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Formatting Injectors
 

--- a/roles/controller_credential_types/tasks/main.yml
+++ b/roles/controller_credential_types/tasks/main.yml
@@ -53,6 +53,7 @@
         cas_async_delay: "{{ controller_configuration_credential_types_async_delay }}"
         cas_async_retries: "{{ controller_configuration_credential_types_async_retries }}"
         cas_job_async_results_item: "{{ __credentialtypes_job_async_result_item }}"
+        cas_register_subvar: controller_credential_types
         cas_error_list_var_name: "controller_credential_types_errors"
         __operation: "{{ operation_translate[__credentialtypes_job_async_result_item.__controller_credential_type_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Controller Credential Type {{ __credentialtypes_job_async_result_item.__controller_credential_type_item.name }} | Wait for finish the credential type {{ __operation.action }}"

--- a/roles/controller_credentials/README.md
+++ b/roles/controller_credentials/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_credentials`|`see below`|yes|Data structure describing your credentials Described below. Alias: credentials ||
 
 ### Enforcing defaults
@@ -83,6 +84,7 @@ This also speeds up the overall role.
 |`user`|""|no|User that should own this credential. If provided, do not give either team or organization. |
 |`team`|""|no|Team that should own this credential. If provided, do not give either user or organization. |
 |`state`|`present`|no|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 |`update_secrets`|true|no| true will always change password if user specifies password, even if API gives $encrypted$ for password. false will only set the password if other values change too.|
 
 ### Credential types

--- a/roles/controller_credentials/tasks/main.yml
+++ b/roles/controller_credentials/tasks/main.yml
@@ -57,6 +57,7 @@
         cas_async_delay: "{{ controller_configuration_credentials_async_delay }}"
         cas_async_retries: "{{ controller_configuration_credentials_async_retries }}"
         cas_job_async_results_item: "{{ __credentials_job_async_results_item }}"
+        cas_register_subvar: controller_credentials
         cas_error_list_var_name: "controller_credentials_errors"
         __operation: "{{ operation_translate[__credentials_job_async_results_item.__controller_credentials_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Credential {{ __credentials_job_async_results_item.__controller_credentials_item.name }} | Wait for finish the credential {{ __operation.action }}"

--- a/roles/controller_execution_environments/README.md
+++ b/roles/controller_execution_environments/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_execution_environments`|`see below`|yes|Data structure describing your execution environments Described below. Alias: execution_environments ||
 
 ### Enforcing defaults
@@ -81,6 +82,7 @@ This also speeds up the overall role.
 |`credential`|""|no|str|Name of the credential to use for the execution environment.|
 |`pull`|"missing"|no|choice("always", "missing", "never")|Determine image pull behavior|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Execution Environment Data Structure
 

--- a/roles/controller_execution_environments/tasks/main.yml
+++ b/roles/controller_execution_environments/tasks/main.yml
@@ -58,6 +58,7 @@
         cas_async_delay: "{{ controller_configuration_execution_environments_async_delay }}"
         cas_async_retries: "{{ controller_configuration_execution_environments_async_retries }}"
         cas_job_async_results_item: "{{ __execution_environments_job_async_results_item }}"
+        cas_register_subvar: controller_execution_environments
         cas_error_list_var_name: "controller_execution_environments_errors"
         __operation: "{{ operation_translate[__execution_environments_job_async_results_item.__execution_environments_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Controller Execution Environment {{ __execution_environments_job_async_results_item.__execution_environments_item.name }} | Wait for finish the Controller Execution Environment {{ __operation.action }}"

--- a/roles/controller_host_groups/README.md
+++ b/roles/controller_host_groups/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_groups`|`see below`|yes|Data structure describing your group or groups Described below.||
 
 ### Enforcing defaults
@@ -103,6 +104,7 @@ The role will strip the double space between the curly bracket in order to provi
 |`preserve_existing_hosts`|`false`|no|bool|Whether to preserve existing hosts in an existing group|
 |`preserve_existing_children`|`false`|no|bool|Whether to preserve existing children in an existing group|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Group Data Structure
 

--- a/roles/controller_host_groups/tasks/main.yml
+++ b/roles/controller_host_groups/tasks/main.yml
@@ -56,6 +56,7 @@
         cas_async_delay: "{{ controller_configuration_group_async_delay }}"
         cas_async_retries: "{{ controller_configuration_group_async_retries }}"
         cas_job_async_results_item: "{{ __group_job_async_results_item }}"
+        cas_register_subvar: controller_host_groups
         cas_error_list_var_name: "controller_host_groups_errors"
         __operation: "{{ operation_translate[__group_job_async_results_item.__controller_groups_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Controller Group {{ __group_job_async_results_item.__controller_groups_item.name }} | Wait for finish the Controller Group {{ __operation.action }}"

--- a/roles/controller_hosts/README.md
+++ b/roles/controller_hosts/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_hosts`|`see below`|yes|Data structure describing your host entries described below.||
 
 ### Enforcing defaults
@@ -100,6 +101,7 @@ The role will strip the double space between the curly bracket in order to provi
 |`enabled`||no|bool|If the host should be enabled.|
 |`variables`|{}|no|str|The variables applicable to the host.|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Host Data Structure
 

--- a/roles/controller_hosts/tasks/main.yml
+++ b/roles/controller_hosts/tasks/main.yml
@@ -53,6 +53,7 @@
         cas_async_delay: "{{ controller_configuration_hosts_async_delay }}"
         cas_async_retries: "{{ controller_configuration_hosts_async_retries }}"
         cas_job_async_results_item: "{{ __host_job_async_results_item }}"
+        cas_register_subvar: controller_hosts
         cas_error_list_var_name: "controller_hosts_errors"
         __operation: "{{ operation_translate[__host_job_async_results_item.__controller_host_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Controller Host {{ __host_job_async_results_item.__controller_host_item.name }} | Wait for finish the Hosts {{ __operation.action }}"

--- a/roles/controller_instance_groups/README.md
+++ b/roles/controller_instance_groups/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_instance_groups`|`see below`|yes|Data structure describing your instance groups Described below.||
 
 ### Enforcing defaults
@@ -85,6 +86,7 @@ This also speeds up the overall role.
 |`pod_spec_override`|""|no|str|A custom Kubernetes or OpenShift Pod specification.|
 |`instances`|""|no|list|The instances associated with this instance_group.|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Instance Group Data Structure
 

--- a/roles/controller_instance_groups/tasks/main.yml
+++ b/roles/controller_instance_groups/tasks/main.yml
@@ -60,6 +60,7 @@
         cas_async_delay: "{{ controller_configuration_instance_groups_async_delay }}"
         cas_async_retries: "{{ controller_configuration_instance_groups_async_retries }}"
         cas_job_async_results_item: "{{ __instance_groups_job_async_results_item }}"
+        cas_register_subvar: controller_instance_groups
         cas_error_list_var_name: "controller_instance_groups_errors"
         __operation: "{{ operation_translate[__instance_groups_job_async_results_item.__controller_instance_group_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Controller instance group {{ __instance_groups_job_async_results_item.__controller_instance_group_item.name }} | Wait for finish the instance groups {{ __operation.action }}"

--- a/roles/controller_instances/README.md
+++ b/roles/controller_instances/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_instances`|`see below`|yes|Data structure describing your instances Described below.||
 
 ### Enforcing defaults
@@ -82,6 +83,7 @@ This also speeds up the overall role.
 |`listener_port`|""|no|int|Port that Receptor will listen for incoming connections on.|
 |`peers`|[]|no|list|List of peers to connect outbound to. Only configurable for hop and execution nodes.|
 |`peers_from_control_nodes`|false|no|bool|If enabled, control plane nodes will automatically peer to this node.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Instance Data Structure
 

--- a/roles/controller_instances/tasks/main.yml
+++ b/roles/controller_instances/tasks/main.yml
@@ -54,6 +54,7 @@
         cas_async_delay: "{{ controller_configuration_instances_async_delay }}"
         cas_async_retries: "{{ controller_configuration_instances_async_retries }}"
         cas_job_async_results_item: "{{ __instance_job_async_results_item }}"
+        cas_register_subvar: controller_instances
         cas_error_list_var_name: "controller_instances_errors"
         cas_object_label: "Waiting for Controller Instance {{ __instance_job_async_results_item.__controller_instance_item.hostname }} to be configured"
 

--- a/roles/controller_inventories/README.md
+++ b/roles/controller_inventories/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_inventories`|`see below`|yes|Data structure describing your inventories described below. Alias: inventory ||
 
 ### Enforcing defaults
@@ -105,6 +106,7 @@ The role will strip the double space between the curly bracket in order to provi
 |`host_filter`|""|no|str|The host filter field, useful only when 'kind=smart'|
 |`prevent_instance_group_fallback`|`false`|no|bool|Prevent falling back to instance groups set on the organization|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Inventory Data Structure
 

--- a/roles/controller_inventories/tasks/main.yml
+++ b/roles/controller_inventories/tasks/main.yml
@@ -59,6 +59,7 @@
         cas_async_delay: "{{ controller_configuration_inventories_async_delay }}"
         cas_async_retries: "{{ controller_configuration_inventories_async_retries }}"
         cas_job_async_results_item: "{{ __inventories_job_async_result_item }}"
+        cas_register_subvar: controller_inventories
         cas_error_list_var_name: "controller_inventories_errors"
         __operation: "{{ operation_translate[__inventories_job_async_result_item.__controller_inventory_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Controller inventory {{ __inventories_job_async_result_item.__controller_inventory_item.name }} | Wait for finish the inventories {{ __operation.action }}"

--- a/roles/controller_inventory_source_update/README.md
+++ b/roles/controller_inventory_source_update/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_inventory_sources`|`see below`|yes|Data structure describing controller inventory sources to update Described below. Alias: inventory_sources ||
 
 ### Secure Logging Variables
@@ -63,6 +64,7 @@ This also speeds up the overall role.
 |`wait`|""|no|bool|Wait for the job to complete.|
 |`interval`|`controller_configuration_inventory_source_update_async_delay`|no|int|The interval to request an update from controller.|
 |`timeout`|""|no|int|If waiting for the job to complete this will abort after this amount of seconds.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Inventory Source Update Data Structure
 

--- a/roles/controller_inventory_source_update/tasks/main.yml
+++ b/roles/controller_inventory_source_update/tasks/main.yml
@@ -53,6 +53,7 @@
         cas_async_delay: "{{ controller_configuration_inventory_source_update_async_delay }}"
         cas_async_retries: "{{ controller_configuration_inventory_source_update_async_retries }}"
         cas_job_async_results_item: "{{ __inventory_source_update_async_results_item }}"
+        cas_register_subvar: controller_inventory_source_update
         cas_error_list_var_name: "controller_inventory_source_update_errors"
         cas_object_label: "Waiting for Controller Inventory Source {{ __inventory_source_update_async_results_item.__inventory_source_update_item.name }} to update"
 

--- a/roles/controller_inventory_sources/README.md
+++ b/roles/controller_inventory_sources/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_inventory_sources`|`see below`|yes|Data structure describing your inventory sources Described below. Alias: inventory_sources ||
 
 ### Enforcing defaults
@@ -117,6 +118,7 @@ The role will strip the double space between the curly bracket in order to provi
 |`source_project`|""|no|Project to use as source with scm option.|
 |`scm_branch`|""|no|Project scm branch to use as source with scm option. Project must have branch override enabled.|
 |`state`|`present`|no|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 |`notification_templates_started`|""|no|The notifications on started to use for this inventory source in a list.|
 |`notification_templates_success`|""|no|The notifications on success to use for this inventory source in a list.|
 |`notification_templates_error`|""|no|The notifications on error to use for this inventory source in a list.|

--- a/roles/controller_inventory_sources/tasks/main.yml
+++ b/roles/controller_inventory_sources/tasks/main.yml
@@ -74,6 +74,7 @@
         cas_async_delay: "{{ controller_configuration_inventory_sources_async_delay }}"
         cas_async_retries: "{{ controller_configuration_inventory_sources_async_retries }}"
         cas_job_async_results_item: "{{ __inventory_source_job_async_results_item }}"
+        cas_register_subvar: controller_inventory_sources
         cas_error_list_var_name: "controller_inventory_sources_errors"
         __operation: "{{ operation_translate[__inventory_source_job_async_results_item.__controller_source_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Inventory Source {{ __inventory_source_job_async_results_item.__controller_source_item.name }} | Wait for finish the Inventory Source {{ __operation.action }}"

--- a/roles/controller_job_templates/README.md
+++ b/roles/controller_job_templates/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_templates`|`see below`|yes|Data structure describing your job template or job templates Described below. Alias: job_templates ||
 
 ### Enforcing defaults
@@ -129,6 +130,7 @@ This also speeds up the overall role.
 |`notification_templates_success`|""|no|list|The notifications on success to use for this organization in a list.|
 |`notification_templates_error`|""|no|list|The notifications on error to use for this organization in a list.|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Surveys
 

--- a/roles/controller_job_templates/tasks/main.yml
+++ b/roles/controller_job_templates/tasks/main.yml
@@ -101,6 +101,7 @@
         cas_async_delay: "{{ controller_configuration_job_templates_async_delay }}"
         cas_async_retries: "{{ controller_configuration_job_templates_async_retries }}"
         cas_job_async_results_item: "{{ __job_templates_job_async_result_item }}"
+        cas_register_subvar: controller_job_templates
         cas_error_list_var_name: "controller_job_templates_errors"
         __operation: "{{ operation_translate[__job_templates_job_async_result_item.__controller_template_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Job Template {{ __job_templates_job_async_result_item.__controller_template_item.name }} | Wait for finish the Job Template {{ __operation.action }}"

--- a/roles/controller_labels/README.md
+++ b/roles/controller_labels/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_labels`|`see below`|yes|Data structure describing your label or labels Described below.||
 
 ### Secure Logging Variables
@@ -61,6 +62,7 @@ This also speeds up the overall role.
 |`new_name`|""|no|str|Setting this option will change the existing name (looked up via the name field).|
 |`organization`|`false`|yes|str|Organization this label belongs to.|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Label Data Structure
 

--- a/roles/controller_labels/tasks/main.yml
+++ b/roles/controller_labels/tasks/main.yml
@@ -50,6 +50,7 @@
         cas_async_delay: "{{ controller_configuration_labels_async_delay }}"
         cas_async_retries: "{{ controller_configuration_labels_async_retries }}"
         cas_job_async_results_item: "{{ __controller_label_job_async_results_item }}"
+        cas_register_subvar: controller_labels
         cas_error_list_var_name: "controller_labels_errors"
         __operation: "{{ operation_translate[__controller_label_job_async_results_item.__controller_label_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Label {{ __controller_label_job_async_results_item.__controller_label_item.name }} | Wait for finish the Label {{ __operation.action }}"

--- a/roles/controller_notification_templates/README.md
+++ b/roles/controller_notification_templates/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_notifications`|`see below`|yes|Data structure describing your notification entries described below. Alias: notification_templates ||
 
 ### Enforcing defaults
@@ -82,6 +83,7 @@ This also speeds up the overall role.
 |`notification_configuration`|""|no|str|The notification configuration file. Note providing this field would disable all depreciated notification-configuration-related fields.|
 |`messages`|""|no|list|Optional custom messages for notification template. Assumes any instance of two space __ are used for adding variables and removes them. Does not effect single space.|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Notification Data Structure
 

--- a/roles/controller_notification_templates/tasks/main.yml
+++ b/roles/controller_notification_templates/tasks/main.yml
@@ -56,6 +56,7 @@
         cas_async_delay: "{{ controller_configuration_notifications_async_delay }}"
         cas_async_retries: "{{ controller_configuration_notifications_async_retries }}"
         cas_job_async_results_item: "{{ __controller_notification_job_async_results_item }}"
+        cas_register_subvar: controller_notification_templates
         cas_error_list_var_name: "controller_notification_templates_errors"
         __operation: "{{ operation_translate[__controller_notification_job_async_results_item.__controller_notification_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} notification {{ __controller_notification_job_async_results_item.__controller_notification_item.name }} | Wait for finish the notifications {{ __operation.action }}"

--- a/roles/controller_organizations/README.md
+++ b/roles/controller_organizations/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`aap_organizations`|`see below`|yes|Data structure describing your organization or organizations Described below. Alias: organizations ||
 |`assign_galaxy_credentials_to_org`|`true`|no|Boolean to indicate whether credentials should be assigned or not. It should be noted that credentials must exist before adding it. The dispatch role will set this to `false`, before re-running the role with it set to `true`. ||
 |`assign_default_ee_to_org`|`true`|no|Boolean to indicate whether default execution environment should be assigned or not. It should be noted that execution environment must exist before adding it. The dispatch role will set this to `false`, before re-running the role with it set to `true`. ||
@@ -92,6 +93,7 @@ This role accepts two data models. A simple straightforward easy to maintain mod
 |`notification_templates_error`|""|no|list|The notifications on error to use for this organization in a list.|
 |`notification_templates_approvals`|""|no|list|The notifications for approval to use for this organization in a list.|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Organization Data Structure model
 

--- a/roles/controller_organizations/tasks/main.yml
+++ b/roles/controller_organizations/tasks/main.yml
@@ -60,6 +60,7 @@
         cas_async_delay: "{{ controller_configuration_organizations_async_delay }}"
         cas_async_retries: "{{ controller_configuration_organizations_async_retries }}"
         cas_job_async_results_item: "{{ __organizations_job_async_results_item }}"
+        cas_register_subvar: controller_organizations
         cas_error_list_var_name: "controller_organizations_errors"
         __operation: "{{ operation_translate[__organizations_job_async_results_item.__controller_organizations_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Controller Organization {{ __organizations_job_async_results_item.__controller_organizations_item.name }} | Wait for finish the organization {{ __operation.action }}"

--- a/roles/controller_project_update/README.md
+++ b/roles/controller_project_update/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_projects`|`see below`|yes|Data structure describing the project to update Described below. Alias: projects ||
 
 ### Secure Logging Variables
@@ -63,6 +64,7 @@ This also speeds up the overall role.
 |`interval`|`controller_configuration_project_update_async_delay`|no|str|The interval to request an update from controller.|
 |`timeout`|""|no|str|If waiting for the job to complete this will abort after this amount of seconds.|
 |`update_project`|`false`|no|bool|If defined and true, the project update will be executed, otherwise it won't.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Project Update Data Structure
 

--- a/roles/controller_project_update/tasks/main.yml
+++ b/roles/controller_project_update/tasks/main.yml
@@ -53,6 +53,7 @@
         cas_async_delay: "{{ controller_configuration_project_update_async_delay }}"
         cas_async_retries: "{{ controller_configuration_project_update_async_retries }}"
         cas_job_async_results_item: "{{ __project_update_job_async_results_item }}"
+        cas_register_subvar: controller_project_update
         cas_error_list_var_name: "controller_project_update_errors"
         cas_object_label: "Waiting for Controller Project {{ __project_update_job_async_results_item.__project_update_update_item.name }} to update"
 

--- a/roles/controller_projects/README.md
+++ b/roles/controller_projects/README.md
@@ -98,6 +98,7 @@ This also speeds up the overall role.
 |`notification_templates_success`|""|no|list|The notifications on success to use for this organization in a list.|
 |`notification_templates_error`|""|no|list|The notifications on error to use for this organization in a list.|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 |`wait`|""|no|bool|Provides option to wait for completed project sync before returning.|
 |`update_project`|`false`|no|bool|Force project to update after changes.Used in conjunction with wait, interval, and timeout.|
 |`interval`|`controller_configuration_projects_async_delay`|no|float|The interval to request an update from controller. Requires wait.|

--- a/roles/controller_projects/tasks/main.yml
+++ b/roles/controller_projects/tasks/main.yml
@@ -74,6 +74,7 @@
         cas_async_delay: "{{ controller_configuration_projects_async_delay }}"
         cas_async_retries: "{{ controller_configuration_projects_async_retries }}"
         cas_job_async_results_item: "{{ __projects_job_async_results_item }}"
+        cas_register_subvar: controller_projects
         cas_error_list_var_name: "controller_projects_errors"
         __operation: "{{ operation_translate[__projects_job_async_results_item.__controller_project_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Project {{ __projects_job_async_results_item.__controller_project_item.name }} | Wait for finish the project {{ __operation.action }}"

--- a/roles/controller_roles/README.md
+++ b/roles/controller_roles/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_roles`|`see below`|yes|Data structure describing your RBAC entries described below.||
 
 ### Enforcing defaults
@@ -96,6 +97,7 @@ This also speeds up the overall role.
 |`projects`|""|no|list|The project the role applies against|
 |`instance_groups`|""|no|list|The instance groups the role applies against|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 #### Role
 

--- a/roles/controller_roles/tasks/main.yml
+++ b/roles/controller_roles/tasks/main.yml
@@ -68,6 +68,7 @@
         cas_async_delay: "{{ controller_configuration_role_async_delay }}"
         cas_async_retries: "{{ controller_configuration_role_async_retries }}"
         cas_job_async_results_item: "{{ __controller_role_job_async_results_item }}"
+        cas_register_subvar: controller_roles
         cas_error_list_var_name: "controller_roles_errors"
         __operation: "{{ operation_translate[__controller_role_job_async_results_item.__controller_role_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Role {{ __controller_role_job_async_results_item.__controller_role_item.1 | default(__controller_role_job_async_results_item.__controller_role_item.role) }} | Wait for finish the Roles {{ __operation.action }}"

--- a/roles/controller_schedules/README.md
+++ b/roles/controller_schedules/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_schedules`|`see below`|yes|Data structure describing your schedule or schedules Described below. Alias: schedules ||
 
 ### Enforcing defaults
@@ -97,6 +98,7 @@ This also speeds up the overall role.
 |`organization`|""|no|str|The organization the unified job template exists in. Used for looking up the unified job template, not a direct model field.|
 |`enabled`|`true`|no|bool|Enabled processing of this job template|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Schedule Data Structure
 

--- a/roles/controller_schedules/tasks/main.yml
+++ b/roles/controller_schedules/tasks/main.yml
@@ -71,6 +71,7 @@
         cas_async_delay: "{{ controller_configuration_schedules_async_delay }}"
         cas_async_retries: "{{ controller_configuration_schedules_async_retries }}"
         cas_job_async_results_item: "{{ __controller_schedule_job_async_results_item }}"
+        cas_register_subvar: controller_schedules
         cas_error_list_var_name: "controller_schedules_errors"
         __operation: "{{ operation_translate[__controller_schedule_job_async_results_item.__controller_schedule_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Schedule {{ __controller_schedule_job_async_results_item.__controller_schedule_item.name }} | Wait for finish the Schedules {{ __operation.action }}"

--- a/roles/controller_settings/README.md
+++ b/roles/controller_settings/README.md
@@ -18,6 +18,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_settings`|`see below`|yes|Data structure describing your settings described below.||
 
 ### Secure Logging Variables
@@ -60,6 +61,7 @@ There are two choices for entering settings. Either provide as a single dict und
 |`settings`|{}|no|Dict of key-value pairs of settings|
 |`name`|""|no|Name of the setting to set.|
 |`value`|""|no|Value of the setting.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Setting Data Structure - as a dict
 

--- a/roles/controller_settings/tasks/main.yml
+++ b/roles/controller_settings/tasks/main.yml
@@ -48,6 +48,7 @@
         cas_async_delay: "{{ controller_configuration_settings_async_delay }}"
         cas_async_retries: "{{ controller_configuration_settings_async_retries }}"
         cas_job_async_results_item: "{{ __controller_setting_job_async_results_item }}"
+        cas_register_subvar: controller_settings
         cas_error_list_var_name: "controller_settings_errors"
         cas_object_label: "Waiting for Controller Setting to be configured"
 

--- a/roles/controller_teams/README.md
+++ b/roles/controller_teams/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`aap_teams`|`see below`|yes|Data structure describing your Teams described below. Alias: teams ||
 
 ### Enforcing defaults
@@ -76,6 +77,7 @@ This also speeds up the overall role.
 |`description`|omitted|no|str|The team description|
 |`organization`||yes|str|The organization in which team will be created|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ## Playbook Examples
 

--- a/roles/controller_teams/tasks/main.yml
+++ b/roles/controller_teams/tasks/main.yml
@@ -51,6 +51,7 @@
         cas_async_delay: "{{ controller_configuration_platform_teams_async_delay }}"
         cas_async_retries: "{{ controller_configuration_platform_teams_async_retries }}"
         cas_job_async_results_item: "{{ __controller_team_job_async_results_item }}"
+        cas_register_subvar: controller_teams
         cas_error_list_var_name: "controller_teams_errors"
         __operation: "{{ operation_translate[__controller_team_job_asycn_results_item.__controller_team_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Teams | Wait for finish the Teams {{ __operation.action }}"

--- a/roles/controller_users/README.md
+++ b/roles/controller_users/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`aap_user_accounts`|`see below`|yes|Data structure describing your user entries described below.  Alias: users ||
 |`controller_user_default_password`|""|no|Global variable to set the password for all users.||
 
@@ -84,6 +85,7 @@ This also speeds up the overall role.
 |`is_system_auditor`|false|no|bool|Whether the user is an auditor|
 |`organization`|""|no|str|The name of the organization the user belongs to.<br />Added in awx.awx >= 20.0.0 DOES NOT exist in ansible.controller yet.|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 |`update_secrets`|true|no|bool| true will always change password if user specifies password, even if API gives $encrypted$ for password. false will only set the password if other values change too.|
 
 ### Standard User Data Structure

--- a/roles/controller_users/tasks/main.yml
+++ b/roles/controller_users/tasks/main.yml
@@ -58,6 +58,7 @@
         cas_async_delay: "{{ controller_configuration_users_async_delay }}"
         cas_async_retries: "{{ controller_configuration_users_async_retries }}"
         cas_job_async_results_item: "{{ __controller_user_accounts_job_async_results_item }}"
+        cas_register_subvar: controller_users
         cas_error_list_var_name: "controller_users_errors"
         __operation: "{{ operation_translate[__controller_user_accounts_job_async_results_item.__controller_user_accounts_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} User {{ __controller_user_accounts_job_async_results_item.__controller_user_accounts_item.user | default(__controller_user_accounts_job_async_results_item.__controller_user_accounts_item.username) }} | Wait for finish the Users {{ __operation.action }}"

--- a/roles/controller_workflow_job_templates/README.md
+++ b/roles/controller_workflow_job_templates/README.md
@@ -20,6 +20,7 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`controller_workflows`|`see below`|yes|Data structure describing your workflow job templates described below. Alias: workflow_job_templates ||
 
 ### Enforcing defaults
@@ -98,6 +99,7 @@ This also speeds up the overall role.
 |`notification_templates_success`|""|no|list|The notifications on success to use for this organization in a list.|
 |`scm_branch`|""|no|str|SCM branch applied as a prompt, assuming job template prompts for SCM branch|
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 |`workflow_nodes`|""|no|dict|A json list of nodes and their corresponding options. The sub-options are in the module doc.|
 |`destroy_current_nodes`|""|no|bool|Set in order to destroy current schema on the workflow, used in cases where drastic changes to schema are happening.|
 |`survey_enabled`|""|no|bool|Enable a survey on the job template.|
@@ -128,6 +130,7 @@ This also speeds up the overall role.
 |`success_nodes`|""|no|list|Nodes that will run after this node completes.|
 |`verbosity`|""|no|str|Verbosity applied as a prompt, if job template prompts for verbosity|
 |`state`|""|no|str|Desired state of the resource|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 |`credentials`|""|no|list|Credentials to be applied to job as launch-time prompts.|
 |`diff_mode`|""|no|bool|Run diff mode, applied as a prompt, if job template prompts for diff mode|
 |`extra_data`|""|no|dict|Variables to apply at launch time. Will only be accepted if job template prompts for vars or has a survey asking for those vars. extra_data are extra_vars at the node level and named so to match the module and the API. These are only for "ask extra vars on prompt" on a given job template.|

--- a/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml
+++ b/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml
@@ -69,6 +69,7 @@
         cas_async_delay: "{{ controller_configuration_workflow_job_templates_async_delay }}"
         cas_async_retries: "{{ controller_configuration_workflow_job_templates_async_retries }}"
         cas_job_async_results_item: "{{ __workflows_node_async_results_item }}"
+        cas_register_subvar: controller_workflows
         cas_error_list_var_name: "controller_workflows_errors"
 
     # Create links between workflow node
@@ -123,6 +124,7 @@
         cas_async_delay: "{{ controller_configuration_workflow_job_templates_async_delay }}"
         cas_async_retries: "{{ controller_configuration_workflow_job_templates_async_retries }}"
         cas_job_async_results_item: "{{ __workflows_link_async_results_item }}"
+        cas_register_subvar: controller_workflows
         cas_error_list_var_name: "controller_workflows_errors"
 
   always:

--- a/roles/controller_workflow_job_templates/tasks/main.yml
+++ b/roles/controller_workflow_job_templates/tasks/main.yml
@@ -87,6 +87,7 @@
         cas_async_delay: "{{ controller_configuration_workflow_job_templates_async_delay }}"
         cas_async_retries: "{{ controller_configuration_workflow_job_templates_async_retries }}"
         cas_job_async_results_item: "{{ __workflows_job_async_results_item }}"
+        cas_register_subvar: controller_workflows
         cas_error_list_var_name: "controller_workflows_errors"
         __operation: "{{ operation_translate[__workflows_job_async_results_item.__workflow_loop_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Workflow {{ __workflows_job_async_results_item.__workflow_loop_item.name }} | Wait for finish the workflow {{ __operation.action }}"

--- a/roles/eda_controller_tokens/README.md
+++ b/roles/eda_controller_tokens/README.md
@@ -17,6 +17,7 @@ Note that tokens cannot be updated, only created.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the controller host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`eda_controller_tokens`|`see below`|yes|Data structure describing your users Described below.||
 
 ### Secure Logging Variables
@@ -57,6 +58,7 @@ This also speeds up the overall role.
 |`name`|""|yes|str|User Token name. Must be lower case containing only alphanumeric characters and underscores.|
 |`description`|""|no|str|Description to use for the Project.|
 |`token`|""|yes|str|The value of the token to associate with the user.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard User Token Data Structure
 

--- a/roles/eda_controller_tokens/tasks/main.yml
+++ b/roles/eda_controller_tokens/tasks/main.yml
@@ -43,6 +43,7 @@
         cas_async_delay: "{{ eda_configuration_users_token_async_delay }}"
         cas_async_retries: "{{ eda_configuration_users_token_async_retries }}"
         cas_job_async_results_item: "{{ __controller_tokens_job_async_result_item }}"
+        cas_register_subvar: eda_controller_tokens
         cas_error_list_var_name: "eda_controller_tokens_errors"
         __operation: "{{ operation_translate[__controller_tokens_job_async_result_item.__token_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Controller token {{ __controller_tokens_job_async_result_item.__token_item.name }} | Wait for finish the Controller token {{ __operation.action }}"

--- a/roles/eda_credential_types/README.md
+++ b/roles/eda_credential_types/README.md
@@ -16,6 +16,7 @@ An Ansible Role to create Credential Types in EDA Controller.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the controller host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`eda_credential_types`|`see below`|yes|Data structure describing your users Described below.||
 
 ### Secure Logging Variables
@@ -59,6 +60,7 @@ This also speeds up the overall role.
 |`inputs`|""|no|dict|Credential inputs where the keys are var names used in templating. Refer to the EDA controller documentation for example syntax.|
 |`injectors`|""|no|dict|Enter injectors using either JSON or YAML syntax. Refer to the Ansible controller documentation for example syntax. See below on proper formatting.|
 |`state`|`present`|no|str|Desired state of the credential.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Formatting Injectors
 

--- a/roles/eda_credential_types/tasks/main.yml
+++ b/roles/eda_credential_types/tasks/main.yml
@@ -46,6 +46,7 @@
         cas_async_delay: "{{ eda_configuration_credential_types_async_delay }}"
         cas_async_retries: "{{ eda_configuration_credential_types_async_retries }}"
         cas_job_async_results_item: "{{ __credential_types_job_async_result_item }}"
+        cas_register_subvar: eda_credential_types
         cas_error_list_var_name: "eda_credential_types_errors"
         __operation: "{{ operation_translate[__credential_types_job_async_result_item.__credential_type_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} credential {{ __credential_types_job_async_result_item.__credential_type_item.name }} | Wait for finish the credential {{ __operation.action }}"

--- a/roles/eda_credentials/README.md
+++ b/roles/eda_credentials/README.md
@@ -16,6 +16,7 @@ An Ansible Role to create Credentials in EDA Controller.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the controller host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`eda_credentials`|`see below`|yes|Data structure describing your users Described below.||
 
 ### Secure Logging Variables
@@ -60,6 +61,7 @@ This also speeds up the overall role.
 |`inputs`|""|no|dict|Credential inputs where the keys are var names used in templating. Refer to the EDA controller documentation for example syntax.|
 |`credential_type`|"GitHub Personal Access Token"|yes|str|The type of the credential.|
 |`state`|`present`|no|str|Desired state of the credential.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Credential types
 

--- a/roles/eda_credentials/tasks/main.yml
+++ b/roles/eda_credentials/tasks/main.yml
@@ -47,6 +47,7 @@
         cas_async_delay: "{{ eda_configuration_credentials_async_delay }}"
         cas_async_retries: "{{ eda_configuration_credentials_async_retries }}"
         cas_job_async_results_item: "{{ __credentials_job_async_result_item }}"
+        cas_register_subvar: eda_credentials
         cas_error_list_var_name: "eda_credentials_errors"
         __operation: "{{ operation_translate[__credentials_job_async_result_item.__credential_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} credential {{ __credentials_job_async_result_item.__credential_item.name }} | Wait for finish the credential {{ __operation.action }}"

--- a/roles/eda_decision_environments/README.md
+++ b/roles/eda_decision_environments/README.md
@@ -16,6 +16,7 @@ An Ansible Role to create Decision Environments in EDA Controller.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the controller host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`eda_decision_environments`|`see below`|yes|Data structure describing your users Described below.||
 
 ### Secure Logging Variables
@@ -60,6 +61,7 @@ This also speeds up the overall role.
 |`credential`|""|no|str|The credential used to access the container registry holding the image.|
 |`organization`|""|no|str|Organization this decision environment belongs to.|
 |`state`|`present`|no|str|Desired state of the decision environment.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Decision Environment Data Structure
 

--- a/roles/eda_decision_environments/tasks/main.yml
+++ b/roles/eda_decision_environments/tasks/main.yml
@@ -48,6 +48,7 @@
         cas_async_delay: "{{ eda_configuration_decision_environments_async_delay }}"
         cas_async_retries: "{{ eda_configuration_decision_environments_async_retries }}"
         cas_job_async_results_item: "{{ __decision_environments_job_async_result_item }}"
+        cas_register_subvar: eda_decision_environments
         cas_error_list_var_name: "eda_decision_environments_errors"
         __operation: "{{ operation_translate[__decision_environments_job_async_result_item.__de_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} decision environment {{ __decision_environments_job_async_result_item.__de_item.name }} | Wait for finish the decision environment {{ __operation.action }}"

--- a/roles/eda_event_streams/README.md
+++ b/roles/eda_event_streams/README.md
@@ -16,6 +16,7 @@ An Ansible Role to create Event Streams in EDA Controller.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the controller host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`eda_event_streams`|`see below`|yes|Data structure describing your users Described below.||
 
 ### Secure Logging Variables
@@ -60,6 +61,7 @@ This also speeds up the overall role.
 |`headers`|""|no|str|Comma separated HTTP header keys that you want to include in the event payload. To include all headers in the event payload, leave the field empty.|
 |`forward_events`|`false`|no|bool|Enable the event stream to forward events to the rulebook activation where it is configured.|
 |`state`|`present`|no|str|Desired state of the project.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Event Stream Data Structure
 

--- a/roles/eda_event_streams/tasks/main.yml
+++ b/roles/eda_event_streams/tasks/main.yml
@@ -47,6 +47,7 @@
         cas_async_delay: "{{ eda_configuration_event_streams_async_delay }}"
         cas_async_retries: "{{ eda_configuration_event_streams_async_retries }}"
         cas_job_async_results_item: "{{ __event_streams_job_async_result_item }}"
+        cas_register_subvar: eda_event_streams
         cas_error_list_var_name: "eda_event_streams_errors"
         __operation: "{{ operation_translate[__event_streams_job_async_result_item.__event_stream_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Event stream {{ __event_streams_job_async_result_item.__event_stream_item.name }} | Wait for finish the Event stream {{ __operation.action }}"

--- a/roles/eda_projects/README.md
+++ b/roles/eda_projects/README.md
@@ -16,6 +16,7 @@ An Ansible Role to create Projects in EDA Controller.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the controller host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`eda_projects`|`see below`|yes|Data structure describing your users Described below.||
 
 ### Secure Logging Variables
@@ -63,6 +64,7 @@ This also speeds up the overall role.
 |`proxy`|""|no|str|Proxy used to access HTTP or HTTPS servers.|
 |`sync`|`false`|no|str|Project sync once created/updated or not.|
 |`state`|`present`|no|str|Desired state of the project.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Project Data Structure
 

--- a/roles/eda_projects/tasks/main.yml
+++ b/roles/eda_projects/tasks/main.yml
@@ -50,6 +50,7 @@
         cas_async_delay: "{{ eda_configuration_projects_async_delay }}"
         cas_async_retries: "{{ eda_configuration_projects_async_retries }}"
         cas_job_async_results_item: "{{ __projects_job_async_result_item }}"
+        cas_register_subvar: eda_projects
         cas_error_list_var_name: "eda_projects_errors"
         __operation: "{{ operation_translate[__projects_job_async_result_item.__project_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} project {{ __projects_job_async_result_item.__project_item.name }} | Wait for finish the project {{ __operation.action }}"

--- a/roles/eda_rulebook_activations/README.md
+++ b/roles/eda_rulebook_activations/README.md
@@ -16,6 +16,7 @@ An Ansible Role to create rulebook activations in EDA Controller.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the controller host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`eda_rulebook_activations`|`see below`|yes|Data structure describing your users Described below.||
 
 ### Secure Logging Variables
@@ -63,6 +64,7 @@ This also speeds up the overall role.
 |`awx_token`|""|no|str|The token used to authenticate to controller.|
 |`enabled`|"true"|no|str|Whether the rulebook activation is automatically enabled to run.|
 |`state`|`present`|no|str|Desired state of the rulebook activation.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 |`organization`|""|no|str|The name of the organization.|
 |`eda_credentials`|""|no|list|A list of IDs for EDA credentials used by the rulebook activation.|
 |`k8s_service_name`|""|no|str|The name of the Kubernetes service associated with this rulebook activation.|

--- a/roles/eda_rulebook_activations/tasks/main.yml
+++ b/roles/eda_rulebook_activations/tasks/main.yml
@@ -57,6 +57,7 @@
         cas_async_delay: "{{ eda_configuration_rulebook_activations_async_delay }}"
         cas_async_retries: "{{ eda_configuration_rulebook_activations_async_retries }}"
         cas_job_async_results_item: "{{ __rulebook_activations_job_async_result_item }}"
+        cas_register_subvar: eda_rulebook_activations
         cas_error_list_var_name: "eda_rulebook_activations_errors"
         __operation: "{{ operation_translate[__rulebook_activations_job_async_result_item.__ra_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} rulebook activation {{ __rulebook_activations_job_async_result_item.__ra_item.name }} | Wait for finish the rulebook activation {{ __operation.action }}"

--- a/roles/eda_users/README.md
+++ b/roles/eda_users/README.md
@@ -16,6 +16,7 @@ An Ansible Role to create users in EDA Controller.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the controller host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`aap_user_accounts`|`see below`|yes|Data structure describing your users Described below.||
 
 ### Secure Logging Variables
@@ -63,6 +64,7 @@ This also speeds up the overall role.
 |`is_superuser`|""|no|bool|Make user as superuser.|
 |`roles`|""|yes|list|Roles the user will have. Current acceptable values are: Viewer, Auditor, Editor, Contributor, Operator, Admin.|
 |`state`|`present`|no|str|Desired state of the user.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard user Data Structure
 

--- a/roles/eda_users/tasks/main.yml
+++ b/roles/eda_users/tasks/main.yml
@@ -50,6 +50,7 @@
         cas_async_delay: "{{ eda_configuration_users_async_delay }}"
         cas_async_retries: "{{ eda_configuration_users_async_retries }}"
         cas_job_async_results_item: "{{ __users_job_async_result_item }}"
+        cas_register_subvar: eda_users
         cas_error_list_var_name: "eda_users_errors"
         __operation: "{{ operation_translate[__users_job_async_result_item.__user_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} user {{ __users_job_async_result_item.__user_item.username }} | Wait for finish the user {{ __operation.action }}"

--- a/roles/gateway_applications/README.md
+++ b/roles/gateway_applications/README.md
@@ -16,6 +16,7 @@ An Ansible Role to create/update/remove Applications on Ansible gateway.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`aap_applications`|`see below`|yes|Data structure describing your aap_applications Described below.||
 
 ### Enforcing defaults
@@ -84,6 +85,8 @@ Options for the `aap_applications` variable:
 | `post_logout_redirect_uris` |         ""          |    no    | str  | Allowed Post Logout URIs list, space separated.                                        |
 | `user`                      |         ""          |    no    | str  | The user who owns this application.                                                    |
 | `state`                     |      `present`      |    no    | str  | Desired state of the application.                                                      |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
+
 
 ### Standard Application Data Structure
 

--- a/roles/gateway_applications/tasks/main.yml
+++ b/roles/gateway_applications/tasks/main.yml
@@ -56,6 +56,7 @@
         cas_async_delay: "{{ gateway_applications_async_delay }}"
         cas_async_retries: "{{ gateway_applications_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_applications_job_async_results_item }}"
+        cas_register_subvar: gateway_applications
         cas_error_list_var_name: "gateway_applications_errors"
         __operation: "{{ operation_translate[__gateway_applications_job_async_results_item.__gateway_application_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} AAP Platform Applications {{ __gateway_applications_job_async_results_item.__gateway_application_item.name }} | Wait for finish the Applications {{ __operation.action }}"

--- a/roles/gateway_authenticator_maps/README.md
+++ b/roles/gateway_authenticator_maps/README.md
@@ -16,6 +16,7 @@ An Ansible Role to add Authenticator Maps on Ansible Automation gateway.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`gateway_authenticator_maps`|`see below`|yes|Data structure describing your gateway_authenticator_maps Described below.||
 
 ### Secure Logging Variables
@@ -67,6 +68,7 @@ Options for the `gateway_authenticator_maps` variable:
 | `triggers`          |      `{}`       |    no    | dict | Trigger information for this rule                                                                                                           |
 | `order`             | N/A(`0` by API) |    no    | int  | The order in which this rule should be processed, smaller numbers are of higher precedence                                                  |
 | `state`             |    `present`    |    no    | str  | Desired state of the resource.                                                                                                              |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 ### Unique value
 

--- a/roles/gateway_authenticator_maps/tasks/main.yml
+++ b/roles/gateway_authenticator_maps/tasks/main.yml
@@ -54,6 +54,7 @@
         cas_async_delay: "{{ gateway_authenticator_maps_async_delay }}"
         cas_async_retries: "{{ gateway_authenticator_maps_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_authenticator_maps_job_async_results_item }}"
+        cas_register_subvar: gateway_authenticator_maps
         cas_error_list_var_name: "gateway_authenticator_maps_errors"
         __operation: "{{ operation_translate[__gateway_authenticator_maps_job_async_results_item.__gateway_authenticator_maps_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} AAP Platform Authenticator Maps {{ __gateway_authenticator_maps_job_async_results_item.__gateway_authenticator_maps_item.name }} | Wait for finish the Authenticator Map {{ __operation.action }}"

--- a/roles/gateway_authenticators/README.md
+++ b/roles/gateway_authenticators/README.md
@@ -16,6 +16,7 @@ An Ansible Role to add Authenticators on Ansible Automation gateway.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`gateway_authenticators`|`see below`|yes|Data structure describing your gateway_authenticators Described below.||
 
 ### Secure Logging Variables
@@ -66,6 +67,7 @@ Options for the `gateway_authenticators` variable:
 | `auto_migrate_users_to` |      'false' |    no    | bool  | Automatically move users from this authenticator to the target authenticator when a matching user logs in via the target authenticator. |
 | `order`          |  N/A (`1` by API)   |    no    | int  | The order in which an authenticator will be tried. This only pertains to username/password authenticators                    |
 | `state`          |      `present`      |    no    | str  | Desired state of the resource.                                                                                               |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 ### Unique value
 

--- a/roles/gateway_authenticators/tasks/main.yml
+++ b/roles/gateway_authenticators/tasks/main.yml
@@ -53,6 +53,7 @@
         cas_async_delay: "{{ gateway_authenticators_async_delay }}"
         cas_async_retries: "{{ gateway_authenticators_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_authenticators_job_async_results_item }}"
+        cas_register_subvar: gateway_authenticators
         cas_error_list_var_name: "gateway_authenticators_errors"
         __operation: "{{ operation_translate[__gateway_authenticators_job_async_results_item.__gateway_authenticators_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} AAP Platform Authenticators {{ __gateway_authenticators_job_async_results_item.__gateway_authenticators_item.name }} | Wait for finish the Authenticators {{ __operation.action }}"

--- a/roles/gateway_http_ports/README.md
+++ b/roles/gateway_http_ports/README.md
@@ -16,6 +16,7 @@ An Ansible Role to add proxy Http Ports on Ansible Automation gateway.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`gateway_http_ports`|`see below`|yes|Data structure describing your http_ports entries Described below.||
 
 ### Secure Logging Variables
@@ -61,6 +62,7 @@ Options for the `gateway_http_ports` variable:
 | `use_https`   |    `false`    |    no    | bool | Secure this port with HTTPS                                                      |
 | `is_api_port` |    `false`    |    no    | bool | If true, port is used for serving remote AAP APIs. Only one can be set to true   |
 | `state`       |   `present`   |    no    | str  | Desired state of the resource.                                                   |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 **Unique value:**
 

--- a/roles/gateway_http_ports/tasks/main.yml
+++ b/roles/gateway_http_ports/tasks/main.yml
@@ -48,6 +48,7 @@
         cas_async_delay: "{{ gateway_http_ports_async_delay }}"
         cas_async_retries: "{{ gateway_http_ports_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_http_ports_job_async_results_item }}"
+        cas_register_subvar: gateway_http_ports
         cas_error_list_var_name: "gateway_http_ports_errors"
         __operation: "{{ operation_translate[__gateway_http_ports_job_async_results_item.__gateway_http_ports_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} AAP Platform Http Ports {{ __gateway_http_ports_job_async_results_item.__gateway_http_ports_item.name }} | Wait for finish the Http Ports {{ __operation.action }}"

--- a/roles/gateway_organizations/README.md
+++ b/roles/gateway_organizations/README.md
@@ -20,6 +20,7 @@ This role requires both `ansible.platform` and `ansible.controller` collections.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`aap_organizations`|`see below`|yes|Data structure describing your organizations Described below.||
 |`assign_galaxy_credentials_to_org`|`true`|no|Boolean to indicate whether credentials should be assigned or not. It should be noted that credentials must exist before adding it. The dispatch role will set this to `false`, before re-running the role with it set to `true`. ||
 |`assign_default_ee_to_org`|`true`|no|Boolean to indicate whether default execution environment should be assigned or not. It should be noted that execution environment must exist before adding it. The dispatch role will set this to `false`, before re-running the role with it set to `true`. ||
@@ -92,6 +93,7 @@ Options for the `aap_organizations` variable:
 | `notification_templates_error`     |      N/A      |    no    | list | The notifications on error to use for this organization in a list.               |
 | `notification_templates_approvals` |      N/A      |    no    | list | The notifications for approval to use for this organization in a list.           |
 | `state`                            |   `present`   |    no    | str  | Desired state of the resource.                                                   |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 ### Unique value
 

--- a/roles/gateway_organizations/tasks/main.yml
+++ b/roles/gateway_organizations/tasks/main.yml
@@ -45,6 +45,7 @@
         cas_async_delay: "{{ gateway_organizations_async_delay }}"
         cas_async_retries: "{{ gateway_organizations_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_organizations_job_async_results_item }}"
+        cas_register_subvar: aap_organizations
         cas_error_list_var_name: "aap_organizations_errors"
         __operation: "{{ operation_translate[__gateway_organizations_job_async_results_item.__gateway_organization_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} AAP Platform Organizations {{ __gateway_organizations_job_async_results_item.__gateway_organization_item.name }} | Wait for finish the Organizations {{ __operation.action }}"
@@ -107,6 +108,7 @@
         cas_async_delay: "{{ gateway_organizations_async_delay }}"
         cas_async_retries: "{{ gateway_organizations_async_retries }}"
         cas_job_async_results_item: "{{ __organizations_job_async_results_item }}"
+        cas_register_subvar: aap_organizations
         cas_error_list_var_name: "aap_organizations_errors"
         __operation: "{{ operation_translate[__organizations_job_async_results_item.__controller_organizations_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Controller Organization {{ __organizations_job_async_results_item.__controller_organizations_item.name }} | Wait for finish the organization {{ __operation.action }}"

--- a/roles/gateway_role_definitions/README.md
+++ b/roles/gateway_role_definitions/README.md
@@ -76,6 +76,7 @@ This also speeds up the overall role.
 | `new_name`          |      N/A      |    no    | str  | Setting this option will change the existing name (looked up via the name field)                      |
 | `permissions`       |      N/A      |   yes    | list | List of permission strings to associate with the role (e.g., awx.view_inventory)                      |
 | `state`             |   `present`   |    no    | str  | Desired state of the resource.                                                                        |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 ### Standard Role Definition Data Structure
 

--- a/roles/gateway_role_definitions/tasks/main.yml
+++ b/roles/gateway_role_definitions/tasks/main.yml
@@ -45,6 +45,7 @@
       vars:
         cas_secure_logging: "{{ gateway_role_definitions_secure_logging }}"
         cas_job_async_results_item: "{{ __gateway_role_definitions_job_async_results_item }}"
+        cas_register_subvar: gateway_role_definitions
         cas_error_list_var_name: "gateway_role_definitions_errors"
         __operation: "{{ operation_translate[__gateway_role_definitions_job_async_results_item.__gateway_role_definitions_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Role {{ __gateway_role_definitions_job_async_results_item.__gateway_role_definitions_item.name }} | Wait for finish the Roles {{ __operation.action }}"

--- a/roles/gateway_role_team_assignments/README.md
+++ b/roles/gateway_role_team_assignments/README.md
@@ -75,6 +75,7 @@ This also speeds up the overall role.
 | `state`             |   `present`   |    no    | str  | Desired state of the resource.                                                                        |
 | `team`              |      N/A      |    no    | str  | The name or id of the team to assign to the object.                                                   |
 | `team_ansible_id`   |      N/A      |    no    | str  | Resource id of the team who will receive permissions from this assignment. Alternative to team field. |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 ### Standard Role Team Assignment Data Structure
 

--- a/roles/gateway_role_team_assignments/tasks/main.yml
+++ b/roles/gateway_role_team_assignments/tasks/main.yml
@@ -44,6 +44,7 @@
       vars:
         cas_secure_logging: "{{ gateway_role_team_assignments_secure_logging }}"
         cas_job_async_results_item: "{{ __gateway_role_team_assignments_job_async_results_item }}"
+        cas_register_subvar: gateway_role_team_assignments
         cas_error_list_var_name: "gateway_role_team_assignments_errors"
         __operation: "{{ operation_translate[__gateway_role_team_assignments_job_async_results_item.__gateway_role_team_assignments_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Role Team Assignments {{ __gateway_role_team_assignments_job_async_results_item.__gateway_role_team_assignments_item.role_definition }} | Wait for finish the Role Team Assignments {{ __operation.action }}"

--- a/roles/gateway_role_user_assignments/README.md
+++ b/roles/gateway_role_user_assignments/README.md
@@ -77,6 +77,7 @@ This also speeds up the overall role.
 | `state`             |   `present`   |    no    | str  | Desired state of the resource.                                                                        |
 | `user`              |      N/A      |    no    | str  | The name or id of the user to assign to the object. This option is mutually exclusive with user_ansible_id. |
 | `user_ansible_id`   |      N/A      |    no    | str  | Resource id of the user who will receive permissions from this assignment. Alternative to user field. This option is mutually exclusive with user. |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 **Unique value:**
 

--- a/roles/gateway_role_user_assignments/tasks/main.yml
+++ b/roles/gateway_role_user_assignments/tasks/main.yml
@@ -48,6 +48,7 @@
         cas_async_delay: "{{ gateway_role_user_assignments_async_delay }}"
         cas_async_retries: "{{ gateway_role_user_assignments_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_role_user_assignments_job_async_results_item }}"
+        cas_register_subvar: gateway_role_user_assignments
         cas_error_list_var_name: "gateway_role_user_assignments_errors"
         __operation: "{{ operation_translate[__gateway_role_user_assignments_job_async_results_item.__gateway_role_user_assignments_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Role {{ __gateway_role_user_assignments_job_async_results_item.__gateway_role_user_assignments_item.1 | default(__gateway_role_user_assignments_job_async_results_item.__gateway_role_user_assignments_item.role_definition) }} | Wait for finish the Roles {{ __operation.action }}"

--- a/roles/gateway_routes/README.md
+++ b/roles/gateway_routes/README.md
@@ -18,6 +18,7 @@ http port and path in the destination service (gateway, controller, hub, eda).
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`gateway_routes`|`see below`|yes|Data structure describing your gateway_routes Described below.||
 
 ### Secure Logging Variables
@@ -69,6 +70,7 @@ Options for the `gateway_routes` variable:
 | `service_port`        |         N/A         |    no    | int  | Port on the service cluster to route traffic to                                     |
 | `tags`                |         ""          |    no    | str  | Comma-separated string, selects which (tagged) nodes receive traffic from this route|
 | `state`               |      `present`      |    no    | str  | README.md#state-variable                                                            |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 **Unique value:**
 

--- a/roles/gateway_routes/tasks/main.yml
+++ b/roles/gateway_routes/tasks/main.yml
@@ -53,6 +53,7 @@
         cas_async_delay: "{{ gateway_routes_async_delay }}"
         cas_async_retries: "{{ gateway_routes_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_routes_job_async_results_item }}"
+        cas_register_subvar: gateway_routes
         cas_error_list_var_name: "gateway_routes_errors"
         __operation: "{{ operation_translate[__gateway_routes_job_async_results_item.__gateway_routes_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Gateway route {{ __gateway_routes_job_async_results_item.__gateway_routes_item.name }} | Wait for finish the Gateway route {{ __operation.action }}"

--- a/roles/gateway_service_clusters/README.md
+++ b/roles/gateway_service_clusters/README.md
@@ -16,6 +16,7 @@ An Ansible Role to configure Service Clusters on Ansible Automation gateway.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`gateway_service_clusters`|`see below`|yes|Data structure describing your gateway_service_clusters Described below.||
 
 ### Secure Logging Variables
@@ -59,6 +60,7 @@ Options for the `gateway_service_clusters` variable:
 | `new_name`     |      N/A      |         no         | str  | Setting this option will change the existing name (looked up via the name field)        |
 | `service_type` |      N/A      | state is 'present' | str  | The type of service for this cluster. Choices : ["hub", "controller", "eda", "gateway"] |
 | `state`        |   `present`   |         no         | str  | README.md#state-variable)                                                  |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 **Unique value:**
 

--- a/roles/gateway_service_clusters/tasks/main.yml
+++ b/roles/gateway_service_clusters/tasks/main.yml
@@ -56,6 +56,7 @@
         cas_async_delay: "{{ gateway_service_clusters_async_delay }}"
         cas_async_retries: "{{ gateway_service_clusters_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_service_clusters_job_async_results_item }}"
+        cas_register_subvar: gateway_service_clusters
         cas_error_list_var_name: "gateway_service_clusters_errors"
         __operation: "{{ operation_translate[__gateway_service_clusters_job_async_results_item.__gateway_service_clusters_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Gateway service cluster {{ __gateway_service_clusters_job_async_results_item.__gateway_service_clusters_item.name }} | Wait for finish the Gateway service cluster {{ __operation.action }}"

--- a/roles/gateway_service_keys/README.md
+++ b/roles/gateway_service_keys/README.md
@@ -16,6 +16,7 @@ An Ansible Role to configure Service Keys on Ansible Automation gateway.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`gateway_service_keys`|`see below`|yes|Data structure describing your gateway_service_keys Described below.||
 
 ### Secure Logging Variables
@@ -64,6 +65,7 @@ Options for the `gateway_service_keys` variable:
 | `secret_length`          |        N/A         |    no    | int  | The number of random bytes in the secret                                         |
 | `mark_previous_inactive` |        N/A         |    no    | bool | If true any other secret keys for this service will become inactive              |
 | `state`                  |     `present`      |    no    | str  | README.md#state-variable)                                           |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 **Unique value:**
 

--- a/roles/gateway_service_keys/tasks/main.yml
+++ b/roles/gateway_service_keys/tasks/main.yml
@@ -50,6 +50,7 @@
         cas_async_delay: "{{ gateway_service_keys_async_delay }}"
         cas_async_retries: "{{ gateway_service_keys_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_service_keys_job_async_results_item }}"
+        cas_register_subvar: gateway_service_keys
         cas_error_list_var_name: "gateway_service_keys_errors"
         __operation: "{{ operation_translate[__gateway_service_keys_job_async_results_item.__gateway_service_keys_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Gateway service key {{ __gateway_service_keys_job_async_results_item.__gateway_service_keys_item.name }} | Wait for finish the Gateway service key {{ __operation.action }}"

--- a/roles/gateway_service_nodes/README.md
+++ b/roles/gateway_service_nodes/README.md
@@ -16,6 +16,7 @@ An Ansible Role to configure Service Nodes on Ansible Automation gateway.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`gateway_service_nodes`|`see below`|yes|Data structure describing your gateway_service_nodes Described below.||
 
 ### Enforcing defaults
@@ -77,6 +78,7 @@ Options for the `gateway_service_nodes` variable:
 | `service_cluster` |      N/A      |    no    | str  | ID or name referencing the [Service Cluster](../gateway_service_clusters/README.md)      |
 | `tags`            |      N/A      |    no    | str  | Comma separated list of tags to assign to the node, for filtering route traffic  |
 | `state`           |   `present`   |    no    | str  | README.md#state-variable)                                           |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 **Unique value:**
 

--- a/roles/gateway_service_nodes/tasks/main.yml
+++ b/roles/gateway_service_nodes/tasks/main.yml
@@ -47,6 +47,7 @@
         cas_async_delay: "{{ gateway_service_nodes_async_delay }}"
         cas_async_retries: "{{ gateway_service_nodes_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_service_nodes_job_async_results_item }}"
+        cas_register_subvar: gateway_service_nodes
         cas_error_list_var_name: "gateway_service_nodes_errors"
         __operation: "{{ operation_translate[__gateway_service_nodes_job_async_results_item.__gateway_service_nodes_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Gateway service node {{ __gateway_service_nodes_job_async_results_item.__gateway_service_nodes_item.name }} | Wait for finish the Gateway service node {{ __operation.action }}"

--- a/roles/gateway_services/README.md
+++ b/roles/gateway_services/README.md
@@ -18,6 +18,7 @@ http port and path in the destination service (gateway, controller, hub, eda).
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`gateway_services`|`see below`|yes|Data structure describing your gateway_services Described below.||
 
 ### Secure Logging Variables
@@ -70,6 +71,7 @@ Options for the `gateway_services` variable:
 | `order`               |  "" (`50` by API)   |    no    | int  | The order to apply the routes in lower numbers are first. Items with the same value have no guaranteed order                                      |
 | `tags`                |         ""          |    no    | str  | Comma-separated string, selects which (tagged) nodes receive traffic from this route                                                              |
 | `state`               |      `present`      |    no    | str  | README.md#state-variable)                                                                                                            |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 **Unique value:**
 

--- a/roles/gateway_services/tasks/main.yml
+++ b/roles/gateway_services/tasks/main.yml
@@ -54,6 +54,7 @@
         cas_async_delay: "{{ gateway_services_async_delay }}"
         cas_async_retries: "{{ gateway_services_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_services_job_async_results_item }}"
+        cas_register_subvar: gateway_services
         cas_error_list_var_name: "gateway_services_errors"
         __operation: "{{ operation_translate[__gateway_services_job_async_results_item.__gateway_services_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Gateway service {{ __gateway_services_job_async_results_item.__gateway_services_item.name }} | Wait for finish the Gateway service {{ __operation.action }}"

--- a/roles/gateway_teams/README.md
+++ b/roles/gateway_teams/README.md
@@ -16,6 +16,7 @@ An Ansible Role to add Teams on Ansible Automation gateway.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`aap_teams`|`see below`|yes|Data structure describing your teams Described below.||
 
 ### Secure Logging Variables
@@ -61,6 +62,7 @@ Options for the `aap_teams` variable:
 | `organization`     |      N/A      |   yes    | str  | The name or ID referencing the [Organization](../gateway_organizations/README.md) |
 | `new_organization` |      N/A      |    no    | str  | The name or ID referencing newly associated organization                          |
 | `state`            |   `present`   |    no    | str  | Desired state of the resource.                                                    |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 ### Unique value
 

--- a/roles/gateway_teams/tasks/main.yml
+++ b/roles/gateway_teams/tasks/main.yml
@@ -47,6 +47,7 @@
         cas_async_delay: "{{ gateway_teams_async_delay }}"
         cas_async_retries: "{{ gateway_teams_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_teams_job_async_results_item }}"
+        cas_register_subvar: gateway_teams
         cas_error_list_var_name: "gateway_teams_errors"
         __operation: "{{ operation_translate[__gateway_teams_job_async_results_item.__gateway_teams_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Gateway team {{ __gateway_teams_job_async_results_item.__gateway_teams_item.name }} | Wait for finish the Gateway team {{ __operation.action }}"

--- a/roles/gateway_users/README.md
+++ b/roles/gateway_users/README.md
@@ -16,6 +16,7 @@ An Ansible Role to configure users on Ansible Automation gateway.
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`aap_user_accounts`|`see below`|yes|Data structure describing your users Described below.||
 
 ### Secure Logging Variables
@@ -65,6 +66,7 @@ Options for the `aap_user_accounts` variable:
 | `authenticator_uid` |                 N/A                   |    no    | bool | UID coming from the authenticators the user is associated with                                                                                                        |
 | `state`             |               `present`               |    no    | str  | Desired state of the resource.                                                                                                                                        |
 | `update_secrets`    |                'true'                 |    no    | bool | true will always change password if user specifies password, even if API gives $encrypted$ for password. false will only set the password if other values change too. |
+|`register`                   |         ""          |   no     | str  | Variable to set based on the result of the object creation/modification                |
 
 **Unique value:**
 

--- a/roles/gateway_users/tasks/main.yml
+++ b/roles/gateway_users/tasks/main.yml
@@ -54,6 +54,7 @@
         cas_async_delay: "{{ gateway_users_async_delay }}"
         cas_async_retries: "{{ gateway_users_async_retries }}"
         cas_job_async_results_item: "{{ __gateway_user_accounts_job_async_results_item }}"
+        cas_register_subvar: gateway_users
         cas_error_list_var_name: "gateway_users_errors"
         __operation: "{{ operation_translate[__gateway_user_accounts_job_async_results_item.__gateway_user_accounts_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Gateway user {{ __gateway_user_accounts_job_async_results_item.__gateway_user_accounts_item.username }} | Wait for finish the Gateway user {{ __operation.action }}"

--- a/roles/hub_collection/README.md
+++ b/roles/hub_collection/README.md
@@ -14,6 +14,7 @@ An Ansible Role to update, or destroy Automation Hub Collections.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`hub_collections`|`see below`|yes|Data structure describing your collections, described below.||
@@ -32,6 +33,7 @@ These are the sub options for the vars `hub_collections` which are dictionaries 
 |`interval`|"true"|10|Interval at which approval is checked||
 |`overwrite_existing`|"false"|no|Overwrites an existing collection and requires version to be set.||
 |`state`|"present"|no|Desired state of the resource||
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 The `aap_configuration_async_dir` variable sets the directory to write the results file for async tasks.
 The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.

--- a/roles/hub_collection/tasks/main.yml
+++ b/roles/hub_collection/tasks/main.yml
@@ -56,6 +56,7 @@
         cas_async_delay: "{{ hub_configuration_collection_async_delay }}"
         cas_async_retries: "{{ hub_configuration_collection_async_retries }}"
         cas_job_async_results_item: "{{ __collections_job_async_result_item }}"
+        cas_register_subvar: hub_collections
         cas_error_list_var_name: "hub_collections_errors"
         __operation: "{{ operation_translate[__collections_job_async_result_item.__hub_collection_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Collection {{ _collection_object_label }} | Wait for finish the Collection {{ __operation.action }}"

--- a/roles/hub_collection_remote/README.md
+++ b/roles/hub_collection_remote/README.md
@@ -14,6 +14,7 @@ An Ansible Role to create a Collection Remote Repository.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`hub_collection_remotes`|`see below`|yes|Data structure describing your collection remote repository, described below.||
@@ -83,6 +84,7 @@ This also speeds up the overall role.
 |`proxy_username`|``|no|The username for the proxy authentication. Defaults to global `proxy_username` variable.||
 |`proxy_password`|``|no|The password for the proxy authentication. Defaults to global `proxy_password` variable.||
 |`state`|`present`|no|Desired state of the collection_remote. Either `present` or `absent`.||
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Project Data Structure
 

--- a/roles/hub_collection_remote/tasks/main.yml
+++ b/roles/hub_collection_remote/tasks/main.yml
@@ -66,6 +66,7 @@
         cas_async_delay: "{{ hub_configuration_collection_remote_async_delay }}"
         cas_async_retries: "{{ hub_configuration_collection_remote_async_retries }}"
         cas_job_async_results_item: "{{ __collection_remote_job_async_result_item }}"
+        cas_register_subvar: hub_collection_remote
         cas_error_list_var_name: "hub_collection_remote_errors"
         __operation: "{{ operation_translate[__collection_remote_job_async_result_item.__hub_collection_remote_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Collection remote {{ __collection_remote_job_async_result_item.__hub_collection_remote_item.name }} | Wait for finish the Collection remote {{ __operation.action }}"

--- a/roles/hub_collection_repository/README.md
+++ b/roles/hub_collection_repository/README.md
@@ -14,6 +14,7 @@ An Ansible Role to create a Collection Repository.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`hub_collection_repositories`|`see below`|yes|Data structure describing your collection remote repository, described below.||
@@ -69,6 +70,7 @@ This also speeds up the overall role.
 |`interval`|1.0|no|float|The interval to request an update from Automation Hub.|
 |`timeout`|""|no|int|If waiting for the project to update this will abort after this amount of seconds.|
 |`state`|`present`|no|str|Desired state of the collection repository. Either `present` or `absent`.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 #### Additional Option Variables
 
@@ -88,6 +90,7 @@ distribution:
 |`hide_from_search`|""|no|str|Pipeline and search options for the collection repository.|
 |`name`|""|no|dict|Distribution name to use for this collection repository. Will default to repository name if not provided.|
 |`state`|`absent`|no|str|Desired state of the distribution. Either `present` or `absent`.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Project Data Structure
 

--- a/roles/hub_collection_repository/tasks/main.yml
+++ b/roles/hub_collection_repository/tasks/main.yml
@@ -53,6 +53,7 @@
         cas_async_delay: "{{ hub_configuration_collection_repository_async_delay }}"
         cas_async_retries: "{{ hub_configuration_collection_repository_async_retries }}"
         cas_job_async_results_item: "{{ __collection_repository_job_async_result_item }}"
+        cas_register_subvar: hub_collection_repository
         cas_error_list_var_name: "hub_collection_repository_errors"
         __operation: "{{ operation_translate[__collection_repository_job_async_result_item.__hub_collection_repository_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Collection repository {{ __collection_repository_job_async_result_item.__hub_collection_repository_item.name }} | Wait for finish the Collection repository {{ __operation.action }}"

--- a/roles/hub_collection_repository_sync/README.md
+++ b/roles/hub_collection_repository_sync/README.md
@@ -14,6 +14,7 @@ An Ansible Role to sync a Collection Repository.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`hub_collection_repositories`|`see below`|yes|Data structure describing your collection remote repository, described below.||
@@ -63,6 +64,7 @@ This also speeds up the overall role.
 |`sync`|true|no|bool|Whether to sync the collection_registry. By default it will sync unless this is set to false.|
 |`timeout`|""|no|int|If waiting for the repository to update this will abort after this amount of seconds.|
 |`state`|`present`|no|str|Desired state of the collection repository. Either `present` or `absent`.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Project Data Structure
 

--- a/roles/hub_collection_repository_sync/tasks/main.yml
+++ b/roles/hub_collection_repository_sync/tasks/main.yml
@@ -46,6 +46,7 @@
         cas_async_delay: "{{ hub_configuration_collection_repository_sync_async_delay }}"
         cas_async_retries: "{{ hub_configuration_collection_repository_sync_async_retries }}"
         cas_job_async_results_item: "{{ __collection_repository_sync_job_async_result_item }}"
+        cas_register_subvar: hub_collection_repository_sync
         cas_error_list_var_name: "hub_collection_repository_sync_errors"
         __operation: "{{ operation_translate[__collection_repository_sync_job_async_result_item.__hub_collection_repository_sync_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Collection repository sync {{ __collection_repository_sync_job_async_result_item.__hub_collection_repository_sync_item.name }} | Wait to finish the Repository sync"

--- a/roles/hub_ee_image/README.md
+++ b/roles/hub_ee_image/README.md
@@ -14,6 +14,7 @@ An Ansible Role to create execution environment images in Automation Hub.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`hub_ee_images`|`see below`|yes|Data structure describing your execution environment images, described below.||
@@ -58,6 +59,7 @@ This also speeds up the overall role.
 |`append`|`true`|no|bool|Whether to append or replace the tags specified to the image.|
 |`tags`|""|no|str|List of the image tags to update.|
 |`state`|`present`|no|str|Desired state of the ee_image. (Possible values of `present` or `absent`)|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Project Data Structure
 

--- a/roles/hub_ee_image/tasks/main.yml
+++ b/roles/hub_ee_image/tasks/main.yml
@@ -45,6 +45,7 @@
         cas_async_delay: "{{ hub_configuration_ee_image_async_delay }}"
         cas_async_retries: "{{ hub_configuration_ee_image_async_retries }}"
         cas_job_async_results_item: "{{ __ee_images_job_async_result_item }}"
+        cas_register_subvar: hub_ee_image
         cas_error_list_var_name: "hub_ee_image_errors"
         __operation: "{{ operation_translate[__ee_images_job_async_result_item.__ee_image_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} EE Image {{ __ee_images_job_async_result_item.__ee_image_item.name }} | Wait for finish the EE image {{ __operation.action }}"

--- a/roles/hub_ee_registry/README.md
+++ b/roles/hub_ee_registry/README.md
@@ -14,6 +14,7 @@ An Ansible Role to create EE Registries in Automation Hub.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`proxy_url`|""|no|str|The URL for the proxy. Defaults to global `proxy_url` variable.|
@@ -66,6 +67,7 @@ This also speeds up the overall role.
 |`download_concurrency`|""|no|str|Number of concurrent collections to download|
 |`rate_limit`|""|no|str|Limits total download rate in requests per second.|
 |`state`|`present`|no|str|Desired state of the ee_registry.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Project Data Structure
 

--- a/roles/hub_ee_registry/tasks/main.yml
+++ b/roles/hub_ee_registry/tasks/main.yml
@@ -51,6 +51,7 @@
         cas_async_delay: "{{ hub_configuration_ee_registry_async_delay }}"
         cas_async_retries: "{{ hub_configuration_ee_registry_async_retries }}"
         cas_job_async_results_item: "{{ __ee_registries_job_async_result_item }}"
+        cas_register_subvar: hub_ee_registry
         cas_error_list_var_name: "hub_ee_registry_errors"
         __operation: "{{ operation_translate[__ee_registries_job_async_result_item.__hub_ee_registry_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} EE Registry {{ __ee_registries_job_async_result_item.__hub_ee_registry_item.name }} | Wait for finish the EE Registry {{ __operation.action }}"

--- a/roles/hub_ee_registry_index/README.md
+++ b/roles/hub_ee_registry_index/README.md
@@ -14,6 +14,7 @@ An Ansible Role to index EE Registries in Automation Hub.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`hub_ee_registries`|`see below`|yes|Data structure describing your ee_registries, described below. (Note this is the same as for the `ee_registries` role and the variable can be combined). Note that this role will only do anything if the `index` sub-option of this variable is set to true.||
@@ -59,6 +60,7 @@ This also speeds up the overall role.
 |`wait`|true|no|str|Whether to wait for the indexing to complete|
 |`interval`|`hub_configuration_ee_registry_index_async_delay`|no|str|The interval which the indexing task will be checked for completion|
 |`timeout`|""|no|str|How long to wait for the indexing task to complete|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Project Data Structure
 

--- a/roles/hub_ee_registry_index/tasks/main.yml
+++ b/roles/hub_ee_registry_index/tasks/main.yml
@@ -45,6 +45,7 @@
         cas_async_delay: "{{ hub_configuration_ee_registry_index_async_delay }}"
         cas_async_retries: "{{ hub_configuration_ee_registry_index_async_retries }}"
         cas_job_async_results_item: "{{ __ee_registry_indexes_job_async_result_item }}"
+        cas_register_subvar: hub_ee_registry_index
         cas_error_list_var_name: "hub_ee_registry_index_errors"
         __operation: "{{ operation_translate[__ee_registry_indexes_job_async_result_item.__hub_ee_registry_index_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} EE registry index {{ __ee_registry_indexes_job_async_result_item.__hub_ee_registry_index_item.name }} | Wait for finish the EE registry index {{ __operation.action }}"

--- a/roles/hub_ee_registry_sync/README.md
+++ b/roles/hub_ee_registry_sync/README.md
@@ -14,6 +14,7 @@ An Ansible Role to sync EE Registries in Automation Hub.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`hub_ee_registries`|`see below`|yes|Data structure describing your ee_registries, described below. (Note this is the same as for the `ee_registries` role and the variable can be combined. Note that this role will only do anything if the `sync` sub-option of this variable is set to true.)||
@@ -59,6 +60,7 @@ This also speeds up the overall role.
 |`wait`|true|no|str|Whether to wait for the sync to complete|
 |`interval`|`hub_configuration_ee_registry_sync_async_delay`|no|str|The interval which the sync task will be checked for completion|
 |`timeout`|""|no|str|How long to wait for the sync task to complete|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Project Data Structure
 

--- a/roles/hub_ee_registry_sync/tasks/main.yml
+++ b/roles/hub_ee_registry_sync/tasks/main.yml
@@ -45,6 +45,7 @@
         cas_async_delay: "{{ hub_configuration_ee_registry_sync_async_delay }}"
         cas_async_retries: "{{ hub_configuration_ee_registry_sync_async_retries }}"
         cas_job_async_results_item: "{{ __ee_registry_syncs_job_async_result_item }}"
+        cas_register_subvar: hub_ee_registry_sync
         cas_error_list_var_name: "hub_ee_registry_sync_errors"
         __operation: "{{ operation_translate[__ee_registry_syncs_job_async_result_item.__hub_ee_registry_sync_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} EE registry sync {{ __ee_registry_syncs_job_async_result_item.__hub_ee_registry_sync_item.name }} | Wait for finish the EE registry sync {{ __operation.action }}"

--- a/roles/hub_ee_repository/README.md
+++ b/roles/hub_ee_repository/README.md
@@ -14,6 +14,7 @@ An Ansible Role to create Repositories in Automation Hub.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`hub_ee_repositories`|`see below`|yes|Data structure describing your ee_repositories, described below.||
@@ -59,6 +60,7 @@ This also speeds up the overall role.
 |`readme`|""|no|str|The readme for the ee repository. (mutex with readme_file)|
 |`readme_file`|""|no|str|The file location for the readme for the ee repository. (mutex with readme)|
 |`state`|`present`|no|str|Desired state of the ee_repository.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 |`registry`|""|no|str|The remote registry that the repository belongs in.|
 |`upstream_name`|""|no|str|The name of the image upstream.|
 |`include_tags`|""|no|str|The tags to pull in.|

--- a/roles/hub_ee_repository/tasks/main.yml
+++ b/roles/hub_ee_repository/tasks/main.yml
@@ -49,6 +49,7 @@
         cas_async_delay: "{{ hub_configuration_ee_repository_async_delay }}"
         cas_async_retries: "{{ hub_configuration_ee_repository_async_retries }}"
         cas_job_async_results_item: "{{ __ee_repositories_job_async_result_item }}"
+        cas_register_subvar: hub_ee_repository
         cas_error_list_var_name: "hub_ee_repository_errors"
         __operation: "{{ operation_translate[__ee_repositories_job_async_result_item.__hub_ee_repository_sync_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} EE Repository {{ __ee_repositories_job_async_result_item.__hub_ee_repository_sync_item.name }} | Wait for finish the EE Repository {{ __operation.action }}"

--- a/roles/hub_ee_repository_sync/README.md
+++ b/roles/hub_ee_repository_sync/README.md
@@ -14,6 +14,7 @@ An Ansible Role to sync EE Repositories in Automation Hub.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`hub_ee_repositories`|`see below`|yes|Data structure describing your ee_repositories, described below. (Note this is the same as for the `ee_repository` role and the variable can be combined. Note that this role will only do anything if the `sync` sub-option of this variable is set to true.)||
@@ -59,6 +60,7 @@ This also speeds up the overall role.
 |`wait`|true|no|str|Whether to wait for the sync to complete|
 |`interval`|`hub_configuration_ee_repository_sync_async_delay`|no|str|The interval which the sync task will be checked for completion|
 |`timeout`|""|no|str|How long to wait for the sync task to complete|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Project Data Structure
 

--- a/roles/hub_ee_repository_sync/tasks/main.yml
+++ b/roles/hub_ee_repository_sync/tasks/main.yml
@@ -45,6 +45,7 @@
         cas_async_delay: "{{ hub_configuration_ee_repository_sync_async_delay }}"
         cas_async_retries: "{{ hub_configuration_ee_repository_sync_async_retries }}"
         cas_job_async_results_item: "{{ __ee_repository_syncs_job_async_result_item }}"
+        cas_register_subvar: hub_ee_repository_sync
         cas_error_list_var_name: "hub_ee_repository_sync_errors"
         __operation: "{{ operation_translate[__ee_repository_syncs_job_async_result_item.__hub_ee_repository_sync_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} EE repository sync {{ __ee_repository_syncs_job_async_result_item.__hub_ee_repository_sync_item.name }} | Wait for finish the EE repository sync {{ __operation.action }}"

--- a/roles/hub_group/README.md
+++ b/roles/hub_group/README.md
@@ -15,6 +15,7 @@ An Ansible Role to create groups in Automation Hub.
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`ah_groups`|`see below`|yes|Data structure describing your groups, described below.||
 
@@ -55,6 +56,7 @@ This also speeds up the overall role.
 |`name`|""|yes|str|Group Name. Must be lower case containing only alphanumeric characters and underscores.|
 |`perms`|""|yes|str|The list of permissions to add to or remove from the given group. See below for options.|
 |`state`|`present`|no|str|Desired state of the group.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 <!-- |`new_name`|""|yes|str|Setting this option will change the existing name (looked up via the name field.| -->
 #### perms
 

--- a/roles/hub_group/tasks/main.yml
+++ b/roles/hub_group/tasks/main.yml
@@ -43,6 +43,7 @@
         cas_async_delay: "{{ hub_configuration_group_async_delay }}"
         cas_async_retries: "{{ hub_configuration_group_async_retries }}"
         cas_job_async_results_item: "{{ __groups_job_async_result_item }}"
+        cas_register_subvar: hub_group
         cas_error_list_var_name: "hub_group_errors"
         __operation: "{{ operation_translate[__groups_job_async_result_item.__hub_group_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Group {{ __groups_job_async_result_item.__hub_group_item.name }} | Wait for finish the Group {{ __operation.action }}"

--- a/roles/hub_group_roles/README.md
+++ b/roles/hub_group_roles/README.md
@@ -14,6 +14,7 @@ An Ansible Role to add roles to groups in Automation Hub.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`hub_group_roles`|`see below`|yes|Data structure describing the roles which are applied to groups, described below.||
@@ -57,6 +58,7 @@ This also speeds up the overall role.
 |`groups`|""|yes|str| List of Group Names to apply the roles to. If the group does not exist, it will be created. Must be lower case containing only alphanumeric characters and underscores.|
 |`role_list`|""|yes|str|The list of roles to add to or remove from the given group. See below for options.|
 |`state`|`present`|no|str|Desired state of the group. Can be `present`, `enforced`, or `absent`. If absent, then the module deletes the given combination of roles for given groups. If present, then the module creates the group roles if it does not already exist. If enforced, then the module will remove any group role combinations not provided.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 #### role_list
 

--- a/roles/hub_group_roles/tasks/main.yml
+++ b/roles/hub_group_roles/tasks/main.yml
@@ -43,6 +43,7 @@
         cas_async_delay: "{{ hub_configuration_group_roles_async_delay }}"
         cas_async_retries: "{{ hub_configuration_group_roles_async_retries }}"
         cas_job_async_results_item: "{{ __group_roles_job_async_result_item }}"
+        cas_register_subvar: hub_group_roles
         cas_error_list_var_name: "hub_group_roles_errors"
         __operation: "{{ operation_translate[__group_roles_job_async_result_item.__hub_group_roles_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Group roles {{ __group_roles_job_async_result_item.__hub_group_roles_item.groups }} | Wait for finish the Group roles {{ __operation.action }}"

--- a/roles/hub_namespace/README.md
+++ b/roles/hub_namespace/README.md
@@ -15,6 +15,7 @@ An Ansible Role to create Namespaces in Automation Hub.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`hub_namespaces`|`see below`|yes|Data structure describing your namespaces, described below.||
@@ -65,6 +66,7 @@ This also speeds up the overall role.
 |`links`|[]|no|list|A list of dictionaries of Name and url values for links related the Namespace. See below for details.|
 |`groups`|[]|yes|list|A list of dictionaries of the Names of groups that own the Namespace.|
 |`state`|`present`|no|str|Desired state of the namespace.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 #### Links
 

--- a/roles/hub_namespace/tasks/main.yml
+++ b/roles/hub_namespace/tasks/main.yml
@@ -64,6 +64,7 @@
         cas_async_delay: "{{ hub_configuration_namespace_async_delay }}"
         cas_async_retries: "{{ hub_configuration_namespace_async_retries }}"
         cas_job_async_results_item: "{{ __namespaces_job_async_result_item }}"
+        cas_register_subvar: hub_namespace
         cas_error_list_var_name: "hub_namespace_errors"
         __operation: "{{ operation_translate[__namespaces_job_async_result_item.__hub_namespace_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Namespace {{ __namespaces_job_async_result_item.__hub_namespace_item.name }} | Wait for finish the Namespace {{ __operation.action }}"

--- a/roles/hub_publish/README.md
+++ b/roles/hub_publish/README.md
@@ -15,6 +15,7 @@ An Ansible Role to publish collections to Automation Hub or Galaxies.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`aap_configuration_working_dir`|`/var/tmp`|no|The working directory where the built artifacts live, or where the artifacts will be built.||
@@ -65,6 +66,7 @@ This also speeds up the overall role.
 |`key_path`|""|no|str|Path to ssh key for authentication.|
 |`ssh_opts`|""|no|str|Options git will pass to ssh when used as protocol.|
 |`collection_local_path`|""|no|str|Path to collection stored locally. Required if git_url not set. This value will be used rather than git_url if set.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard Project Data Structure
 

--- a/roles/hub_publish/tasks/main.yml
+++ b/roles/hub_publish/tasks/main.yml
@@ -117,6 +117,7 @@
         cas_async_delay: "{{ hub_configuration_publish_async_delay }}"
         cas_async_retries: "{{ hub_configuration_publish_async_retries }}"
         cas_job_async_results_item: "{{ __publish_job_async_result_item }}"
+        cas_register_subvar: hub_publish
         cas_error_list_var_name: "hub_publish_errors"
         cas_object_label: "Waiting for collection {{ (__publish_job_async_result_item.__hub_collection_file | basename).split('-')[1] }} to be published"
 

--- a/roles/hub_role/README.md
+++ b/roles/hub_role/README.md
@@ -14,6 +14,7 @@ An Ansible Role to create role permissions in Automation Hub.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`hub_roles`|`see below`|yes|Data structure describing your role permissions, described below.||
@@ -56,6 +57,7 @@ This also speeds up the overall role.
 |`description`|""|yes|str|The description of the permission role.|
 |`perms`|""|yes|str|The list of permissions for the given role. See below for options.|
 |`state`|`present`|no|str|Desired state of the group.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 <!-- |`new_name`|""|yes|str|Setting this option will change the existing name (looked up via the name field.| -->
 #### perms
 

--- a/roles/hub_role/tasks/main.yml
+++ b/roles/hub_role/tasks/main.yml
@@ -44,6 +44,7 @@
         cas_async_delay: "{{ hub_configuration_role_async_delay }}"
         cas_async_retries: "{{ hub_configuration_role_async_retries }}"
         cas_job_async_results_item: "{{ __roles_job_async_result_item }}"
+        cas_register_subvar: hub_role
         cas_error_list_var_name: "hub_role_errors"
         __operation: "{{ operation_translate[__roles_job_async_result_item.__hub_role_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Role {{ __roles_job_async_result_item.__hub_role_item.name }} | Wait for finish the Role {{ __operation.action }}"

--- a/roles/hub_user/README.md
+++ b/roles/hub_user/README.md
@@ -14,6 +14,7 @@ An Ansible Role to create users in Automation Hub.
 |`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
 |`aap_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`hub_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 |`aap_user_accounts`|`see below`|yes|Data structure describing your execution environment images, described below.||
@@ -63,6 +64,7 @@ This also speeds up the overall role.
 |`is_superuser`|false|no|bool|Whether the user is a superuser.|
 |`password`|""|no|str|User's password as a clear string. The password must contain at least 9 characters with numbers or special characters.|
 |`state`|`present`|no|str|Desired state of the user.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 <!-- |`new_name`|""|yes|str|Setting this option will change the existing name (looked up via the name field.| -->
 
 ### Standard Project Data Structure

--- a/roles/hub_user/tasks/main.yml
+++ b/roles/hub_user/tasks/main.yml
@@ -50,6 +50,7 @@
         cas_async_delay: "{{ hub_configuration_user_async_delay }}"
         cas_async_retries: "{{ hub_configuration_user_async_retries }}"
         cas_job_async_results_item: "{{ __users_job_async_result_item }}"
+        cas_register_subvar: hub_user
         cas_error_list_var_name: "hub_user_errors"
         __operation: "{{ operation_translate[__users_job_async_result_item.__hub_user_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} User {{ __users_job_async_result_item.__hub_user_item.username }} | Wait for finish the User {{ __operation.action }}"

--- a/tests/templated_role_example/README.md
+++ b/tests/templated_role_example/README.md
@@ -62,6 +62,7 @@ This also speeds up the overall role.
 |`description`|`false`|no|str|Description to use for the job template.|
 
 |`state`|`present`|no|str|Desired state of the resource.|
+|`register`|""|no|str|Variable to set based on the result of the object creation/modification|
 
 ### Standard ************ Data Structure
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Enables setting of a variable for individual items by adding `register` or for everything by setting `aap_configuration_register`. 

I've added a section to the readme of the collection to document this properly.

# How should this be tested?
```
---
- name: Create JT with roles
  hosts: localhost
  vars:
    aap_teams:
      - name: team1
        organization: Default
    aap_configuration_register: aap_register_var
    controller_templates:
      - name: myjt1
        project: Demo Project
        playbook: install_product_demos.yml
        inventory: Demo Inventory
        register: register_var
      - name: myjt2
        project: Demo Project
        playbook: install_product_demos.yml
        inventory: Demo Inventory

  roles:
    - infra.aap_configuration.controller_job_templates
  tasks:
    - ansible.builtin.debug:
        var: register_var
    - ansible.builtin.debug:
        var: aap_register_var
...
```

# Is there a relevant Issue open for this?
No

# Other Relevant info, PRs, etc
