### PR TITLE
Clarify event_streams parameter format in eda_rulebook_activations docs

### DIFF
--- a/changelogs/fragments/1271-eda-rulebook-event-streams-docs.yml
+++ b/changelogs/fragments/1271-eda-rulebook-event-streams-docs.yml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - Clarify event_streams parameter format in eda_rulebook_activations documentation.
+...

--- a/roles/eda_rulebook_activations/README.md
+++ b/roles/eda_rulebook_activations/README.md
@@ -69,7 +69,7 @@ This also speeds up the overall role.
 |`eda_credentials`|""|no|list|A list of IDs for EDA credentials used by the rulebook activation.|
 |`k8s_service_name`|""|no|str|The name of the Kubernetes service associated with this rulebook activation.|
 |`swap_single_source`|"true"|no|bool|Allow swapping of single sources in a rulebook without name match.|
-|`event_streams`|""|no|list|A list of event streams, source names, and source_index that this rulebook activation listens to. |
+|`event_streams`|""|no|list|A list of dicts defining event streams for this rulebook activation. Each dict requires `event_stream` (str, the event stream name) and one of `source_name` (str) or `source_index` (int) to identify the source. `source_name` and `source_index` are mutually exclusive. See the YAML example below.|
 |`log_level`|""|no|str|Allow setting the desired log level.|
 
 ### Standard rulebook activation Data Structure


### PR DESCRIPTION
The event_streams table description was vague and could be read as a flat list of strings. Clarify that it requires a list of dicts, each with an event_stream name and either source_name or source_index.

Fixes #1271

Made-with: Cursor

