### PR TITLE
Fix formatting in controller_license argument_specs

### DIFF
--- a/changelogs/fragments/fix_controller_license_argument_spec.yml
+++ b/changelogs/fragments/fix_controller_license_argument_spec.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - Fix controller_license argument_specs: re-allow parameters that should be allowed
+  - Fix controller_license argument_specs, re-allow parameters that should be allowed


### PR DESCRIPTION

<!-- markdownlint-disable -->
# What does this PR do?
The release process is broken because it sees this as a dict, changing it to allow that to continue.


# How should this be tested?
Auto

