### PR TITLE
Allow conditionally preventing object roles to be added to objects

### DIFF
--- a/changelogs/fragments/object_roles_conditional.yml
+++ b/changelogs/fragments/object_roles_conditional.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Allow conditionally preventing object roles to be added to objects directly.
+...

--- a/roles/controller_credentials/README.md
+++ b/roles/controller_credentials/README.md
@@ -104,6 +104,8 @@ You can apply roles to users or teams using the `roles` field. This is applied a
         - sysadmin1
 ```
 
+This functionality can be disabled by setting `aap_configuration_apply_object_roles` as `false`.
+
 ### Credential types
 
 To get a list of all the available builtin credential types, [checkout the ansible doc's link here](https://docs.ansible.com/automation-controller/4.5/html/userguide/credential_types.html)

--- a/roles/controller_credentials/defaults/main.yml
+++ b/roles/controller_credentials/defaults/main.yml
@@ -7,4 +7,5 @@ controller_configuration_credentials_async_delay: "{{ aap_configuration_async_de
 controller_configuration_credentials_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_credentials_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
+aap_configuration_apply_object_roles: true
 ...

--- a/roles/controller_credentials/tasks/main.yml
+++ b/roles/controller_credentials/tasks/main.yml
@@ -78,6 +78,7 @@
 - name: Add roles to credentials
   ansible.builtin.include_role:
     name: infra.aap_configuration.controller_roles
+  when: aap_configuration_apply_object_roles
   vars:
     controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
     _item_list: "{{ credentials if credentials is defined else controller_credentials }}"

--- a/roles/controller_instance_groups/README.md
+++ b/roles/controller_instance_groups/README.md
@@ -105,6 +105,8 @@ You can apply roles to users or teams using the `roles` field. This is applied a
         - sysadmin1
 ```
 
+This functionality can be disabled by setting `aap_configuration_apply_object_roles` as `false`.
+
 ### Standard Instance Group Data Structure
 
 #### Yaml Example

--- a/roles/controller_instance_groups/defaults/main.yml
+++ b/roles/controller_instance_groups/defaults/main.yml
@@ -6,4 +6,5 @@ controller_configuration_instance_groups_async_delay: "{{ aap_configuration_asyn
 controller_configuration_instance_groups_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_instance_groups_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
+aap_configuration_apply_object_roles: true
 ...

--- a/roles/controller_instance_groups/tasks/main.yml
+++ b/roles/controller_instance_groups/tasks/main.yml
@@ -81,6 +81,7 @@
 - name: Add roles to instance groups
   ansible.builtin.include_role:
     name: infra.aap_configuration.controller_roles
+  when: aap_configuration_apply_object_roles
   vars:
     controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
     _item_list: "{{ controller_instance_groups }}"

--- a/roles/controller_inventories/README.md
+++ b/roles/controller_inventories/README.md
@@ -131,6 +131,8 @@ You can apply roles to users or teams using the `roles` field. This is applied a
         - myteam2
 ```
 
+This functionality can be disabled by setting `aap_configuration_apply_object_roles` as `false`.
+
 ### Standard Inventory Data Structure
 
 #### Json Example

--- a/roles/controller_inventories/defaults/main.yml
+++ b/roles/controller_inventories/defaults/main.yml
@@ -7,4 +7,5 @@ controller_configuration_inventories_async_delay: "{{ aap_configuration_async_de
 controller_configuration_inventories_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_inventories_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
+aap_configuration_apply_object_roles: true
 ...

--- a/roles/controller_inventories/tasks/main.yml
+++ b/roles/controller_inventories/tasks/main.yml
@@ -80,6 +80,7 @@
 - name: Add roles to inventories
   ansible.builtin.include_role:
     name: infra.aap_configuration.controller_roles
+  when: aap_configuration_apply_object_roles
   vars:
     controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
     _item_list: "{{ inventory if inventory is defined else controller_inventories }}"

--- a/roles/controller_job_templates/README.md
+++ b/roles/controller_job_templates/README.md
@@ -149,6 +149,8 @@ You can apply roles to users or teams using the `roles` field. This is applied a
         - sysadmin1
 ```
 
