### PR TITLE
Add role for EDA Credential Input Sources

### DIFF
--- a/changelogs/fragments/eda_credential_input_sources_role.yml
+++ b/changelogs/fragments/eda_credential_input_sources_role.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add role for creation of EDA credential input sources.
+...

--- a/roles/dispatch/defaults/main.yml
+++ b/roles/dispatch/defaults/main.yml
@@ -189,6 +189,9 @@ eda_configuration_dispatcher_roles:
   - role: eda_credentials
     var: eda_credentials
     tags: credential
+  - role: eda_credential_input_sources
+    var: eda_credential_input_sources
+    tags: credential_input_sources
   - role: eda_controller_tokens
     var: eda_controller_tokens
     tags: controller_token

--- a/roles/dispatch/tasks/include_wildcard_vars.yml
+++ b/roles/dispatch/tasks/include_wildcard_vars.yml
@@ -51,6 +51,7 @@
       - controller_workflow_launch_jobs
       - eda_credential_types
       - eda_credentials
+      - eda_credential_input_sources
       - eda_controller_tokens
       - eda_projects
       - eda_event_streams

--- a/roles/eda_credential_input_sources/README.md
+++ b/roles/eda_credential_input_sources/README.md
@@ -73,7 +73,7 @@ This also speeds up the overall role.
 |`target_credential`|""|yes|str|Target Credential name (the credential receiving the lookup value.)|
 |`source_credential`|""|yes|str|Source Credential name (the credential the lookup value will be retrieved from.)|
 |`description`|""|no|str|Description to use for the credential input source.|
-|`organization`|""|no|str|Organization this Credential Input Source belongs to.|
+|`organization`|""|yes|str|Organization this Credential Input Source belongs to.|
 |`input_field_name`|""|yes|str|The name of the Credential input field which will be set from the lookup value.|
 |`metadata`|{}|no|dict|Metadata provided to the target credential for the lookup.|
 |`state`|`present`|no|str|Desired state of the credential.|

