### PR TITLE
Replace pool_id to subscription_id in license management

### DIFF
--- a/changelogs/fragments/controller_license_subscription_id.yml
+++ b/changelogs/fragments/controller_license_subscription_id.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - controller_license - Make controller_license role compatible with license module by replacing pool_id parameter with subscription_id.
+...

--- a/roles/controller_license/README.md
+++ b/roles/controller_license/README.md
@@ -53,7 +53,7 @@ The module and this role can use either a manifest file, or lookup the subscript
 |`manifest`|""|no|obj|DEPRECATED - changed to `manifest_file` (still works as an alias)|
 |`manifest_username`|""|no|obj|Optional username for access to `manifest_url`|
 |`manifest_password`|""|no|obj|Optional password for access to `manifest_url`|
-|`pool_id`|""|no|str|Red Hat or Red Hat Satellite pool_id to attach to|
+|`subscription_id`|""|no|str|Red Hat or Red Hat Satellite subscription_id to attach to|
 |`eula_accepted`|""|yes|bool|DEPRECATED since Tower 3.8 - Whether to accept the End User License Agreement for Ansible controller|
 |`force`|`false`|no|bool|By default, the license manifest will only be applied if controller is currently unlicensed or trial licensed. When force=true, the license is always applied.|
 |`state`|`present`|no|str|Desired state of the resource.|
@@ -65,7 +65,7 @@ The module and this role can use either a manifest file, or lookup the subscript
 |`filters`|"default values"|no|str|dict of filters to use to narrow the subscription. See example below for how to use this.|
 |`support_level`|"Self-Support"|no|str|DEPRECATED - changed to `manifest_file` (still works as an alias)|
 |`list_num`|0|no|int|List index of the subscription to use, if you want to override the default, it is recommended to use the filters to limit the pools found.|
-|`pool_id`|""|no|str|Red Hat or Red Hat Satellite pool_id to attach to.|
+|`subscription_id`|""|no|str|Red Hat or Red Hat Satellite subscription_id to attach to.|
 |`force`|`false`|no|bool|By default, the license will only be applied if controller is currently unlicensed or trial licensed. When force=true, the license is always applied.|
 |`use_lookup`|`false`|no|bool|Whether or not to lookup subscriptions.|
 |`state`|`present`|no|str|Desired state of the resource.|

--- a/roles/controller_license/meta/argument_specs.yml
+++ b/roles/controller_license/meta/argument_specs.yml
@@ -32,10 +32,10 @@ argument_specs:
 #            required: false
 #            type: str
 #            description: Optional password for access to `manifest_url`
-#          pool_id:
+#          subscription_id:
 #            required: false
 #            type: str
-#            description: Red Hat or Red Hat Satellite pool_id to attach to
+#            description: Red Hat or Red Hat Satellite subscription_id to attach to
 #          eula_accepted:
 #            required: true
 #            type: bool

--- a/roles/controller_license/tasks/main.yml
+++ b/roles/controller_license/tasks/main.yml
@@ -6,8 +6,8 @@
   when:
     - controller_license.manifest_file is defined or controller_license.manifest is defined or controller_license.manifest_content is defined or controller_license.manifest_url is defined
 
-- name: Use subscription pool id or subscription lookup
+- name: Use subscription id or subscription lookup
   ansible.builtin.include_tasks: subscription.yml
   when:
-    - (redhat_subscription_username is defined and redhat_subscription_password is defined) or controller_license.pool_id is defined
+    - (redhat_subscription_username is defined and redhat_subscription_password is defined) or controller_license.subscription_id is defined
 ...

--- a/roles/controller_license/tasks/manifest.yml
+++ b/roles/controller_license/tasks/manifest.yml
@@ -41,7 +41,7 @@
   ansible.controller.license:
     manifest: "{{ __controller_manifest_path | default(omit) }}"
     eula_accepted: "{{ controller_license.eula_accepted | default(omit) }}" # Depreciated only for Tower 3.8.x or lower
-    pool_id: "{{ controller_license.pool_id | default(omit) }}"
+    pool_id: "{{ controller_license.subscription_id | default(omit) }}"
     force: "{{ controller_license.force | default(omit) }}"
     state: "{{ controller_license.state | default(omit) }}"
 

--- a/roles/controller_license/tasks/subscription.yml
+++ b/roles/controller_license/tasks/subscription.yml
@@ -20,7 +20,7 @@
 
 - name: subscription | Install the Controller license
   ansible.controller.license:
-    pool_id: "{{ controller_license.pool_id | default(subscription.subscriptions[(controller_license.list_num | default(0))].pool_id) }}"
+    subscription_id: "{{ controller_license.subscription_id | default(subscription.subscriptions[(controller_license.list_num | default(0))].subscription_id) }}"
     force: "{{ controller_license.force | default(omit) }}"
     state: "{{ controller_license.state | default(omit) }}"
 


### PR DESCRIPTION
Make `controller_license` role compatible with `license` module.
See https://github.com/redhat-cop/infra.aap_configuration/issues/1068#issuecomment-3727633565