+This functionality can be disabled by setting `aap_configuration_apply_object_roles` as `false`.
+
 ### Surveys
 
 Refer to the [controller Api Guide](https://docs.ansible.com/ansible-tower/latest/html/towerapi/api_ref.html#/Job_Templates/Job_Templates_job_templates_survey_spec_create) for more information about forming surveys

--- a/roles/controller_job_templates/defaults/main.yml
+++ b/roles/controller_job_templates/defaults/main.yml
@@ -7,4 +7,5 @@ controller_configuration_job_templates_async_delay: "{{ aap_configuration_async_
 controller_configuration_job_templates_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_job_templates_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
+aap_configuration_apply_object_roles: true
 ...

--- a/roles/controller_job_templates/tasks/main.yml
+++ b/roles/controller_job_templates/tasks/main.yml
@@ -122,6 +122,7 @@
 - name: Add roles to job templates
   ansible.builtin.include_role:
     name: infra.aap_configuration.controller_roles
+  when: aap_configuration_apply_object_roles
   vars:
     controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
     _item_list: "{{ job_templates if job_templates is defined else controller_templates }}"

--- a/roles/controller_projects/README.md
+++ b/roles/controller_projects/README.md
@@ -124,6 +124,8 @@ You can apply roles to users or teams using the `roles` field. This is applied a
         - myteam2
 ```
 
+This functionality can be disabled by setting `aap_configuration_apply_object_roles` as `false`.
+
 ### Standard Project Data Structure
 
 #### Json Example

--- a/roles/controller_projects/defaults/main.yml
+++ b/roles/controller_projects/defaults/main.yml
@@ -7,4 +7,5 @@ controller_configuration_projects_async_delay: "{{ aap_configuration_async_delay
 controller_configuration_projects_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_projects_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
+aap_configuration_apply_object_roles: true
 ...

--- a/roles/controller_projects/tasks/main.yml
+++ b/roles/controller_projects/tasks/main.yml
@@ -95,6 +95,7 @@
 - name: Add roles to projects
   ansible.builtin.include_role:
     name: infra.aap_configuration.controller_roles
+  when: aap_configuration_apply_object_roles
   vars:
     controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
     _item_list: "{{ projects if projects is defined else controller_projects }}"

--- a/roles/controller_workflow_job_templates/README.md
+++ b/roles/controller_workflow_job_templates/README.md
@@ -127,6 +127,8 @@ You can apply roles to users or teams using the `roles` field. This is applied a
       users: manager1
 ```
 
+This functionality can be disabled by setting `aap_configuration_apply_object_roles` as `false`.
+
 ### Variables For Workflow Job Template Node
 
 |Variable Name|Default Value|Required|Type|Description|

--- a/roles/controller_workflow_job_templates/defaults/main.yml
+++ b/roles/controller_workflow_job_templates/defaults/main.yml
@@ -7,4 +7,5 @@ controller_configuration_workflow_job_templates_async_delay: "{{ aap_configurati
 controller_configuration_workflow_job_templates_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_workflows_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
+aap_configuration_apply_object_roles: true
 ...

--- a/roles/controller_workflow_job_templates/tasks/main.yml
+++ b/roles/controller_workflow_job_templates/tasks/main.yml
@@ -119,6 +119,7 @@
 - name: Add roles to job templates
   ansible.builtin.include_role:
     name: infra.aap_configuration.controller_roles
+  when: aap_configuration_apply_object_roles
   vars:
     controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
     _item_list: "{{ workflow_job_templates if workflow_job_templates is defined else controller_workflows }}"


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
Allow conditionally preventing object roles to be added to objects directly.

By setting `aap_configuration_apply_object_roles: false`

Consider the scenario that I have a tight pipeline which is created with dispatch controlling which items can be created by the objects which are provided by the end users. With the addition of object roles being added directly, people may be able to subvert the controls by providing themselves admin access. This ensures that if we don't want to give someone the ability to directly add the objects we can.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->


# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
