### PR TITLE
Fix EDA credentials failing when inputs is not specified

### DIFF
--- a/changelogs/fragments/1278-fix-eda-credentials-inputs.yml
+++ b/changelogs/fragments/1278-fix-eda-credentials-inputs.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix EDA credentials failing when inputs is not specified by defaulting to an empty dict when state is present.
+...

--- a/roles/eda_credentials/tasks/main.yml
+++ b/roles/eda_credentials/tasks/main.yml
@@ -12,7 +12,7 @@
         description: "{{ __credential_item.description | default(omit) }}"
         organization_name: "{{ __credential_item.organization | default(omit) }}"
         credential_type_name: "{{ __credential_item.credential_type | mandatory }}"
-        inputs: "{{ __credential_item.inputs | default(omit) }}"
+        inputs: "{{ __credential_item.inputs | default(({} if (__credential_item.state | default(eda_state | default('present'))) == 'present' else omit)) }}"
         state: "{{ __credential_item.state | default(eda_state | default('present')) }}"
         controller_host: "{{ aap_hostname | default(omit, true) }}"
         controller_username: "{{ aap_username | default(omit, true) }}"


### PR DESCRIPTION
The ansible.eda.credential module requires the inputs parameter when state is present. When using eda_credential_input_sources to populate credentials externally, users need to create credentials without specifying inputs. Default inputs to an empty dict when state is present instead of omitting it entirely.

Fixes #1278

Made-with: Cursor
