### PR TITLE
removing enforce defaults for schedules on execution environments

### DIFF
--- a/changelogs/fragments/1295-fix.yml
+++ b/changelogs/fragments/1295-fix.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Removing enforce defaults for schedules on execution environments because the it causes the api to return an error
+...

--- a/roles/controller_schedules/tasks/main.yml
+++ b/roles/controller_schedules/tasks/main.yml
@@ -14,7 +14,7 @@
         inventory: "{{ __controller_schedule_item.inventory | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
         credentials: "{{ __controller_schedule_item.credentials | default(omit, true) }}"
         scm_branch: "{{ __controller_schedule_item.scm_branch | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
-        execution_environment: "{{ __controller_schedule_item.execution_environment.name | default(__controller_schedule_item.execution_environment | default(('' if controller_configuration_schedules_enforce_defaults else omit), true)) }}"
+        execution_environment: "{{ __controller_schedule_item.execution_environment.name | default(__controller_schedule_item.execution_environment | default(omit, true)) }}"
         forks: "{{ __controller_schedule_item.forks | default(omit, true) }}"
         instance_groups: "{{ __controller_schedule_item.instance_groups | default(omit, true) }}"
         job_slice_count: "{{ __controller_schedule_item.job_slice_count | default((1 if controller_configuration_schedules_enforce_defaults else omit), true) }}"


### PR DESCRIPTION
removing enforce defaults for schedules on execution environments because the it causes the api to return an error
