### PR TITLE
Fix for error when using ansible 2.19 or 2.20

### DIFF
--- a/changelogs/fragments/1287-fix-variables-argument-type-str.yml
+++ b/changelogs/fragments/1287-fix-variables-argument-type-str.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix "argument 'variables' is of type str" error on ansible 2.19+ by avoiding regex_replace on non-string values.

--- a/roles/controller_credential_types/tasks/main.yml
+++ b/roles/controller_credential_types/tasks/main.yml
@@ -9,7 +9,7 @@
         name: "{{ __controller_credential_type_item.name | mandatory }}"
         new_name: "{{ __controller_credential_type_item.new_name | default(omit, true) }}"
         description: "{{ __controller_credential_type_item.description | default(('' if controller_configuration_credential_types_enforce_defaults else omit), true) }}"
-        injectors: "{{ __controller_credential_type_item.injectors | default(({} if controller_configuration_credential_types_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
+        injectors: "{{ __controller_credential_type_item.injectors | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_credential_type_item.injectors is defined and __controller_credential_type_item.injectors) else ({} if controller_configuration_credential_types_enforce_defaults else omit) }}"
         inputs: "{{ __controller_credential_type_item.inputs | default(({} if controller_configuration_credential_types_enforce_defaults else omit), true) }}"
         kind: "{{ __controller_credential_type_item.kind | default('cloud') }}"
         state: "{{ __controller_credential_type_item.state | default(platform_state | default('present')) }}"

--- a/roles/controller_host_groups/tasks/main.yml
+++ b/roles/controller_host_groups/tasks/main.yml
@@ -10,7 +10,7 @@
         new_name: "{{ __controller_groups_item.new_name | default(omit, true) }}"
         description: "{{ __controller_groups_item.description | default(('' if controller_configuration_groups_enforce_defaults else omit), true) }}"
         inventory: "{{ __controller_groups_item.inventory | mandatory }}"
-        variables: "{{ __controller_groups_item.variables | default(({} if controller_configuration_groups_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
+        variables: "{{ __controller_groups_item.variables | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_groups_item.variables is defined and __controller_groups_item.variables) else ({} if controller_configuration_groups_enforce_defaults else omit) }}"
         hosts: "{{ __controller_groups_item.hosts | default(([] if controller_configuration_groups_enforce_defaults else omit), true) }}"
         children: "{{ __controller_groups_item.children | default(([] if controller_configuration_groups_enforce_defaults else omit), true) }}"
         preserve_existing_hosts: "{{ __controller_groups_item.preserve_existing_hosts | default((false if controller_configuration_groups_enforce_defaults else omit)) }}"

--- a/roles/controller_hosts/tasks/main.yml
+++ b/roles/controller_hosts/tasks/main.yml
@@ -12,7 +12,7 @@
         inventory: "{{ __controller_host_item.inventory | mandatory }}"
         enabled: "{{ __controller_host_item.enabled | default((false if controller_configuration_host_enforce_defaults else omit), true) }}"
         state: "{{ __controller_host_item.state | default(platform_state | default('present')) }}"
-        variables: "{{ __controller_host_item.variables | default(({} if controller_configuration_host_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
+        variables: "{{ __controller_host_item.variables | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_host_item.variables is defined and __controller_host_item.variables) else ({} if controller_configuration_host_enforce_defaults else omit) }}"
 
         # Role Standard Options
         controller_host: "{{ aap_hostname | default(omit, true) }}"

--- a/roles/controller_inventories/tasks/main.yml
+++ b/roles/controller_inventories/tasks/main.yml
@@ -13,7 +13,7 @@
         organization: "{{ __controller_inventory_item.organization.name | default(__controller_inventory_item.organization) | mandatory }}"
         instance_groups: "{{ __controller_inventory_item.instance_groups | default(([] if controller_configuration_inventories_enforce_defaults else omit), true) }}"
         input_inventories: "{{ __controller_inventory_item.input_inventories | default(([] if controller_configuration_inventories_enforce_defaults else omit), true) }}"
-        variables: "{{ __controller_inventory_item.variables | default(({} if controller_configuration_inventories_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
+        variables: "{{ __controller_inventory_item.variables | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_inventory_item.variables is defined and __controller_inventory_item.variables) else ({} if controller_configuration_inventories_enforce_defaults else omit) }}"
         kind: "{{ __controller_inventory_item.kind | default(('' if controller_configuration_inventories_enforce_defaults else omit), true) }}"
         host_filter: "{{ __controller_inventory_item.host_filter | default(('' if controller_configuration_inventories_enforce_defaults else omit), true) }}"
         prevent_instance_group_fallback: "{{ __controller_inventory_item.prevent_instance_group_fallback | default((false if controller_configuration_inventories_enforce_defaults else omit), true) }}"

