### PR TITLE
Fix role assignment failing when users/teams are lists

### DIFF
--- a/changelogs/fragments/1296-fix-role-assignment-lists.yml
+++ b/changelogs/fragments/1296-fix-role-assignment-lists.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix role assignment failing when users/teams are specified as lists in job_templates, inventories, and workflow_job_templates roles blocks.
+...

--- a/roles/controller_inventories/tasks/main.yml
+++ b/roles/controller_inventories/tasks/main.yml
@@ -91,8 +91,8 @@
       - role: "{{ _role }}"
         inventories:
           - "{{ _item.name }}"
-        teams: "{{ _item.roles[_role].teams | default(omit) }}"
-        users: "{{ _item.roles[_role].users | default(omit) }}"
+        teams: {{ _item.roles[_role].teams | default(omit) | to_json }}
+        users: {{ _item.roles[_role].users | default(omit) | to_json }}
       {% endfor %}
       {% endif %}
       {% endfor %}

--- a/roles/controller_job_templates/tasks/main.yml
+++ b/roles/controller_job_templates/tasks/main.yml
@@ -133,8 +133,8 @@
       - role: "{{ _role }}"
         job_templates:
           - "{{ _item.name }}"
-        teams: "{{ _item.roles[_role].teams | default(omit) }}"
-        users: "{{ _item.roles[_role].users | default(omit) }}"
+        teams: {{ _item.roles[_role].teams | default(omit) | to_json }}
+        users: {{ _item.roles[_role].users | default(omit) | to_json }}
       {% endfor %}
       {% endif %}
       {% endfor %}

--- a/roles/controller_workflow_job_templates/tasks/main.yml
+++ b/roles/controller_workflow_job_templates/tasks/main.yml
@@ -130,8 +130,8 @@
       - role: "{{ _role }}"
         workflows:
           - "{{ _item.name }}"
-        teams: "{{ _item.roles[_role].teams | default(omit) }}"
-        users: "{{ _item.roles[_role].users | default(omit) }}"
+        teams: {{ _item.roles[_role].teams | default(omit) | to_json }}
+        users: {{ _item.roles[_role].users | default(omit) | to_json }}
       {% endfor %}
       {% endif %}
       {% endfor %}


### PR DESCRIPTION
When users or teams were specified as lists in the roles block of job_templates, inventories, or workflow_job_templates, the Jinja template rendered Python list repr strings (e.g. "['user1']") instead of proper YAML/JSON lists. The ansible.controller.role module then failed with "missing items" because it received a string, not a list.

Use to_json to properly serialize list values in the generated YAML.

Fixes #1296

Made-with: Cursor
