### PR TITLE
feature: Add credentials count

### DIFF
--- a/changelogs/fragments/1291-add_credentials-count-fix.yml
+++ b/changelogs/fragments/1291-add_credentials-count-fix.yml
@@ -1,0 +1,2 @@
+feat(reporting):
+  - include credentials count in get_stats output report

--- a/changelogs/fragments/1291-add_credentials-count-fix.yml
+++ b/changelogs/fragments/1291-add_credentials-count-fix.yml
@@ -1,2 +1,2 @@
-feat(reporting):
+trivial:
   - include credentials count in get_stats output report

--- a/playbooks/get_stats.yml
+++ b/playbooks/get_stats.yml
@@ -93,6 +93,19 @@
         validate_certs: "{{ aap_validate_certs | default(false) }}"
       register: r_subscription
 
+    - name: Get credentials info
+      ansible.builtin.uri:
+        url: "https://{{ aap_hostname }}/api/controller/v2/credentials/?format=json"
+        method: GET
+        force_basic_auth: true
+        user: "{{ aap_username }}"
+        password: "{{ aap_password }}"
+        return_content: true
+        headers:
+          Content-Type: application/json
+        validate_certs: "{{ aap_validate_certs | default(false) }}"
+      register: r_credentials
+
     - name: Output
       ansible.builtin.debug:
         msg:
@@ -110,5 +123,6 @@
           - "{{ r_metrics['json']['awx_status_total']['samples'] }}"
           - "{{ r_metrics['json']['awx_system_info']['samples'][0]['labels'] }}"
           - "{{ r_subscription['json']['LICENSE'] }}"
+          - "Total Credentials Count: {{ r_credentials['json']['count'] }}"
 
 ...


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
This PR modifies the playbooks/get_stats.yml to add additional output to get the  credentials count. 

# How should this be tested?
ansible-playbook -v get_stats.yml -e "@aap_configs/auth.yml"

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
