### PR TITLE
Add controller_role_definitions role to collection

### DIFF
--- a/changelogs/fragments/add_controller_role_definitions_role.yml
+++ b/changelogs/fragments/add_controller_role_definitions_role.yml
@@ -1,0 +1,3 @@
+---
+major_changes:
+  - Added the controller_role_definitions role; this allows AAP 2.5 compatibility with creating roles 

--- a/changelogs/fragments/add_controller_role_definitions_role.yml
+++ b/changelogs/fragments/add_controller_role_definitions_role.yml
@@ -1,4 +1,4 @@
 ---
 major_changes:
   - Added the controller_role_definitions role; this allows AAP 2.5 compatibility with creating roles
-  
+...

--- a/changelogs/fragments/add_controller_role_definitions_role.yml
+++ b/changelogs/fragments/add_controller_role_definitions_role.yml
@@ -1,3 +1,4 @@
 ---
 major_changes:
-  - Added the controller_role_definitions role; this allows AAP 2.5 compatibility with creating roles 
+  - Added the controller_role_definitions role; this allows AAP 2.5 compatibility with creating roles
+  

--- a/changelogs/fragments/add_controller_role_definitions_role.yml
+++ b/changelogs/fragments/add_controller_role_definitions_role.yml
@@ -1,4 +1,4 @@
 ---
-major_changes:
+minor_changes:
   - Added the controller_role_definitions role; this allows AAP 2.5 compatibility with creating roles
 ...

--- a/roles/controller_role_definitions/README.md
+++ b/roles/controller_role_definitions/README.md
@@ -84,6 +84,122 @@ This also speeds up the overall role.
 | `state`             |   `present`   |    no    | str  | Desired state of the resource.                                                                        |
 |`register`           |         ""    |    no    | str  | Variable to set based on the result of the object creation/modification                               |
 
+#### Content Type
+
+Below are the available content_types that can be used when managing role definitions. Under the content type names, are available permissions that can used with those content types.
+
+`shared.organization`
+
+- shared.audit_organization
+- shared.change_organization
+- shared.delete_organization
+- shared.member_organization
+- shared.view_organization
+- shared.add_team
+- shared.change_team
+- shared.delete_team
+- shared.member_team
+- shared.view_team
+- awx.add_executionenvironment
+- awx.change_executionenvironment
+- awx.delete_executionenvironment
+- awx.add_project
+- awx.change_project
+- awx.delete_project
+- awx.update_project
+- awx.use_project
+- awx.view_project
+- awx.change_jobtemplate
+- awx.delete_jobtemplate
+- awx.execute_jobtemplate
+- awx.view_jobtemplate
+- awx.add_credential
+- awx.change_credential
+- awx.delete_credential
+- awx.use_credential
+- awx.view_credential
+- awx.add_notificationtemplate
+- awx.change_notificationtemplate
+- awx.delete_notificationtemplate
+- awx.view_notificationtemplate
+- awx.add_inventory
+- awx.adhoc_inventory
+- awx.change_inventory
+- awx.delete_inventory
+- awx.update_inventory
+- awx.use_inventory
+- awx.view_inventory
+- awx.add_workflowjobtemplate
+- awx.approve_workflowjobtemplate
+- awx.change_workflowjobtemplate
+- awx.delete_workflowjobtemplate
+- awx.execute_workflowjobtemplate
+- awx.view_workflowjobtemplate
+
+`shared.team`
+
+- shared.change_team
+- shared.delete_team
+- shared.member_team
+- shared.view_team
+
+`awx.credential`
+
+- awx.change_credential
+- awx.delete_credential
+- awx.use_credential
+- awx.view_credential
+
+`awx.executionenvironment`
+
+- awx.change_executionenvironment
+- awx.delete_executionenvironment
+
+`awx.instancegroup`
+
+- awx.change_instancegroup
+- awx.delete_instancegroup
+- awx.use_instancegroup
+- awx.view_instancegroup
+
+`awx.inventory`
+
+- awx.adhoc_inventory
+- awx.change_inventory
+- awx.delete_inventory
+- awx.update_inventory
+- awx.use_inventory
+- awx.view_inventory
+
+`awx.jobtemplate`
+
+- awx.change_jobtemplate
+- awx.delete_jobtemplate
+- awx.execute_jobtemplate
+- awx.view_jobtemplate
+
+`awx.notificationtemplate`
+
+- awx.change_notificationtemplate
+- awx.delete_notificationtemplate
+- awx.view_notificationtemplate
+
+`awx.project`
+
+- awx.change_project
+- awx.delete_project
+- awx.update_project
+- awx.use_project
+- awx.view_project
+
+`awx.workflowjobtemplate`
+
+- awx.approve_workflowjobtemplate
+- awx.change_workflowjobtemplate
+- awx.delete_workflowjobtemplate
+- awx.execute_workflowjobtemplate
+- awx.view_workflowjobtemplate
+
 ### Standard Role Definition Data Structure
 
 #### Json Example

