### PR TITLE
Add 'tags: always' to include_wildcard_vars and main task definitions

### DIFF
--- a/changelogs/fragments/dispatch_tags.yml
+++ b/changelogs/fragments/dispatch_tags.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added `tags: always` to tasks in the dispatch role for include_wildcard_vars to ensure they run regardless of applied tags.

--- a/changelogs/fragments/dispatch_tags.yml
+++ b/changelogs/fragments/dispatch_tags.yml
@@ -1,2 +1,2 @@
-minor_changes:
+bugfixes:
   - Added `tags: always` to tasks in the dispatch role for include_wildcard_vars to ensure they run regardless of applied tags.

--- a/roles/dispatch/tasks/include_wildcard_vars.yml
+++ b/roles/dispatch/tasks/include_wildcard_vars.yml
@@ -67,5 +67,6 @@
                           (prev_val + curr_val) | unique }}"
   loop: "{{ query('ansible.builtin.varnames', '^(' + all_vars | join('|') + ')_.*') }}"
   when: not item.endswith('_secure_logging')
+  tags: always
 
 ...

--- a/roles/dispatch/tasks/main.yml
+++ b/roles/dispatch/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Sort out vars that are included
   ansible.builtin.include_tasks: include_wildcard_vars.yml
   when: dispatch_include_wildcard_vars
+  tags: always
 
 - name: "Run the following infra.aap_configuration roles: {{ aap_configuration_dispatcher_roles | map(attribute='role') | join(', ') }}"
   ansible.builtin.include_role:


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?

Always include the wildcard vars, regardless of what tags are passed when the feature is enabled

When running the dispatch with a tag of --tags=project, the wildcard_vars component fails to run, it only works as expected when no tags are run

# How should this be tested?

Run with include wildcards enabled and include a tag of --tag=project or any other valid tag. It should run the process without this the expected outcome is different. Note this issue is not seen if you're using the base var eg controller_projects: over controller_projects_myteam:

# Is there a relevant Issue open for this?

N/A

# Other Relevant info, PRs, etc

N/A