--- a/roles/eda_credential_input_sources/README.md
+++ b/roles/eda_credential_input_sources/README.md
@@ -1,0 +1,131 @@
+# infra.aap_configuration.eda_credential_input_sources
+
+## Description
+
+An Ansible Role to create Credential Input Sources in EDA Controller.
+
+## Variables
+
+|Variable Name|Default Value|Required|Description|Example|
+|:---|:---:|:---:|:---|:---|
+|`platform_state`|"present"|no|The state all objects will take unless overridden by object default|'absent'|
+|`aap_hostname`|""|yes|URL to the Ansible Automation Platform Server.|127.0.0.1|
+|`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
+|`aap_username`|""|no|Admin User on the Ansible Automation Platform Server. Either username / password or oauthtoken need to be specified.||
+|`aap_password`|""|no|Platform Admin User's password on the Server.  This should be stored in an Ansible Vault at vars/platform-secrets.yml or elsewhere and called from a parent playbook.||
+|`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
+|`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the controller host.||
+|`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
+|`eda_credential_input_sources`|`see below`|yes|Data structure describing your credential input sources. Described below.||
+
+### Enforcing defaults
+
+The following Variables complement each other.
+If Both variables are not set, enforcing default values is not done.
+Enabling these variables enforce default values on options that are optional in the EDA API.
+This should be enabled to enforce configuration and prevent configuration drift. It is recommended to be enabled, however it is not enforced by default.
+
+Enabling this will enforce configuration without specifying every option in the configuration files.
+
+'eda_configuration_credential_input_sources_enforce_defaults' defaults to the value of 'aap_configuration_enforce_defaults' if it is not explicitly called. This allows for enforced defaults to be toggled for the entire suite of AAP configuration roles with a single variable, or for the user to selectively use it.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`eda_configuration_credential_input_sources_enforce_defaults`|`false`|no|Whether or not to enforce default option values on only the credential input sources role|
+|`aap_configuration_enforce_defaults`|`false`|no|This variable enables enforced default values as well, but is shared across multiple roles, see above.|
+
+### Secure Logging Variables
+
+The following Variables complement each other.
+If Both variables are not set, secure logging defaults to false.
+The role defaults to false as normally the add group_roles task does not include sensitive information.
+eda_configuration_credential_input_sources_secure_logging defaults to the value of aap_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of automation hub configuration roles with a single variable, or for the user to selectively use it.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`eda_configuration_credential_input_sources_secure_logging`|`true`|no|Whether or not to include the sensitive Registry role tasks in the log.  Set this value to `true` if you will be providing your sensitive values from elsewhere.|
+|`aap_configuration_secure_logging`|`false`|no|Whether or not to include the sensitive Registry role tasks in the log.  Set this value to `true` if you will be providing your sensitive values from elsewhere.|
+
+### Asynchronous Retry Variables
+
+The following Variables set asynchronous retries for the role.
+If neither of the retries or delay or retries are set, they will default to their respective defaults.
+This allows for all items to be created, then checked that the task finishes successfully.
+This also speeds up the overall role.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`aap_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
+|`eda_configuration_credential_input_sources_async_retries`|`aap_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
+|`aap_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
+|`eda_configuration_credential_input_sources_async_delay`|`aap_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`aap_configuration_loop_delay`|1000|no|This variable sets the loop_delay for the role globally.|
+|`eda_configuration_credential_input_sources_async_delay`|`aap_configuration_loop_delay`|no|This variable sets the loop_delay for the role.|
+|`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
+
+## Data Structure
+
+### Credential Input Source Variables
+
+|Variable Name|Default Value|Required|Type|Description|
+|:---:|:---:|:---:|:---:|:---:|
+|`target_credential`|""|yes|str|Target Credential name (the credential receiving the lookup value.)|
+|`source_credential`|""|yes|str|Source Credential name (the credential the lookup value will be retrieved from.)|
+|`description`|""|no|str|Description to use for the credential input source.|
+|`organization`|""|no|str|Organization this Credential Input Source belongs to.|
+|`input_field_name`|""|yes|str|The name of the Credential input field which will be set from the lookup value.|
+|`metadata`|{}|no|dict|Metadata provided to the target credential for the lookup.|
+|`state`|`present`|no|str|Desired state of the credential.|
+
+### Standard Credential Input Source Data Structure
+
+#### Yaml Example
+
+```yaml
+---
+eda_credential_input_sources:
+  - target_credential: hashivault_lookup
+    source_credential: github_hmac_secret
+    description: Lookup the GitHub HMAC Secret in Hashi Vault
+    organization: "Default"
+    input_field_name: "secret"
+    metadata:
+      secret_key: "hmac"
+      secret_path: "my/path/to/github/secrets/"
+    state: present
+```
+
+## Playbook Examples
+
+### Standard Role Usage
+
+```yaml
+---
+- name: Add credential input source to EDA Controller
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    eda_validate_certs: false
+  # Define following vars here, or in eda_configs/eda_auth.yml
+  # controller_host: ansible-eda-web-svc-test-credential.example.com
+  # eda_token: changeme
+  pre_tasks:
+    - name: Include vars from eda_configs directory
+      ansible.builtin.include_vars:
+        dir: ./vars
+        extensions: ["yml"]
+      tags:
+        - always
+  roles:
+    - infra.aap_configuration.eda_credential_input_sources
+```
+
+## License
+
+[GPLv3+](https://github.com/redhat-cop/infra.aap_configuration/blob/devel/LICENSE)
+
+## Author
+
+[Derek Waters](https://github.com/derekwaters/)

--- a/roles/eda_credential_input_sources/README.md
+++ b/roles/eda_credential_input_sources/README.md
@@ -4,6 +4,10 @@
 
 An Ansible Role to create Credential Input Sources in EDA Controller.
 
+## Requirements
+
+This role requires ansible.eda >= 2.9.0
+
 ## Variables
 
 |Variable Name|Default Value|Required|Description|Example|

--- a/roles/eda_credential_input_sources/defaults/main.yml
+++ b/roles/eda_credential_input_sources/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+eda_credential_input_sources: []
+eda_configuration_credential_input_sources_secure_logging: "{{ aap_configuration_secure_logging | default(true) }}"
+eda_configuration_credential_input_sources_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
+eda_configuration_credential_input_sources_async_delay: "{{ aap_configuration_async_delay| default(1) }}"
+aap_configuration_async_dir:
+eda_configuration_credential_input_sources_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
+...

--- a/roles/eda_credential_input_sources/meta/argument_specs.yml
+++ b/roles/eda_credential_input_sources/meta/argument_specs.yml
@@ -1,0 +1,78 @@
+---
+argument_specs:
+  main:
+    short_description: An Ansible Role to create credential input sources in EDA controller.
+    options:
+      eda_credential_input_sources:
+        default: []
+        required: false
+        description: Data structure describing your credential input sources to manage.
+        type: list
+        elements: dict
+
+      # Async variables
+      eda_configuration_credential_input_sources_async_retries:
+        default: "{{ aap_configuration_async_retries | default(50) }}"
+        required: false
+        description: This variable sets the number of retries to attempt for the role.
+      aap_configuration_async_retries:
+        default: 50
+        required: false
+        description: This variable sets number of retries across all roles as a default.
+      eda_configuration_credential_input_sources_async_delay:
+        default: "{{ aap_configuration_async_delay| default(1) }}"
+        required: false
+        description: This variable sets delay between retries for the role.
+      eda_configuration_async_delay:
+        default: 1
+        required: false
+        description: This variable sets delay between retries across all roles as a default.
+      aap_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
+
+      # No_log variables
+      eda_configuration_credential_input_sources_secure_logging:
+        default: "{{ aap_configuration_secure_logging | default(true) }}"
+        required: false
+        type: bool
+        description: Whether or not to include the sensitive role tasks in the log. Set this value to `true` if you will be providing your sensitive values from elsewhere.
+      aap_configuration_secure_logging:
+        default: false
+        required: false
+        type: bool
+        description: This variable enables secure logging across all roles as a default.
+
+      # Generic across all roles
+      platform_state:
+        default: present
+        required: false
+        description: The state all objects will take unless overridden by object default
+        type: str
+      aap_hostname:
+        default: None
+        required: false
+        description: URL to the Ansible Automation Platform Server.
+        type: str
+      aap_validate_certs:
+        default: true
+        required: false
+        description: Whether or not to validate the Ansible Automation Platform Server's SSL certificate.
+        type: str
+      aap_username:
+        default: None
+        required: false
+        description: Admin User on the Ansible Automation Platform Server. Either username / password or oauthtoken need to be specified.
+        type: str
+      aap_password:
+        default: None
+        required: false
+        description: Platform Admin User's password on the Server.  This should be stored in an Ansible Vault at vars/platform-secrets.yml or elsewhere and called from a parent playbook.
+        type: str
+      aap_token:
+        default: None
+        required: false
+        description: Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.
+        type: str
+...

--- a/roles/eda_credential_input_sources/meta/main.yml
+++ b/roles/eda_credential_input_sources/meta/main.yml
@@ -1,0 +1,43 @@
+---
+galaxy_info:
+  role_name: eda_credential_input_sources
+  author: Derek Waters
+  description: An Ansible Role to create credential input sources in EDA Controller.
+  company: Red Hat
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+  license: GPL-3.0-or-later
+
+  min_ansible_version: 2.16.0
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+
+  # github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  platforms:
+    - name: EL
+      versions:
+        - all
+
+  galaxy_tags:
+    - edacontroller
+    - eda
+    - configuration
+    - credential
+    - credentials
+
+dependencies:
+  - role: global_vars
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+...

--- a/roles/eda_credential_input_sources/tasks/main.yml
+++ b/roles/eda_credential_input_sources/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+# Create EDA Controller Credential Input Source
+- name: Manage EDA Controller credential input source Block
+  vars:
+    ansible_async_dir: "{{ aap_configuration_async_dir }}"
+  no_log: "{{ eda_configuration_credential_input_sources_secure_logging }}"
+  block:
+    - name: Add EDA Controller credential input source
+      ansible.eda.credential_input_source:
+        target_credential: "{{ __credential_input_source_item.target_credential | mandatory }}"
+        input_field_name: "{{ __credential_input_source_item.input_field_name | mandatory }}"
+        source_credential: "{{ __credential_input_source_item.source_credential | default(omit, true) }}"
+        description: "{{ __credential_input_source_item.description | default(('' if eda_configuration_credential_input_sources_enforce_defaults else omit), true) }}"
+        organization_name: "{{ __credential_input_source_item.organization | default(omit) }}"
+        metadata: "{{ __credential_input_source_item.metadata | default(({} if eda_configuration_credential_input_sources_enforce_defaults else omit), true) }}"
+        state: "{{ __credential_input_source_item.state | default(platform_state | default('present')) }}"
+
+        # Role specific options
+        controller_username: "{{ aap_username | default(omit, true) }}"
+        controller_password: "{{ aap_password | default(omit, true) }}"
+        controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+        request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+        controller_host: "{{ aap_hostname | default(omit, true) }}"
+        validate_certs: "{{ aap_validate_certs | default(omit) }}"
+      loop: "{{ eda_credential_input_sources }}"
+      loop_control:
+        loop_var: __credential_input_source_item
+        label: "{{ __operation.verb }} EDA Credential Input Source for Credential {{ __credential_input_source_item.target_credential }}"
+        pause: "{{ eda_configuration_credential_input_sources_async_delay }}"
+      async: 1000
+      poll: 0
+      register: __credential_input_sources_job_async
+      changed_when: not __credential_input_sources_job_async.changed
+      vars:
+        __operation: "{{ operation_translate[__credential_input_sources_job_async.state | default(platform_state) | default('present')] }}"
+
+    - name: Create credential input source | Wait for finish the credential input source creation
+      when:
+        - not ansible_check_mode
+        - __credential_input_sources_job_async_result_item.ansible_job_id is defined
+      ansible.builtin.include_role:
+        name: infra.aap_configuration.collect_async_status
+      loop: "{{ __credential_input_sources_job_async.results }}"
+      loop_control:
+        loop_var: __credential_input_sources_job_async_result_item
+        label: "{{ __operation.verb }} credential input source {{ __credential_input_sources_job_async_result_item.__credential_input_source_item.name }} | Wait for finish the credential input source {{ __operation.action }}"
+      vars:
+        cas_secure_logging: "{{ eda_configuration_credential_input_sources_secure_logging }}"
+        cas_async_delay: "{{ eda_configuration_credential_input_sources_async_delay }}"
+        cas_async_retries: "{{ eda_configuration_credential_input_sources_async_retries }}"
+        cas_job_async_results_item: "{{ __credential_input_sources_job_async_result_item }}"
+        cas_register_subvar: eda_credential_input_sources
+        cas_error_list_var_name: "eda_credential_input_sources_errors"
+        __operation: "{{ operation_translate[__credential_input_sources_job_async_result_item.__credential_input_source_item.state | default(platform_state) | default('present')] }}"
+        cas_object_label: "{{ __operation.verb }} credential input source {{ __credential_input_sources_job_async_result_item.__credential_input_source_item.name }} | Wait for finish the credential input source {{ __operation.action }}"
+
+  always:
+    - name: Cleanup async results files
+      when:
+        - not ansible_check_mode
+        - __credential_input_sources_job_async_result_item.ansible_job_id is defined
+      ansible.builtin.async_status:
+        jid: "{{ __credential_input_sources_job_async_result_item.ansible_job_id }}"
+        mode: cleanup
+      loop: "{{ __credential_input_sources_job_async.results }}"
+      loop_control:
+        loop_var: __credential_input_sources_job_async_result_item
+        label: "Cleaning up job results file: {{ __credential_input_sources_job_async_result_item.results_file | default('Unknown') }}"
+...

--- a/roles/eda_credential_input_sources/tasks/main.yml
+++ b/roles/eda_credential_input_sources/tasks/main.yml
@@ -11,7 +11,7 @@
         input_field_name: "{{ __credential_input_source_item.input_field_name | mandatory }}"
         source_credential: "{{ __credential_input_source_item.source_credential | default(omit, true) }}"
         description: "{{ __credential_input_source_item.description | default(('' if eda_configuration_credential_input_sources_enforce_defaults else omit), true) }}"
-        organization_name: "{{ __credential_input_source_item.organization | default(omit) }}"
+        organization_name: "{{ __credential_input_source_item.organization | mandatory }}"
         metadata: "{{ __credential_input_source_item.metadata | default(({} if eda_configuration_credential_input_sources_enforce_defaults else omit), true) }}"
         state: "{{ __credential_input_source_item.state | default(platform_state | default('present')) }}"
 
@@ -43,7 +43,7 @@
       loop: "{{ __credential_input_sources_job_async.results }}"
       loop_control:
         loop_var: __credential_input_sources_job_async_result_item
-        label: "{{ __operation.verb }} credential input source {{ __credential_input_sources_job_async_result_item.__credential_input_source_item.name }} | Wait for finish the credential input source {{ __operation.action }}"
+        label: "{{ __operation.verb }} credential input source {{ __credential_input_sources_job_async_result_item.__credential_input_source_item.target_credential }} | Wait for finish the credential input source {{ __operation.action }}"
       vars:
         cas_secure_logging: "{{ eda_configuration_credential_input_sources_secure_logging }}"
         cas_async_delay: "{{ eda_configuration_credential_input_sources_async_delay }}"
@@ -52,7 +52,7 @@
         cas_register_subvar: eda_credential_input_sources
         cas_error_list_var_name: "eda_credential_input_sources_errors"
         __operation: "{{ operation_translate[__credential_input_sources_job_async_result_item.__credential_input_source_item.state | default(platform_state) | default('present')] }}"
-        cas_object_label: "{{ __operation.verb }} credential input source {{ __credential_input_sources_job_async_result_item.__credential_input_source_item.name }} | Wait for finish the credential input source {{ __operation.action }}"
+        cas_object_label: "{{ __operation.verb }} credential input source {{ __credential_input_sources_job_async_result_item.__credential_input_source_item.target_credential }} | Wait for finish the credential input source {{ __operation.action }}"
 
   always:
     - name: Cleanup async results files

--- a/roles/eda_credential_input_sources/tests/test.yml
+++ b/roles/eda_credential_input_sources/tests/test.yml
@@ -1,0 +1,20 @@
+---
+- name: Add credential input source to EDA Controller
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    eda_validate_certs: false
+  # Define following vars here, or in eda_configs/eda_auth.yml
+  # controller_host: ansible-eda-web-svc-test-project.example.com
+  # eda_token: changeme
+  pre_tasks:
+    - name: Include vars from eda_configs directory
+      ansible.builtin.include_vars:
+        dir: ./vars
+        extensions: [yml]
+      tags:
+        - always
+  roles:
+    - infra.aap_configuration.eda_credential_input_sources
+...

--- a/roles/eda_credential_input_sources/tests/vars/credential_input_sources.yml
+++ b/roles/eda_credential_input_sources/tests/vars/credential_input_sources.yml
@@ -3,6 +3,7 @@ eda_credential_input_sources:
   - source_credential: my_hashi_server
     target_credential: github_hmac_secret
     input_field_name: secret
+    organization: Default
     metadata:
       secret_key: "hmac"
       secret_path: "path/to/secret"

--- a/roles/eda_credential_input_sources/tests/vars/credential_input_sources.yml
+++ b/roles/eda_credential_input_sources/tests/vars/credential_input_sources.yml
@@ -1,0 +1,10 @@
+---
+eda_credential_input_sources:
+  - source_credential: my_hashi_server
+    target_credential: github_hmac_secret
+    input_field_name: secret
+    metadata:
+      secret_key: "hmac"
+      secret_path: "path/to/secret"
+    description: Populate the GitHub HMAC Secret from HashiVault
+...

--- a/roles/eda_credential_input_sources/tests/vars/credentials.yml
+++ b/roles/eda_credential_input_sources/tests/vars/credentials.yml
@@ -1,0 +1,24 @@
+---
+eda_credentials:
+  - name: my_hashi_server
+    description: my HashiVault Credential
+    organization: Default
+    credential_type: "HashiCorp Vault Secret Lookup"
+    inputs:
+      api_version: "v1"
+      url: "hashi_server_url"
+      default_auth_path: "approle"
+    state: present
+  - name: github_hmac_secret
+    description: HMAC Secret for Github Access
+    organization: Default
+    credential_type: "GitHub Event Stream"
+    inputs:
+      auth_type: "hmac"
+      hash_algorithm: "sha256"
+      http_header_key: "X-Hub-Signature-256"
+      secret: "provided-by-hashi"
+      signature_encoding: "hex"
+      signature_prefix: "sha256="
+    state: present
+...

--- a/tests/configs/eda/eda_credential_input_sources.yml
+++ b/tests/configs/eda/eda_credential_input_sources.yml
@@ -1,0 +1,10 @@
+---
+eda_credential_input_sources:
+  - source_credential: hashivault_lookup
+    target_credential: github_hmac_secret
+    input_field_name: secret
+    metadata:
+      secret_key: "hmac"
+      secret_path: "path/to/secret"
+    description: Populate the GitHub HMAC Secret from HashiVault
+...

--- a/tests/configs/eda/eda_credential_input_sources.yml
+++ b/tests/configs/eda/eda_credential_input_sources.yml
@@ -3,6 +3,7 @@ eda_credential_input_sources:
   - source_credential: hashivault_lookup
     target_credential: github_hmac_secret
     input_field_name: secret
+    organization: Default
     metadata:
       secret_key: "hmac"
       secret_path: "path/to/secret"

--- a/tests/configs/eda/eda_credentials.yml
+++ b/tests/configs/eda/eda_credentials.yml
@@ -14,4 +14,24 @@ eda_credentials:
     inputs:
       username: user
       password: pass
+  # Credentials used for testing credential_input_sources
+  - name: hashivault_lookup
+    description: HashiVault Secret Lookup
+    organization: Default
+    credential_type: "HashiCorp Vault Secret Lookup"
+    inputs:
+      api_version: "v1"
+      url: "hashi_server_url"
+      default_auth_path: "approle"
+  - name: github_hmac_secret
+    description: HMAC Secret for Github Access
+    organization: Default
+    credential_type: "GitHub Event Stream"
+    inputs:
+      auth_type: "hmac"
+      hash_algorithm: "sha256"
+      http_header_key: "X-Hub-Signature-256"
+      secret: "provided-by-hashi"
+      signature_encoding: "hex"
+      signature_prefix: "sha256="
 ...


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
This PR adds a role to allow users to create EDA Credential Input Sources, to link EDA credentials to external secret management systems like CyberArk or HashiVault.

# How should this be tested?
Test case definitions have been added to the existing tests/configs/eda/ subfolder. 

Alternatively, the following sample playbook can be used to test this role:

```
---
- name: Test adding inventory credential sources

  hosts: all
  connection: local
  vars:
    aap_hostname: <hostname>
    aap_token: <token>
    aap_configuration_secure_logging: false

    eda_credentials:
      - name: test_hashivault_lookup
        description: HashiVault Secret Lookup
        organization: Default
        credential_type: "HashiCorp Vault Secret Lookup"
        inputs:
          api_version: "v1"
          url: "hashi_server_url"
          default_auth_path: "approle"
      - name: test_github_hmac_secret
        description: HMAC Secret for Github Access
        organization: Default
        credential_type: "GitHub Event Stream"
        inputs:
          auth_type: "hmac"
          hash_algorithm: "sha256"
          http_header_key: "X-Hub-Signature-256"
          secret: "provided-by-hashi"
          signature_encoding: "hex"
          signature_prefix: "sha256="
    eda_credential_input_sources:
      - source_credential: test_hashivault_lookup
        target_credential: test_github_hmac_secret
        input_field_name: secret
        organization: Default
        metadata:
          secret_key: "hmac"
          secret_path: "path/to/secret"
        description: Populate the GitHub HMAC Secret from HashiVault

  tasks:
    - name: Run dispatcher to ensure EDA credentials and sources are added
      ansible.builtin.include_role:
        name: infra.aap_configuration.dispatch
```

# Is there a relevant Issue open for this?
resolves #1261

# Other Relevant info, PRs, etc
None