--- a/roles/controller_role_definitions/README.md
+++ b/roles/controller_role_definitions/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-An Ansible Role to create/update/remove Role Definitions on Ansible Controller.
+An Ansible Role to create/update/remove Role Definitions on Ansible Controller **AAP 2.5 ONLY**.
 
 ## Requirements
 
@@ -72,7 +72,7 @@ This also speeds up the overall role.
 
 ### Role Definition Variables
 
-**WARNING: This role will only work in AAP 2.5+** Options for the `controller_role_definitions` variable:
+**WARNING: This role will only work in AAP 2.5** Options for the `controller_role_definitions` variable:
 
 | Variable Name       | Default Value | Required | Type | Description                                                                                           |
 |:--------------------|:-------------:|:--------:|:----:|:------------------------------------------------------------------------------------------------------|

--- a/roles/controller_role_definitions/README.md
+++ b/roles/controller_role_definitions/README.md
@@ -1,0 +1,158 @@
+# Ansible Role infra.aap_configuration.controller_role_definitions
+
+## Description
+
+An Ansible Role to create/update/remove Role Definitions on Ansible Controller.
+
+## Requirements
+
+ansible-galaxy collection install -r tests/collections/requirements.yml to be installed
+
+## Variables
+
+|Variable Name|Default Value|Required|Description|Example|
+|:---|:---:|:---:|:---|:---|
+|`controller_state`|"present"|no|str|The state all objects will take unless overridden by object default|'absent'|
+|`aap_hostname`|""|yes|str|URL to the Ansible Controller Server.|127.0.0.1|
+|`aap_validate_certs`|`true`|no|str|Whether or not to validate the Ansible Controller Server's SSL certificate.||
+|`aap_username`|""|no|str|Admin User on the Ansible Controller Server. Either username / password or oauthtoken need to be specified.||
+|`aap_password`|""|no|str|Controller Admin User's password on the Ansible Controller Server. This should be stored in an Ansible Vault at vars/controller-secrets.yml or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
+|`controller_oauthtoken`|""|no|str|Controller Admin User's token on the Ansible Controller Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
+|`controller_request_timeout`|`10`|no|int|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
+|`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
+|`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
+|`controller_role_definitions`|`see below`|yes|Data structure describing your role definitions described below.||
+
+### Enforcing defaults
+
+The following Variables complement each other.
+If Both variables are not set, enforcing default values is not done.
+Enabling these variables enforce default values on options that are optional in the controller API.
+This should be enabled to enforce configuration and prevent configuration drift. It is recommended to be enabled, however it is not enforced by default.
+
+Enabling this will enforce configuration without specifying every option in the configuration files.
+
+'controller_role_definitions_enforce_defaults' defaults to the value of 'aap_configuration_enforce_defaults' if it is not explicitly called. This allows for enforced defaults to be toggled for the entire suite of controller configuration roles with a single variable, or for the user to selectively use it.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`controller_role_definitions_enforce_defaults`|`false`|no|Whether or not to enforce default option values on only the role definitions role|
+|`aap_configuration_enforce_defaults`|`false`|no|This variable enables enforced default values as well, but is shared globally.|
+
+### Secure Logging Variables
+
+The following Variables complement each other.
+If Both variables are not set, secure logging defaults to false.
+The role defaults to false as normally the add role definitions task does not include sensitive information.
+controller_role_definitions_secure_logging defaults to the value of aap_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`controller_role_definitions_secure_logging`|`false`|no|Whether or not to include the sensitive role definitions role tasks in the log.  Set this value to `true` if you will be providing your sensitive values from elsewhere.|
+|`aap_configuration_secure_logging`|`false`|no|This variable enables secure logging as well, but is shared across multiple roles, see above.|
+
+### Asynchronous Retry Variables
+
+The following Variables set asynchronous retries for the role.
+If neither of the retries or delay or retries are set, they will default to their respective defaults.
+This allows for all items to be created, then checked that the task finishes successfully.
+This also speeds up the overall role.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`aap_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
+|`controller_role_definitions_async_retries`|`aap_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
+|`aap_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
+|`controller_role_definitions_async_delay`|`aap_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`aap_configuration_loop_delay`|0|no|This sets the pause between each item in the loop for the roles globally. To help when API is getting overloaded.|
+|`controller_role_definitions_loop_delay`|`aap_configuration_loop_delay`|no|This sets the pause between each item in the loop for the role. To help when API is getting overloaded.|
+|`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
+
+## Data Structure
+
+### Role Definition Variables
+
+**WARNING: This role will only work in AAP 2.5+** Options for the `controller_role_definitions` variable:
+
+| Variable Name       | Default Value | Required | Type | Description                                                                                           |
+|:--------------------|:-------------:|:--------:|:----:|:------------------------------------------------------------------------------------------------------|
+| `content_type`      |      N/A      |   yes    | str  | The content type for which the role applies (e.g., awx.inventory)                                     |
+| `description`       |      N/A      |    no    | str  | Description of the role definition                                                                    |
+| `name`              |      N/A      |   yes    | str  | The name of the role definition (must be unique)                                                      |
+| `new_name`          |      N/A      |    no    | str  | Setting this option will change the existing name (looked up via the name field)                      |
+| `permissions`       |      N/A      |   yes    | list | List of permission strings to associate with the role (e.g., awx.view_inventory)                      |
+| `state`             |   `present`   |    no    | str  | Desired state of the resource.                                                                        |
+|`register`           |         ""    |    no    | str  | Variable to set based on the result of the object creation/modification                |
+
+### Standard Role Definition Data Structure
+
+#### Json Example
+
+```json
+{
+  "controller_role_definitions": [
+    {
+      "name": "Organization Inventory Use",
+      "description": "Grants use permissions to inventories for a single organization.",
+      "content_type": "awx.inventory",
+      "permissions": [
+        "awx.view_inventory",
+        "awx.use_inventory"
+      ]
+    },
+    {
+      "name": "Organization Credential Use",
+      "description": "Grants use permissions to inventoriesfor a single organization.",
+      "content_type": "awx.credential",
+      "permissions": [
+        "awx.view_credential",
+        "awx.use_credential"
+      ]
+    },
+    {
+      "name": "Workflow Template Modify",
+      "description": "Grants modify permissions to workflow templates.",
+      "content_type": "awx.workflowjobtemplate",
+      "permissions": [
+        "awx.view_workflowjobtemplate",
+        "awx.approve_workflowjobtemplate",
+        "awx.change_workflowjobtemplate",
+        "awx.delete_workflowjobtemplate",
+      ]
+    },
+  ]
+}
+```
+
+#### Yaml Example
+
+File name: `configs/controller/controller_role_definitions.yml`
+
+```yaml
+---
+controller_role_definitions:
+  - name: Organization Inventory Use
+    description: Grants use permissions to inventories for a single organization.
+    content_type: shared.organization
+    permissions:
+      - awx.view_inventory
+      - awx.use_inventory
+  - name: Organization Credential Use
+    description: Grants use permissions to credentials for a single organization.
+    content_type: shared.organization
+    permissions:
+      - awx.view_credential
+      - awx.use_credential
+  - name: Workflow Template Modify
+    description: Grants modify permissions to workflow templates.
+    content_type: awx.workflowjobtemplate
+    permissions:
+      - awx.view_workflowjobtemplate
+      - awx.approve_workflowjobtemplate
+      - awx.change_workflowjobtemplate
+      - awx.delete_workflowjobtemplate
+```
+
+## License
+
+[GPLv3+](https://github.com/redhat-cop/infra.aap_configuration/blob/devel/LICENSE)

--- a/roles/controller_role_definitions/README.md
+++ b/roles/controller_role_definitions/README.md
@@ -12,13 +12,13 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 
 |Variable Name|Default Value|Required|Description|Example|
 |:---|:---:|:---:|:---|:---|
-|`controller_state`|"present"|no|str|The state all objects will take unless overridden by object default|'absent'|
-|`aap_hostname`|""|yes|str|URL to the Ansible Controller Server.|127.0.0.1|
-|`aap_validate_certs`|`true`|no|str|Whether or not to validate the Ansible Controller Server's SSL certificate.||
-|`aap_username`|""|no|str|Admin User on the Ansible Controller Server. Either username / password or oauthtoken need to be specified.||
-|`aap_password`|""|no|str|Controller Admin User's password on the Ansible Controller Server. This should be stored in an Ansible Vault at vars/controller-secrets.yml or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
-|`controller_oauthtoken`|""|no|str|Controller Admin User's token on the Ansible Controller Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
-|`controller_request_timeout`|`10`|no|int|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
+|`controller_state`|"present"|no|The state all objects will take unless overridden by object default|'absent'|
+|`aap_hostname`|""|yes|URL to the Ansible Controller Server.|127.0.0.1|
+|`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Controller Server's SSL certificate.||
+|`aap_username`|""|no|Admin User on the Ansible Controller Server. Either username / password or oauthtoken need to be specified.||
+|`aap_password`|""|no|Controller Admin User's password on the Ansible Controller Server. This should be stored in an Ansible Vault at vars/controller-secrets.yml or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
+|`controller_oauthtoken`|""|no|Controller Admin User's token on the Ansible Controller Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
+|`controller_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`aap_configuration_register`|""|no|Specify a variable to register the values of all aap_configuration tasks. This will create an object with each aap object as an element containing a list of each item created.||
 |`aap_configuration_collect_logs`|`false`|no|Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the `aap_configuration_role_errors` variable.||
 |`controller_role_definitions`|`see below`|yes|Data structure describing your role definitions described below.||
@@ -82,7 +82,7 @@ This also speeds up the overall role.
 | `new_name`          |      N/A      |    no    | str  | Setting this option will change the existing name (looked up via the name field)                      |
 | `permissions`       |      N/A      |   yes    | list | List of permission strings to associate with the role (e.g., awx.view_inventory)                      |
 | `state`             |   `present`   |    no    | str  | Desired state of the resource.                                                                        |
-|`register`           |         ""    |    no    | str  | Variable to set based on the result of the object creation/modification                |
+|`register`           |         ""    |    no    | str  | Variable to set based on the result of the object creation/modification                               |
 
 ### Standard Role Definition Data Structure
 

--- a/roles/controller_role_definitions/defaults/main.yml
+++ b/roles/controller_role_definitions/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# These are the default variables common to most gateway_configuration roles
+# You shouldn't need to define them again and again but they should be defined
+# aap_hostname: "{{ inventory_hostname }}"
+# aap_token: ""
+# aap_validate_certs: false
+
+# These are the default variables specific to the license role
+
+# a list of dictionaries describing the controller_role_definitions
+controller_role_definitions: []
+controller_role_definitions_secure_logging: "{{ aap_configuration_secure_logging | default('false') }}"
+controller_role_definitions_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
+controller_role_definitions_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
+controller_role_definitions_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
+controller_role_definitions_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+aap_configuration_async_dir:
+...

--- a/roles/controller_role_definitions/meta/argument_specs.yml
+++ b/roles/controller_role_definitions/meta/argument_specs.yml
@@ -1,0 +1,110 @@
+---
+argument_specs:
+  main:
+    short_description: An Ansible Role to create role_definitions on Ansible Controller.
+    options:
+      controller_role_definitions:
+        description: Data structure describing your role_definitions
+        type: list
+        required: true
+        elements: dict
+#        options:
+#          content_type:
+#            required: true
+#            type: str
+#            description: The content type for which the role applies (e.g., awx.inventory)
+#          description:
+#            type: str
+#            description: Description of the role definition
+#          name:
+#            required: true
+#            type: str
+#            description: The name of the role definition (must be unique)
+#          new_name:
+#            type: str
+#            description: Setting this option will change the existing name (looked up via the name field)
+#          permissions:
+#            required: true
+#            type: list
+#            description: List of permission strings to associate with the role (e.g., awx.view_inventory)
+#          state:
+#            default: present
+#            type: str
+#            description: Desired state of the role definition
+
+      # Async variables
+      controller_role_definitions_async_retries:
+        default: "{{ aap_configuration_async_retries | default(50) }}"
+        required: false
+        description: This variable sets the number of retries to attempt for the role.
+      aap_configuration_async_retries:
+        default: 50
+        required: false
+        description: This variable sets number of retries across all roles as a default.
+      role_definitions_async_delay:
+        default: "{{ aap_configuration_async_delay | default(1) }}"
+        required: false
+        description: This variable sets delay between retries for the role.
+      aap_configuration_async_delay:
+        default: 1
+        required: false
+        description: This variable sets delay between retries across all roles as a default.
+      aap_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
+
+      # No_log variables
+      controller_role_definitions_secure_logging:
+        default: "{{ aap_configuration_secure_logging | default(false) }}"
+        required: false
+        type: bool
+        description: Whether or not to include the sensitive tasks from this role in the log. Set this value to `true` if you will be providing your sensitive values from elsewhere.
+      aap_configuration_secure_logging:
+        default: false
+        required: false
+        type: bool
+        description: This variable enables secure logging across all roles as a default.
+
+      # Generic across all roles
+      platform_state:
+        default: present
+        required: false
+        description: The state all objects will take unless overridden by object default
+        type: str
+      aap_hostname:
+        default: None
+        required: false
+        description: URL to the Ansible gateway Server.
+        type: str
+      aap_validate_certs:
+        default: true
+        required: false
+        description: Whether or not to validate the Ansible gateway Server's SSL certificate.
+        type: str
+      aap_username:
+        default: None
+        required: false
+        description: Admin User on the Ansible gateway Server. Either username / password or oauthtoken need to be specified.
+        type: str
+      aap_password:
+        default: None
+        required: false
+        description: Gateway Admin User's password on the Ansible gateway Server. This should be stored in an Ansible Vault at vars/gateway-secrets.yml or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.
+        type: str
+      aap_token:
+        default: None
+        required: false
+        description: Gateway Admin User's token on the Ansible gateway Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.
+        type: str
+      aap_request_timeout:
+        default: 10
+        required: false
+        description: Specify the timeout Ansible should use in requests to the Ansible gateway Server.
+        type: float
+      aap_configuration_collect_logs:
+        default: false
+        required: false
+        description: Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the aap_configuration_role_errors variable.
+        type: bool
+...

--- a/roles/controller_role_definitions/meta/argument_specs.yml
+++ b/roles/controller_role_definitions/meta/argument_specs.yml
@@ -1,7 +1,7 @@
 ---
 argument_specs:
   main:
-    short_description: An Ansible Role to create role_definitions on Ansible Controller.
+    short_description: An Ansible Role to create role_definitions on Ansible Controller for AAP 2.5 ONLY.
     options:
       controller_role_definitions:
         description: Data structure describing your role_definitions

--- a/roles/controller_role_definitions/meta/main.yml
+++ b/roles/controller_role_definitions/meta/main.yml
@@ -27,7 +27,7 @@ galaxy_info:
 
 collections:
   - ansible.controller
-  
+
 dependencies:
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,
   # if you add dependencies to this list.

--- a/roles/controller_role_definitions/meta/main.yml
+++ b/roles/controller_role_definitions/meta/main.yml
@@ -1,0 +1,36 @@
+---
+galaxy_info:
+  role_name: controller_role_definitions
+  author: Matt Willis
+  description: An Ansible Role to create role_definitions in Ansible Controller.
+  company: Red Hat
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+  license: GPL-3.0-or-later
+
+  min_ansible_version: 2.16.0
+
+  platforms:
+    - name: EL
+      versions:
+        - all
+
+  galaxy_tags:
+    - controller
+    - aap
+    - awx
+    - configuration
+    - roledefinition
+    - roledefinitions
+
+collections:
+  - ansible.controller
+  
+dependencies:
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  - role: global_vars
+  - role: meta_dependency_check
+...

--- a/roles/controller_role_definitions/meta/main.yml
+++ b/roles/controller_role_definitions/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: controller_role_definitions
   author: Matt Willis
-  description: An Ansible Role to create role_definitions in Ansible Controller.
+  description: An Ansible Role to create role_definitions in Ansible Controller (AAP 2.5 ONLY).
   company: Red Hat
 
   # If the issue tracker for your role is not on github, uncomment the

--- a/roles/controller_role_definitions/tasks/main.yml
+++ b/roles/controller_role_definitions/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+- name: Manage Controller Role Definitions Block
+  vars:
+    ansible_async_dir: "{{ aap_configuration_async_dir }}"
+  no_log: "{{ controller_role_definitions_secure_logging }}"
+  block:
+    - name: Role definitions | Configuration
+      ansible.controller.role_definition:
+        name: "{{ __controller_role_definitions_item.name | mandatory }}"
+        new_name: "{{ __controller_role_definitions_item.new_name | default(omit, true) }}"
+        description: "{{ __controller_role_definitions_item.description | default(('' if controller_role_definitions_enforce_defaults else omit), true) }}"
+        content_type: "{{ __controller_role_definitions_item.content_type | mandatory }}"
+        permissions: "{{ __controller_role_definitions_item.permissions | mandatory }}"
+        state: "{{ __controller_role_definitions_item.state | default(platform_state | default(omit, true)) }}"
+
+        # Role Standard Options
+        controller_host: "{{ aap_hostname | default(omit, true) }}"
+        controller_username: "{{ aap_username | default(omit, true) }}"
+        controller_password: "{{ aap_password | default(omit, true) }}"
+        controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+        request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+        validate_certs: "{{ aap_validate_certs | default(omit) }}"
+      loop: "{{ controller_role_definitions }}"
+      loop_control:
+        loop_var: __controller_role_definitions_item
+        label: "{{ __operation.verb }} Role Based Access Entry on Controller {{ __controller_role_definitions_item.name }}"
+        pause: "{{ controller_role_definitions_loop_delay }}"
+      async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+      poll: 0
+      register: __controller_role_definitions_job_async
+      changed_when: not __controller_role_definitions_job_async.changed
+      vars:
+        __operation: "{{ operation_translate[__controller_role_definitions_item.state | default(platform_state) | default('present')] }}"
+
+    - name: Role definitions | Wait for finish the configuration
+      when:
+        - not ansible_check_mode
+        - __controller_role_definitions_job_async_results_item.ansible_job_id is defined
+      ansible.builtin.include_role:
+        name: infra.aap_configuration.collect_async_status
+      loop: "{{ __controller_role_definitions_job_async.results }}"
+      loop_control:
+        loop_var: __controller_role_definitions_job_async_results_item
+        label: "{{ __operation.verb }} Role {{ __controller_role_definitions_job_async_results_item.__controller_role_definitions_item.name }} | Wait for finish the Roles {{ __operation.action }}"
+      vars:
+        cas_secure_logging: "{{ controller_role_definitions_secure_logging }}"
+        cas_job_async_results_item: "{{ __controller_role_definitions_job_async_results_item }}"
+        cas_register_subvar: controller_role_definitions
+        cas_error_list_var_name: "controller_role_definitions_errors"
+        __operation: "{{ operation_translate[__controller_role_definitions_job_async_results_item.__controller_role_definitions_item.state | default(platform_state) | default('present')] }}"
+        cas_object_label: "{{ __operation.verb }} Role {{ __controller_role_definitions_job_async_results_item.__controller_role_definitions_item.name }} | Wait for finish the Roles {{ __operation.action }}"
+
+  always:
+    - name: Cleanup async results files
+      when:
+        - not ansible_check_mode
+        - __controller_role_definitions_job_async_results_item.ansible_job_id is defined
+      ansible.builtin.async_status:
+        jid: "{{ __controller_role_definitions_job_async_results_item.ansible_job_id }}"
+        mode: cleanup
+      loop: "{{ __controller_role_definitions_job_async.results }}"
+      loop_control:
+        loop_var: __controller_role_definitions_job_async_results_item
+        label: "Cleaning up job results file: {{ __controller_role_definitions_job_async_results_item.results_file | default('Unknown') }}"
+...

--- a/roles/controller_role_definitions/tests/configs/roles.yml
+++ b/roles/controller_role_definitions/tests/configs/roles.yml
@@ -1,0 +1,23 @@
+---
+controller_role_definitions:
+  - name: Demo Controller Role - Organization Inventory Use
+    description: Add permissions to demo role.
+    content_type: shared.organization
+    permissions:
+      - awx.view_inventory
+      - awx.use_inventory
+  - name: Demo Controller Role - Organization Credential Use
+    description: Add permissions to demo role.
+    content_type: shared.organization
+    permissions:
+      - awx.view_credential
+      - awx.use_credential
+  - name: Demo Controller Role - Workflow Template Modify
+    description: Add permissions to demo role.
+    content_type: awx.workflowjobtemplate
+    permissions:
+      - awx.view_workflowjobtemplate
+      - awx.approve_workflowjobtemplate
+      - awx.change_workflowjobtemplate
+      - awx.delete_workflowjobtemplate
+...

--- a/roles/controller_role_definitions/tests/test.yml
+++ b/roles/controller_role_definitions/tests/test.yml
@@ -1,0 +1,20 @@
+---
+- name: Add role definitions to Controller
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    aap_validate_certs: false
+    aap_hostname: aap.example.com
+    aap_username: admin
+    aap_password: changeme
+
+  pre_tasks:
+    - name: Include vars from platform_configs directory
+      ansible.builtin.include_vars:
+        dir: ./configs
+        extensions: [yml]
+
+  roles:
+    - { role: ../.., when: controller_role_definitions is defined }
+...


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->
Currently the gateway_role_definitions role does not support AAP 2.5, when creating roles. Created role to support AAP 2.5. It's very similar to the gateway_role_definitions role. 

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

Added a test playbook in the tests/ directory.

```
---
- name: Add role definitions to Controller
  hosts: localhost
  connection: local
  gather_facts: false
  vars:
    aap_validate_certs: false
    aap_hostname: aap.example.com
    aap_username: admin
    aap_password: changeme
    controller_role_definitions:
      - name: Demo Controller Role - Organization Inventory Use
        description: Add permissions to demo role.
        content_type: shared.organization
        permissions:
          - awx.view_inventory
          - awx.use_inventory

  roles:
    - { role: infra.aap_configuration.controller_role_definitions, when: controller_role_definitions is defined }
...
```

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]
N/A

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
