### PR TITLE
Fix dispatch ordering: credentials before instance_groups

### DIFF
--- a/changelogs/fragments/1014-fix-dispatch-ordering.yml
+++ b/changelogs/fragments/1014-fix-dispatch-ordering.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix dispatch ordering so credential_types, credentials, and credential_input_sources are processed before instance_groups.
+...

--- a/roles/dispatch/defaults/main.yml
+++ b/roles/dispatch/defaults/main.yml
@@ -107,9 +107,6 @@ controller_configuration_dispatcher_roles:
   - role: controller_instances
     var: controller_instances
     tags: instances
-  - role: controller_instance_groups
-    var: controller_instance_groups
-    tags: instance_groups
   - role: controller_labels
     var: controller_labels
     tags: labels
@@ -122,6 +119,9 @@ controller_configuration_dispatcher_roles:
   - role: controller_credential_input_sources
     var: controller_credential_input_sources
     tags: credential_input_sources
+  - role: controller_instance_groups
+    var: controller_instance_groups
+    tags: instance_groups
   - role: controller_execution_environments
     var: controller_execution_environments
     tags: execution_environments


### PR DESCRIPTION
Instance groups may reference credentials (e.g. container group credentials), but controller_instance_groups was dispatched before controller_credentials and controller_credential_types. This caused failures when setting up a new controller from scratch.

Reorder so credential_types, credentials, and credential_input_sources are processed before instance_groups.

Fixes #1014

Made-with: Cursor