--- a/roles/controller_inventory_sources/tasks/main.yml
+++ b/roles/controller_inventory_sources/tasks/main.yml
@@ -13,7 +13,7 @@
         organization: "{{ __controller_source_item.inventory.organization.name | default(__controller_source_item.organization | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true)) }}"
         source: "{{ __controller_source_item.source | default(('scm' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
         source_path: "{{ __controller_source_item.source_path | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        source_vars: "{{ __controller_source_item.source_vars | default(({} if controller_configuration_inventory_sources_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
+        source_vars: "{{ __controller_source_item.source_vars | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_source_item.source_vars is defined and __controller_source_item.source_vars) else ({} if controller_configuration_inventory_sources_enforce_defaults else omit) }}"
         enabled_var: "{{ __controller_source_item.enabled_var | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
         enabled_value: "{{ __controller_source_item.enabled_value | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
         host_filter: "{{ __controller_source_item.host_filter | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"

--- a/roles/controller_notification_templates/tasks/main.yml
+++ b/roles/controller_notification_templates/tasks/main.yml
@@ -13,7 +13,7 @@
         organization: "{{ __controller_notification_item.organization.name | default(__controller_notification_item.organization) | default(omit, true) }}"
         notification_type: "{{ __controller_notification_item.notification_type | default(omit, true) }}"
         notification_configuration: "{{ __controller_notification_item.notification_configuration | default(({} if controller_configuration_notifications_enforce_defaults else omit), true) }}"
-        messages: "{{ __controller_notification_item.messages | default(({} if controller_configuration_notifications_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
+        messages: "{{ __controller_notification_item.messages | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_notification_item.messages is defined and __controller_notification_item.messages) else ({} if controller_configuration_notifications_enforce_defaults else omit) }}"
         state: "{{ __controller_notification_item.state | default(platform_state | default('present')) }}"
 
         # Role Standard Options


### PR DESCRIPTION
Starting with ansible 2.19 (and also 2.20) we hit the following error all the time:

    TASK [infra.aap_configuration.collect_async_status : Handle Async Job Failure] ***
      task path: /pattern-home/.ansible/collections/ansible_collections/infra/aap_configuration/roles/collect_async_status/tasks/main.yml:24
      Read `vars_file` '/pattern-home/agof_vault.yml'.
      Read `vars_file` '/pattern-home/agof_vault.yml'.
      included: /pattern-home/.ansible/collections/ansible_collections/infra/aap_configuration/roles/collect_async_status/tasks/handle_error.yml for localhost
      Read `vars_file` '/pattern-home/agof_vault.yml'.

    TASK [infra.aap_configuration.collect_async_status : handle_error | Show error and stop execution] ***^M
      task path: /pattern-home/.ansible/collections/ansible_collections/infra/aap_configuration/roles/collect_async_status/tasks/handle_error.yml:4
      fatal: [localhost]: FAILED! => {
          "changed": false,
          "msg": "error: argument 'variables' is of type str and we were unable to convert to dict: dictionary requested, could not parse JSON or key=value"
      }
      Read `vars_file` '/pattern-home/agof_vault.yml'.

The old pattern was:

  variables: "{{ item.variables | default(({} if enforce else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"

The filter chain always runs regex_replace() on whatever comes out of default(). When item.variables is not defined, default() produces {} (an empty Python dict). Then regex_replace — a string filter — coerces that dict into the string "{}".

With 2.19 (native Jinja only): Types are preserved through the template. regex_replace returns a native Python str object "{}", which is passed directly to the module. The module sees a string where it expects a dict and fails:

  "error: argument 'variables' is of type str and we were unable to convert to dict:
  dictionary requested, could not parse JSON or key=value"

Let's just avoid calling regex_replace on non-string/empty values.

Tested this successfully with both ansible-2.18 and ansible-2.20

Closes: https://github.com/redhat-cop/infra.aap_configuration/issues/1287

<!-- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Fixes the role which broke with ansible-2.19 stricter jinja templating

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

Running the role against this https://github.com/mbaldessari/agof_minimal_config/blob/main/controller_config.yml while using ansible >= 2.19. 

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #1287 

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
