### PR TITLE
Add repository parameter to hub_publish role

### DIFF
--- a/changelogs/fragments/1286-hub-publish-repository.yml
+++ b/changelogs/fragments/1286-hub-publish-repository.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add hub_repository variable to hub_publish role allowing collections to be published to any repository, not just staging.
+...

--- a/roles/hub_publish/README.md
+++ b/roles/hub_publish/README.md
@@ -21,6 +21,7 @@ An Ansible Role to publish collections to Automation Hub or Galaxies.
 |`aap_configuration_working_dir`|`/var/tmp`|no|The working directory where the built artifacts live, or where the artifacts will be built.||
 |`hub_auto_approve`|`false`|no|Whether the collection will be automatically approved in Automation Hub. This will only work if the account being used has correct privileges.||
 |`hub_overwrite_existing`|`false`|no|Whether the collection will be automatically overwrite an existing collection in Automation Hub. This will only work if the account being used has correct privileges.||
+|`hub_repository`|`staging`|no|Name of the destination repository to publish collections to. Defaults to `staging`.||
 |`hub_custom_collections`|`see below`|no|Data structure describing your collections, mutually exclusive to hub_collection_list, described below.||
 |`hub_collection_list`|`list`|no|Data structure file paths to pre built collections, mutually exclusive with hub_custom_collections.||
 

--- a/roles/hub_publish/defaults/main.yml
+++ b/roles/hub_publish/defaults/main.yml
@@ -21,6 +21,7 @@ aap_configuration_working_dir: /var/tmp
 
 hub_auto_approve: "{{ ah_auto_approve | default(false) }}"
 hub_overwrite_existing: "{{ ah_overwrite_existing | default(false) }}"
+hub_repository: "{{ ah_repository | default('staging') }}"
 
 hub_configuration_publish_secure_logging: "{{ aap_configuration_secure_logging | default(false) }}"
 hub_configuration_publish_async_timeout: "{{ aap_configuration_async_timeout | default(1000) }}"

--- a/roles/hub_publish/tasks/main.yml
+++ b/roles/hub_publish/tasks/main.yml
@@ -90,6 +90,7 @@
         name: "{{ (__hub_collection_file | basename).split('-')[1] }}"
         version: "{{ (__hub_collection_file | basename).split('-')[2:] | join('-') | splitext | first | splitext | first }}"
         path: "{{ __hub_collection_file }}"
+        repository: "{{ hub_repository }}"
         auto_approve: "{{ hub_auto_approve }}"
         overwrite_existing: "{{ hub_overwrite_existing }}"
         ah_host: "{{ aap_hostname | default(omit) }}"


### PR DESCRIPTION
The Publish Collections task always published to the default staging repository. Add a hub_repository variable (defaulting to 'staging') that is passed to the ansible.hub.ah_collection module's repository parameter, allowing users to publish to any repository.

Fixes #1286

Made-with: Cursor
