### PR TITLE
Added controller_role_user_assignments and controller_role_team_assignments to collection compatibility with AAP 2.5

### DIFF
--- a/changelogs/fragments/add_role_to_collection.yml
+++ b/changelogs/fragments/add_role_to_collection.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Added controller_role_user_assignments and controller_role_team_assignments to support AAP 2.5 and custom role definitions.
+...

--- a/roles/controller_role_team_assignments/README.md
+++ b/roles/controller_role_team_assignments/README.md
@@ -84,9 +84,9 @@ This also speeds up the overall role.
 {
   "controller_role_team_assignments": [
     {
-        "object_id": 1,        
         "role_definition": "Organization Inventory Admin",
-        "team": "team2",
+        "object_id": 1,        
+        "team": "team2"
     }
   ]
 }

--- a/roles/controller_role_team_assignments/README.md
+++ b/roles/controller_role_team_assignments/README.md
@@ -4,6 +4,9 @@
 
 An Ansible Role to create/update/remove Role Team Assignments on Ansible Controller **AAP 2.5 ONLY**.
 
+>[!NOTE]
+>This role is not included in the default dispatch role dispatcher list because it is AAP 2.5-only. To use it, either call the role directly in your playbook or create a custom dispatcher list that includes it. See the dispatch role's aap_configuration_dispatcher_roles variable for details.
+
 ## Variables
 
 |Variable Name|Default Value|Required|Description|Example|

--- a/roles/controller_role_team_assignments/README.md
+++ b/roles/controller_role_team_assignments/README.md
@@ -85,7 +85,7 @@ This also speeds up the overall role.
   "controller_role_team_assignments": [
     {
         "role_definition": "Organization Inventory Admin",
-        "object_id": 1,        
+        "object_id": 1,
         "team": "team2"
     }
   ]

--- a/roles/controller_role_team_assignments/README.md
+++ b/roles/controller_role_team_assignments/README.md
@@ -1,0 +1,109 @@
+# Ansible Role infra.aap_configuration.controller_role_team_assignments
+
+## Description
+
+An Ansible Role to create/update/remove Role Team Assignments on Ansible Controller **AAP 2.5 ONLY**.
+
+## Variables
+
+|Variable Name|Default Value|Required|Description|Example|
+|:---|:---:|:---:|:---|:---|
+|`platform_state`|"present"|no|The state all objects will take unless overridden by object default|'absent'|
+|`aap_hostname`|""|yes|URL to the Ansible Automation Platform Server.|127.0.0.1|
+|`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
+|`aap_username`|""|no|Admin User on the Ansible Automation Platform Server. Either username / password or oauthtoken need to be specified.||
+|`aap_password`|""|no|Platform Admin User's password on the Server.  This should be stored in an Ansible Vault at vars/platform-secrets.yml or elsewhere and called from a parent playbook.||
+|`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
+|`aap_request_timeout`|""|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
+|`controller_role_team_assignments`|`see below`|yes|Data structure describing your role team assignments Described below.||
+
+### Enforcing defaults
+
+The following Variables complement each other.
+If Both variables are not set, enforcing default values is not done.
+Enabling these variables enforce default values on options that are optional in the controller API.
+This should be enabled to enforce configuration and prevent configuration drift. It is recommended to be enabled, however it is not enforced by default.
+
+Enabling this will enforce configuration without specifying every option in the configuration files.
+
+'controller_role_team_assignments_enforce_defaults' defaults to the value of 'aap_configuration_enforce_defaults' if it is not explicitly called. This allows for enforced defaults to be toggled for the entire suite of controller configuration roles with a single variable, or for the user to selectively use it.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`controller_role_team_assignments_enforce_defaults`|`false`|no|Whether or not to enforce default option values on only the role team assignments role|
+|`aap_configuration_enforce_defaults`|`false`|no|This variable enables enforced default values as well, but is shared globally.|
+
+### Secure Logging Variables
+
+The following Variables complement each other.
+If Both variables are not set, secure logging defaults to false.
+The role defaults to false as normally the add role team assignments task does not include sensitive information.
+controller_role_team_assignments_secure_logging defaults to the value of aap_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of controller configuration roles with a single variable, or for the user to selectively use it.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`controller_role_team_assignments_secure_logging`|`false`|no|Whether or not to include the sensitive Role Team Assignments role tasks in the log.  Set this value to `true` if you will be providing your sensitive values from elsewhere.|
+|`aap_configuration_secure_logging`|`false`|no|This variable enables secure logging as well, but is shared across multiple roles, see above.|
+
+### Asynchronous Retry Variables
+
+The following Variables set asynchronous retries for the role.
+If neither of the retries or delay or retries are set, they will default to their respective defaults.
+This allows for all items to be created, then checked that the task finishes successfully.
+This also speeds up the overall role.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`aap_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
+|`controller_role_team_assignments_async_retries`|`aap_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
+|`aap_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
+|`controller_role_team_assignments_async_delay`|`aap_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`aap_configuration_loop_delay`|0|no|This variable sets the loop_delay for the role globally.|
+|`controller_role_team_assignments_loop_delay`|`aap_configuration_loop_delay`|no|This variable sets the loop_delay for the role.|
+|`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
+
+## Data Structure
+
+### Role Team Assignment Variables
+
+**WARNING: This role will only work in AAP 2.5** Options for the `controller_role_team_assignments` variable:
+
+| Variable Name       | Default Value | Required | Type | Description                                                                                           |
+|:--------------------|:-------------:|:--------:|:----:|:------------------------------------------------------------------------------------------------------|
+| `object_id`         |      N/A      |    yes   | int  | Primary key of the organization this assignment applies to. Organization id                           |
+| `role_definition`   |      N/A      |    yes   | str  | The name or id of the role definition to assign to the team.                                          |
+| `state`             |   `present`   |    no    | str  | Desired state of the resource.                                                                        |
+| `team`              |      N/A      |    no    | str  | The name or id of the team to assign to the object.                                                   |
+| `team_ansible_id`   |      N/A      |    no    | int  | Resource id of the team who will receive permissions from this assignment. Alternative to team field. |
+
+### Standard Role Team Assignment Data Structure
+
+#### Json Example
+
+```json
+{
+  "controller_role_team_assignments": [
+    {
+        "object_id": 1,        
+        "role_definition": "Organization Inventory Admin",
+        "team": "team2",
+    }
+  ]
+}
+```
+
+#### Yaml Example
+
+File name: `configs/controller/controller_role_team_assignments.yml`
+
+```yaml
+---
+controller_role_team_assignments:
+  - object_id: 1
+    role_definition: Organization Inventory Admin
+    team: team2
+```
+
+## License
+
+[GPLv3+](https://github.com/redhat-cop/infra.aap_configuration/blob/devel/LICENSE)

--- a/roles/controller_role_team_assignments/defaults/main.yml
+++ b/roles/controller_role_team_assignments/defaults/main.yml
@@ -5,7 +5,7 @@
 # aap_token: ""
 # aap_validate_certs: false
 
-# These are the default variables specific to the license role
+# These are the default variables specific to the controller_role_team_assignments role
 
 # a list of dictionaries describing the controller_role_team_assignments
 controller_role_team_assignments: []

--- a/roles/controller_role_team_assignments/defaults/main.yml
+++ b/roles/controller_role_team_assignments/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# These are the default variables common to most gateway_configuration roles
+# You shouldn't need to define them again and again but they should be defined
+# aap_hostname: "{{ inventory_hostname }}"
+# aap_token: ""
+# aap_validate_certs: false
+
+# These are the default variables specific to the license role
+
+# a list of dictionaries describing the controller_role_team_assignments
+controller_role_team_assignments: []
+controller_role_team_assignments_secure_logging: "{{ aap_configuration_secure_logging | default('false') }}"
+controller_role_team_assignments_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
+controller_role_team_assignments_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
+controller_role_team_assignments_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
+controller_role_team_assignments_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+aap_configuration_async_dir:
+...

--- a/roles/controller_role_team_assignments/meta/argument_specs.yml
+++ b/roles/controller_role_team_assignments/meta/argument_specs.yml
@@ -1,0 +1,110 @@
+---
+argument_specs:
+  main:
+    short_description: An Ansible Role to create role_team_assignments on Ansible Controller for AAP 2.5 ONLY.
+    options:
+      controller_role_team_assignments:
+        description: Data structure describing your role_team_assignments
+        type: list
+        required: true
+        elements: dict
+#        options:
+#          content_type:
+#            required: true
+#            type: str
+#            description: The content type for which the role applies (e.g., awx.inventory)
+#          description:
+#            type: str
+#            description: Description of the role definition
+#          name:
+#            required: true
+#            type: str
+#            description: The name of the role definition (must be unique)
+#          new_name:
+#            type: str
+#            description: Setting this option will change the existing name (looked up via the name field)
+#          permissions:
+#            required: true
+#            type: list
+#            description: List of permission strings to associate with the role (e.g., awx.view_inventory)
+#          state:
+#            default: present
+#            type: str
+#            description: Desired state of the role definition
+
+      # Async variables
+      controller_role_team_assignments_async_retries:
+        default: "{{ aap_configuration_async_retries | default(50) }}"
+        required: false
+        description: This variable sets the number of retries to attempt for the role.
+      aap_configuration_async_retries:
+        default: 50
+        required: false
+        description: This variable sets number of retries across all roles as a default.
+      role_team_assignments_async_delay:
+        default: "{{ aap_configuration_async_delay | default(1) }}"
+        required: false
+        description: This variable sets delay between retries for the role.
+      aap_configuration_async_delay:
+        default: 1
+        required: false
+        description: This variable sets delay between retries across all roles as a default.
+      aap_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
+
+      # No_log variables
+      controller_role_team_assignments_secure_logging:
+        default: "{{ aap_configuration_secure_logging | default(false) }}"
+        required: false
+        type: bool
+        description: Whether or not to include the sensitive tasks from this role in the log. Set this value to `true` if you will be providing your sensitive values from elsewhere.
+      aap_configuration_secure_logging:
+        default: false
+        required: false
+        type: bool
+        description: This variable enables secure logging across all roles as a default.
+
+      # Generic across all roles
+      platform_state:
+        default: present
+        required: false
+        description: The state all objects will take unless overridden by object default
+        type: str
+      aap_hostname:
+        default: None
+        required: false
+        description: URL to the Ansible gateway Server.
+        type: str
+      aap_validate_certs:
+        default: true
+        required: false
+        description: Whether or not to validate the Ansible gateway Server's SSL certificate.
+        type: str
+      aap_username:
+        default: None
+        required: false
+        description: Admin User on the Ansible gateway Server. Either username / password or oauthtoken need to be specified.
+        type: str
+      aap_password:
+        default: None
+        required: false
+        description: Gateway Admin User's password on the Ansible gateway Server. This should be stored in an Ansible Vault at vars/gateway-secrets.yml or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.
+        type: str
+      aap_token:
+        default: None
+        required: false
+        description: Gateway Admin User's token on the Ansible gateway Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.
+        type: str
+      aap_request_timeout:
+        default: 10
+        required: false
+        description: Specify the timeout Ansible should use in requests to the Ansible gateway Server.
+        type: float
+      aap_configuration_collect_logs:
+        default: false
+        required: false
+        description: Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the aap_configuration_role_errors variable.
+        type: bool
+...

--- a/roles/controller_role_team_assignments/meta/main.yml
+++ b/roles/controller_role_team_assignments/meta/main.yml
@@ -1,0 +1,36 @@
+---
+galaxy_info:
+  role_name: controller_role_team_assignments
+  author: Matt Willis
+  description: An Ansible Role to create role_team_assignments in Ansible Controller (AAP 2.5 ONLY).
+  company: Red Hat
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+  license: GPL-3.0-or-later
+
+  min_ansible_version: 2.16.0
+
+  platforms:
+    - name: EL
+      versions:
+        - all
+
+  galaxy_tags:
+    - controller
+    - aap
+    - awx
+    - configuration
+    - roleteamassignment
+    - roleteamassignments
+
+collections:
+  - ansible.controller
+
+dependencies:
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  - role: global_vars
+  - role: meta_dependency_check
+...

--- a/roles/controller_role_team_assignments/tasks/main.yml
+++ b/roles/controller_role_team_assignments/tasks/main.yml
@@ -31,7 +31,7 @@
       changed_when: (__controller_role_team_assignments_job_async.changed if ansible_check_mode else false)
       vars:
         __operation: "{{ operation_translate[__controller_role_team_assignments_item.state | default(platform_state) | default('present')] }}"
-    
+
     - name: Flag for errors (check mode only)
       ansible.builtin.set_fact:
         error_flag: true

--- a/roles/controller_role_team_assignments/tasks/main.yml
+++ b/roles/controller_role_team_assignments/tasks/main.yml
@@ -28,9 +28,14 @@
       async: "{{ ansible_check_mode | ternary(0, 1000) }}"
       poll: 0
       register: __controller_role_team_assignments_job_async
-      changed_when: not __controller_role_team_assignments_job_async.changed
+      changed_when: (__controller_role_team_assignments_job_async.changed if ansible_check_mode else false)
       vars:
         __operation: "{{ operation_translate[__controller_role_team_assignments_item.state | default(platform_state) | default('present')] }}"
+    
+    - name: Flag for errors (check mode only)
+      ansible.builtin.set_fact:
+        error_flag: true
+      when: ansible_check_mode and __controller_role_team_assignments_job_async.failed is defined and __controller_role_team_assignments_job_async.failed
 
     - name: Role team_assignments | Wait for finish the configuration
       when:
@@ -49,6 +54,8 @@
         cas_error_list_var_name: "controller_role_team_assignments_errors"
         __operation: "{{ operation_translate[__controller_role_team_assignments_job_async_results_item.__controller_role_team_assignments_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Role {{ __controller_role_team_assignments_job_async_results_item.__controller_role_team_assignments_item.role_definition }} | Wait for finish the Roles {{ __operation.action }}"
+        cas_async_delay: "{{ controller_role_team_assignments_async_delay }}"
+        cas_async_retries: "{{ controller_role_team_assignments_async_retries }}"
 
   always:
     - name: Cleanup async results files

--- a/roles/controller_role_team_assignments/tasks/main.yml
+++ b/roles/controller_role_team_assignments/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+- name: Manage Controller Role Team Assignments Block
+  vars:
+    ansible_async_dir: "{{ aap_configuration_async_dir }}"
+  no_log: "{{ controller_role_team_assignments_secure_logging }}"
+  block:
+    - name: Role Team Assignments | Configuration
+      ansible.controller.role_team_assignment:
+        role_definition: "{{ __controller_role_team_assignments_item.role_definition | mandatory }}"
+        object_id: "{{ __controller_role_team_assignments_item.object_id | default(omit, true)}}"
+        object_ansible_id: "{{ __controller_role_team_assignments_item.object_ansible_id | default(omit, true)}}"
+        team: "{{ __controller_role_team_assignments_item.team | default(omit, true) }}"
+        team_ansible_id: "{{ __controller_role_team_assignments_item.team_ansible_id | default(omit, true) }}"
+        state: "{{ __controller_role_team_assignments_item.state | default(platform_state | default(omit, true)) }}"
+
+        # Role Standard Options
+        controller_host: "{{ aap_hostname | default(omit, true) }}"
+        controller_username: "{{ aap_username | default(omit, true) }}"
+        controller_password: "{{ aap_password | default(omit, true) }}"
+        controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+        request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+        validate_certs: "{{ aap_validate_certs | default(omit) }}"
+      loop: "{{ controller_role_team_assignments }}"
+      loop_control:
+        loop_var: __controller_role_team_assignments_item
+        label: "{{ __operation.verb }} Role Based Access Entry on Controller {{ __controller_role_team_assignments_item.role_definition }}"
+        pause: "{{ controller_role_team_assignments_loop_delay }}"
+      async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+      poll: 0
+      register: __controller_role_team_assignments_job_async
+      changed_when: not __controller_role_team_assignments_job_async.changed
+      vars:
+        __operation: "{{ operation_translate[__controller_role_team_assignments_item.state | default(platform_state) | default('present')] }}"
+
+    - name: Role team_assignments | Wait for finish the configuration
+      when:
+        - not ansible_check_mode
+        - __controller_role_team_assignments_job_async_results_item.ansible_job_id is defined
+      ansible.builtin.include_role:
+        name: infra.aap_configuration.collect_async_status
+      loop: "{{ __controller_role_team_assignments_job_async.results }}"
+      loop_control:
+        loop_var: __controller_role_team_assignments_job_async_results_item
+        label: "{{ __operation.verb }} Role {{ __controller_role_team_assignments_job_async_results_item.__controller_role_team_assignments_item.role_definition }} | Wait for finish the Roles {{ __operation.action }}"
+      vars:
+        cas_secure_logging: "{{ controller_role_team_assignments_secure_logging }}"
+        cas_job_async_results_item: "{{ __controller_role_team_assignments_job_async_results_item }}"
+        cas_register_subvar: controller_role_team_assignments
+        cas_error_list_var_name: "controller_role_team_assignments_errors"
+        __operation: "{{ operation_translate[__controller_role_team_assignments_job_async_results_item.__controller_role_team_assignments_item.state | default(platform_state) | default('present')] }}"
+        cas_object_label: "{{ __operation.verb }} Role {{ __controller_role_team_assignments_job_async_results_item.__controller_role_team_assignments_item.role_definition }} | Wait for finish the Roles {{ __operation.action }}"
+
+  always:
+    - name: Cleanup async results files
+      when:
+        - not ansible_check_mode
+        - __controller_role_team_assignments_job_async_results_item.ansible_job_id is defined
+      ansible.builtin.async_status:
+        jid: "{{ __controller_role_team_assignments_job_async_results_item.ansible_job_id }}"
+        mode: cleanup
+      loop: "{{ __controller_role_team_assignments_job_async.results }}"
+      loop_control:
+        loop_var: __controller_role_team_assignments_job_async_results_item
+        label: "Cleaning up job results file: {{ __controller_role_team_assignments_job_async_results_item.results_file | default('Unknown') }}"
+...

--- a/roles/controller_role_team_assignments/tests/configs/roles.yml
+++ b/roles/controller_role_team_assignments/tests/configs/roles.yml
@@ -1,0 +1,7 @@
+---
+controller_role_team_assignments:
+  - name: Demo Controller Role - Organization Inventory Use
+    object_id: 1
+    role_definition: Organization Inventory Admin
+    team: demo_team
+...

--- a/roles/controller_role_team_assignments/tests/configs/roles.yml
+++ b/roles/controller_role_team_assignments/tests/configs/roles.yml
@@ -1,7 +1,6 @@
 ---
 controller_role_team_assignments:
-  - name: Demo Controller Role - Organization Inventory Use
-    object_id: 1
-    role_definition: Organization Inventory Admin
+  - role_definition: Demo Controller Role - Organization Inventory Admin
+    object_id: 1    
     team: demo_team
 ...

--- a/roles/controller_role_team_assignments/tests/configs/roles.yml
+++ b/roles/controller_role_team_assignments/tests/configs/roles.yml
@@ -1,6 +1,6 @@
 ---
 controller_role_team_assignments:
   - role_definition: Demo Controller Role - Organization Inventory Admin
-    object_id: 1    
+    object_id: 1
     team: demo_team
 ...

--- a/roles/controller_role_team_assignments/tests/test.yml
+++ b/roles/controller_role_team_assignments/tests/test.yml
@@ -1,0 +1,20 @@
+---
+- name: Add role team assignments to Controller
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    aap_validate_certs: false
+    aap_hostname: aap.example.com
+    aap_username: admin
+    aap_password: changeme
+
+  pre_tasks:
+    - name: Include vars from platform_configs directory
+      ansible.builtin.include_vars:
+        dir: ./configs
+        extensions: [yml]
+
+  roles:
+    - { role: ../.., when: controller_role_team_assignments is defined }
+...

--- a/roles/controller_role_user_assignments/README.md
+++ b/roles/controller_role_user_assignments/README.md
@@ -1,0 +1,115 @@
+# Ansible Role infra.aap_configuration.controller_role_user_assignments
+
+## Description
+
+An Ansible Role to create/update/remove Role User Assignments on Ansible Controller **AAP 2.5 ONLY**.
+
+## Variables
+
+|Variable Name|Default Value|Required|Description|Example|
+|:---|:---:|:---:|:---|:---|
+|`platform_state`|"present"|no|The state all objects will take unless overridden by object default|'absent'|
+|`aap_hostname`|""|yes|URL to the Ansible Automation Platform Server.|127.0.0.1|
+|`aap_validate_certs`|`true`|no|Whether or not to validate the Ansible Automation Platform Server's SSL certificate.||
+|`aap_username`|""|no|Admin User on the Ansible Automation Platform Server. Either username / password or oauthtoken need to be specified.||
+|`aap_password`|""|no|Platform Admin User's password on the Server.  This should be stored in an Ansible Vault at vars/platform-secrets.yml or elsewhere and called from a parent playbook.||
+|`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
+|`aap_request_timeout`|""|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
+|`controller_role_user_assignments`|`see below`|yes|Data structure describing your role user assignments Described below.||
+
+### Enforcing defaults
+
+The following Variables complement each other.
+If Both variables are not set, enforcing default values is not done.
+Enabling these variables enforce default values on options that are optional in the controller API.
+This should be enabled to enforce configuration and prevent configuration drift. It is recommended to be enabled, however it is not enforced by default.
+
+Enabling this will enforce configuration without specifying every option in the configuration files.
+
+'controller_role_user_assignments_enforce_defaults' defaults to the value of 'aap_configuration_enforce_defaults' if it is not explicitly called. This allows for enforced defaults to be toggled for the entire suite of controller configuration roles with a single variable, or for the user to selectively use it.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`controller_role_user_assignments_enforce_defaults`|`false`|no|Whether or not to enforce default option values on only the role user assignments role|
+|`aap_configuration_enforce_defaults`|`false`|no|This variable enables enforced default values as well, but is shared globally.|
+
+### Secure Logging Variables
+
+The following Variables complement each other.
+If Both variables are not set, secure logging defaults to false.
+The role defaults to false as normally the add role user assignments task does not include sensitive information.
+controller_role_user_assignments_secure_logging defaults to the value of aap_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of controller configuration roles with a single variable, or for the user to selectively use it.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`controller_role_user_assignments_secure_logging`|`false`|no|Whether or not to include the sensitive Role User Assignments role tasks in the log.  Set this value to `true` if you will be providing your sensitive values from elsewhere.|
+|`aap_configuration_secure_logging`|`false`|no|This variable enables secure logging as well, but is shared across multiple roles, see above.|
+
+### Asynchronous Retry Variables
+
+The following Variables set asynchronous retries for the role.
+If neither of the retries or delay or retries are set, they will default to their respective defaults.
+This allows for all items to be created, then checked that the task finishes successfully.
+This also speeds up the overall role.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`aap_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
+|`controller_role_user_assignments_async_retries`|`aap_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
+|`aap_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
+|`controller_role_user_assignments_async_delay`|`aap_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`aap_configuration_loop_delay`|0|no|This variable sets the loop_delay for the role globally.|
+|`controller_role_user_assignments_loop_delay`|`aap_configuration_loop_delay`|no|This variable sets the loop_delay for the role.|
+|`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
+
+## Data Structure
+
+### Role User Assignment Variables
+
+**WARNING: This role will only work in AAP 2.5** Options for the `controller_role_user_assignments` variable:
+
+| Variable Name       | Default Value | Required | Type | Description                                                                                           |
+|:--------------------|:-------------:|:--------:|:----:|:------------------------------------------------------------------------------------------------------|
+| `object_id`         |      N/A      |    yes   | int  | Primary key of the object this assignment applies to.                                                 |
+| `role_definition`   |      N/A      |    yes   | str  | The name or id of the role definition to assign to the user.                                          |
+| `state`             |   `present`   |    no    | str  | Desired state of the resource.                                                                        |
+| `user`              |      N/A      |    no    | str  | The name or id of the user to assign to the object.                                                   |
+| `user_ansible_id`   |      N/A      |    no    | int  | Resource id of the user who will receive permissions from this assignment. Alternative to user field. |
+
+### Standard Role User Assignment Data Structure
+
+#### Json Example
+
+```json
+{
+  "controller_role_user_assignments": [
+    {
+        "role_definition": "Inventory Admin",
+        "object_id": 1,
+        "user": "user"
+    }
+  ]
+}
+```
+
+#### Yaml Example
+
+File name: `configs/controller/controller_role_user_assignments.yml`
+
+```yaml
+---
+
+controller_role_user_assignments:
+  # This will apply the role 'Inventory Admin' to the user 'user123' on the inventory with the id of '1'
+  - role_definition: Inventory Admin
+    object_id: 1    
+    user: user123
+  # This will apply the role 'Credential Use' to the user 'user456' on the credential with the id of '23'
+  - role_definition: Credential Use
+    object_id: 23
+    user: user456
+```
+
+## License
+
+[GPLv3+](https://github.com/redhat-cop/infra.aap_configuration/blob/devel/LICENSE)

--- a/roles/controller_role_user_assignments/README.md
+++ b/roles/controller_role_user_assignments/README.md
@@ -102,7 +102,7 @@ File name: `configs/controller/controller_role_user_assignments.yml`
 controller_role_user_assignments:
   # This will apply the role 'Inventory Admin' to the user 'user123' on the inventory with the id of '1'
   - role_definition: Inventory Admin
-    object_id: 1    
+    object_id: 1
     user: user123
   # This will apply the role 'Credential Use' to the user 'user456' on the credential with the id of '23'
   - role_definition: Credential Use

--- a/roles/controller_role_user_assignments/README.md
+++ b/roles/controller_role_user_assignments/README.md
@@ -4,8 +4,8 @@
 
 An Ansible Role to create/update/remove Role User Assignments on Ansible Controller **AAP 2.5 ONLY**.
 
-[!NOTE]
-This role is not included in the default dispatch role dispatcher list because it is AAP 2.5-only. To use it, either call the role directly in your playbook or create a custom dispatcher list that includes it. See the dispatch role's aap_configuration_dispatcher_roles variable for details.
+>[!NOTE]
+>This role is not included in the default dispatch role dispatcher list because it is AAP 2.5-only. To use it, either call the role directly in your playbook or create a custom dispatcher list that includes it. See the dispatch role's aap_configuration_dispatcher_roles variable for details.
 
 ## Variables
 

--- a/roles/controller_role_user_assignments/README.md
+++ b/roles/controller_role_user_assignments/README.md
@@ -4,6 +4,9 @@
 
 An Ansible Role to create/update/remove Role User Assignments on Ansible Controller **AAP 2.5 ONLY**.
 
+[!NOTE]
+This role is not included in the default dispatch role dispatcher list because it is AAP 2.5-only. To use it, either call the role directly in your playbook or create a custom dispatcher list that includes it. See the dispatch role's aap_configuration_dispatcher_roles variable for details.
+
 ## Variables
 
 |Variable Name|Default Value|Required|Description|Example|

--- a/roles/controller_role_user_assignments/defaults/main.yml
+++ b/roles/controller_role_user_assignments/defaults/main.yml
@@ -5,7 +5,7 @@
 # aap_token: ""
 # aap_validate_certs: false
 
-# These are the default variables specific to the license role
+# These are the default variables specific to the controller_role_user_assignments role
 
 # a list of dictionaries describing the controller_role_user_assignments
 controller_role_user_assignments: []

--- a/roles/controller_role_user_assignments/defaults/main.yml
+++ b/roles/controller_role_user_assignments/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# These are the default variables common to most gateway_configuration roles
+# You shouldn't need to define them again and again but they should be defined
+# aap_hostname: "{{ inventory_hostname }}"
+# aap_token: ""
+# aap_validate_certs: false
+
+# These are the default variables specific to the license role
+
+# a list of dictionaries describing the controller_role_user_assignments
+controller_role_user_assignments: []
+controller_role_user_assignments_secure_logging: "{{ aap_configuration_secure_logging | default('false') }}"
+controller_role_user_assignments_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
+controller_role_user_assignments_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
+controller_role_user_assignments_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
+controller_role_user_assignments_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+aap_configuration_async_dir:
+...

--- a/roles/controller_role_user_assignments/meta/argument_specs.yml
+++ b/roles/controller_role_user_assignments/meta/argument_specs.yml
@@ -1,0 +1,110 @@
+---
+argument_specs:
+  main:
+    short_description: An Ansible Role to create role_user_assignments on Ansible Controller for AAP 2.5 ONLY.
+    options:
+      controller_role_user_assignments:
+        description: Data structure describing your role_user_assignments
+        type: list
+        required: true
+        elements: dict
+#        options:
+#          content_type:
+#            required: true
+#            type: str
+#            description: The content type for which the role applies (e.g., awx.inventory)
+#          description:
+#            type: str
+#            description: Description of the role definition
+#          name:
+#            required: true
+#            type: str
+#            description: The name of the role definition (must be unique)
+#          new_name:
+#            type: str
+#            description: Setting this option will change the existing name (looked up via the name field)
+#          permissions:
+#            required: true
+#            type: list
+#            description: List of permission strings to associate with the role (e.g., awx.view_inventory)
+#          state:
+#            default: present
+#            type: str
+#            description: Desired state of the role definition
+
+      # Async variables
+      controller_role_user_assignments_async_retries:
+        default: "{{ aap_configuration_async_retries | default(50) }}"
+        required: false
+        description: This variable sets the number of retries to attempt for the role.
+      aap_configuration_async_retries:
+        default: 50
+        required: false
+        description: This variable sets number of retries across all roles as a default.
+      role_user_assignments_async_delay:
+        default: "{{ aap_configuration_async_delay | default(1) }}"
+        required: false
+        description: This variable sets delay between retries for the role.
+      aap_configuration_async_delay:
+        default: 1
+        required: false
+        description: This variable sets delay between retries across all roles as a default.
+      aap_configuration_async_dir:
+        default: null
+        required: false
+        description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
+
+      # No_log variables
+      controller_role_user_assignments_secure_logging:
+        default: "{{ aap_configuration_secure_logging | default(false) }}"
+        required: false
+        type: bool
+        description: Whether or not to include the sensitive tasks from this role in the log. Set this value to `true` if you will be providing your sensitive values from elsewhere.
+      aap_configuration_secure_logging:
+        default: false
+        required: false
+        type: bool
+        description: This variable enables secure logging across all roles as a default.
+
+      # Generic across all roles
+      platform_state:
+        default: present
+        required: false
+        description: The state all objects will take unless overridden by object default
+        type: str
+      aap_hostname:
+        default: None
+        required: false
+        description: URL to the Ansible gateway Server.
+        type: str
+      aap_validate_certs:
+        default: true
+        required: false
+        description: Whether or not to validate the Ansible gateway Server's SSL certificate.
+        type: str
+      aap_username:
+        default: None
+        required: false
+        description: Admin User on the Ansible gateway Server. Either username / password or oauthtoken need to be specified.
+        type: str
+      aap_password:
+        default: None
+        required: false
+        description: Gateway Admin User's password on the Ansible gateway Server. This should be stored in an Ansible Vault at vars/gateway-secrets.yml or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.
+        type: str
+      aap_token:
+        default: None
+        required: false
+        description: Gateway Admin User's token on the Ansible gateway Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.
+        type: str
+      aap_request_timeout:
+        default: 10
+        required: false
+        description: Specify the timeout Ansible should use in requests to the Ansible gateway Server.
+        type: float
+      aap_configuration_collect_logs:
+        default: false
+        required: false
+        description: Specify whether to collect async results and continue for all failed async tasks instead of failing on the first error. Collected results are available in the aap_configuration_role_errors variable.
+        type: bool
+...

--- a/roles/controller_role_user_assignments/meta/main.yml
+++ b/roles/controller_role_user_assignments/meta/main.yml
@@ -1,0 +1,36 @@
+---
+galaxy_info:
+  role_name: controller_role_user_assignments
+  author: Matt Willis
+  description: An Ansible Role to create role_user_assignments in Ansible Controller (AAP 2.5 ONLY).
+  company: Red Hat
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+  license: GPL-3.0-or-later
+
+  min_ansible_version: 2.16.0
+
+  platforms:
+    - name: EL
+      versions:
+        - all
+
+  galaxy_tags:
+    - controller
+    - aap
+    - awx
+    - configuration
+    - roleuserassignment
+    - roleuserassignments
+
+collections:
+  - ansible.controller
+
+dependencies:
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  - role: global_vars
+  - role: meta_dependency_check
+...

--- a/roles/controller_role_user_assignments/tasks/main.yml
+++ b/roles/controller_role_user_assignments/tasks/main.yml
@@ -28,9 +28,14 @@
       async: "{{ ansible_check_mode | ternary(0, 1000) }}"
       poll: 0
       register: __controller_role_user_assignments_job_async
-      changed_when: not __controller_role_user_assignments_job_async.changed
+      changed_when: (__controller_role_user_assignments_job_async.changed if ansible_check_mode else false)
       vars:
         __operation: "{{ operation_translate[__controller_role_user_assignments_item.state | default(platform_state) | default('present')] }}"
+
+    - name: Flag for errors (check mode only)
+      ansible.builtin.set_fact:
+        error_flag: true
+      when: ansible_check_mode and __controller_role_user_assignments_job_async.failed is defined and __controller_role_user_assignments_job_async.failed
 
     - name: Role user_assignments | Wait for finish the configuration
       when:
@@ -49,6 +54,8 @@
         cas_error_list_var_name: "controller_role_user_assignments_errors"
         __operation: "{{ operation_translate[__controller_role_user_assignments_job_async_results_item.__controller_role_user_assignments_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} Role {{ __controller_role_user_assignments_job_async_results_item.__controller_role_user_assignments_item.role_definition }} | Wait for finish the Roles {{ __operation.action }}"
+        cas_async_delay: "{{ controller_role_user_assignments_async_delay }}"
+        cas_async_retries: "{{ controller_role_user_assignments_async_retries }}"
 
   always:
     - name: Cleanup async results files

--- a/roles/controller_role_user_assignments/tasks/main.yml
+++ b/roles/controller_role_user_assignments/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+- name: Manage Controller Role User Assignments Block
+  vars:
+    ansible_async_dir: "{{ aap_configuration_async_dir }}"
+  no_log: "{{ controller_role_user_assignments_secure_logging }}"
+  block:
+    - name: Role User Assignments | Configuration
+      ansible.controller.role_user_assignment:
+        role_definition: "{{ __controller_role_user_assignments_item.role_definition | mandatory }}"
+        object_id: "{{ __controller_role_user_assignments_item.object_id | default(omit, true)}}"
+        object_ansible_id: "{{ __controller_role_user_assignments_item.object_ansible_id | default(omit, true)}}"
+        user: "{{ __controller_role_user_assignments_item.user | default(omit, true) }}"
+        user_ansible_id: "{{ __controller_role_user_assignments_item.user_ansible_id | default(omit, true) }}"
+        state: "{{ __controller_role_user_assignments_item.state | default(platform_state | default(omit, true)) }}"
+
+        # Role Standard Options
+        controller_host: "{{ aap_hostname | default(omit, true) }}"
+        controller_username: "{{ aap_username | default(omit, true) }}"
+        controller_password: "{{ aap_password | default(omit, true) }}"
+        controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+        request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+        validate_certs: "{{ aap_validate_certs | default(omit) }}"
+      loop: "{{ controller_role_user_assignments }}"
+      loop_control:
+        loop_var: __controller_role_user_assignments_item
+        label: "{{ __operation.verb }} Role Based Access Entry on Controller {{ __controller_role_user_assignments_item.role_definition }}"
+        pause: "{{ controller_role_user_assignments_loop_delay }}"
+      async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+      poll: 0
+      register: __controller_role_user_assignments_job_async
+      changed_when: not __controller_role_user_assignments_job_async.changed
+      vars:
+        __operation: "{{ operation_translate[__controller_role_user_assignments_item.state | default(platform_state) | default('present')] }}"
+
+    - name: Role user_assignments | Wait for finish the configuration
+      when:
+        - not ansible_check_mode
+        - __controller_role_user_assignments_job_async_results_item.ansible_job_id is defined
+      ansible.builtin.include_role:
+        name: infra.aap_configuration.collect_async_status
+      loop: "{{ __controller_role_user_assignments_job_async.results }}"
+      loop_control:
+        loop_var: __controller_role_user_assignments_job_async_results_item
+        label: "{{ __operation.verb }} Role {{ __controller_role_user_assignments_job_async_results_item.__controller_role_user_assignments_item.role_definition }} | Wait for finish the Roles {{ __operation.action }}"
+      vars:
+        cas_secure_logging: "{{ controller_role_user_assignments_secure_logging }}"
+        cas_job_async_results_item: "{{ __controller_role_user_assignments_job_async_results_item }}"
+        cas_register_subvar: controller_role_user_assignments
+        cas_error_list_var_name: "controller_role_user_assignments_errors"
+        __operation: "{{ operation_translate[__controller_role_user_assignments_job_async_results_item.__controller_role_user_assignments_item.state | default(platform_state) | default('present')] }}"
+        cas_object_label: "{{ __operation.verb }} Role {{ __controller_role_user_assignments_job_async_results_item.__controller_role_user_assignments_item.role_definition }} | Wait for finish the Roles {{ __operation.action }}"
+
+  always:
+    - name: Cleanup async results files
+      when:
+        - not ansible_check_mode
+        - __controller_role_user_assignments_job_async_results_item.ansible_job_id is defined
+      ansible.builtin.async_status:
+        jid: "{{ __controller_role_user_assignments_job_async_results_item.ansible_job_id }}"
+        mode: cleanup
+      loop: "{{ __controller_role_user_assignments_job_async.results }}"
+      loop_control:
+        loop_var: __controller_role_user_assignments_job_async_results_item
+        label: "Cleaning up job results file: {{ __controller_role_user_assignments_job_async_results_item.results_file | default('Unknown') }}"
+...

--- a/roles/controller_role_user_assignments/tests/configs/roles.yml
+++ b/roles/controller_role_user_assignments/tests/configs/roles.yml
@@ -1,0 +1,6 @@
+---
+controller_role_user_assignments:
+  - role_definition: Demo Controller Role - Inventory Admin
+    object_id: 1
+    user: demo_user
+...

--- a/roles/controller_role_user_assignments/tests/test.yml
+++ b/roles/controller_role_user_assignments/tests/test.yml
@@ -1,0 +1,20 @@
+---
+- name: Add role user assignments to Controller
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    aap_validate_certs: false
+    aap_hostname: aap.example.com
+    aap_username: admin
+    aap_password: changeme
+
+  pre_tasks:
+    - name: Include vars from platform_configs directory
+      ansible.builtin.include_vars:
+        dir: ./configs
+        extensions: [yml]
+
+  roles:
+    - { role: ../.., when: controller_role_user_assignments is defined }
+...


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?
<!--- Brief explanation of the code or documentation change you've made -->

Added controller_role_user_assignments and controller_role_team_assignments to collection compatibility with AAP 2.5. Only way to use custom role definitions in AAP 2.5, is write a playbook with the module `ansible.controller.role_team_assingment` or `ansible.controller.role_user_assingment`. With the understanding, this is meant to support only with AAP 2.5.

# How should this be tested?
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

Added test playbook in `tests/` directory

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #[number]

N/A

# Other Relevant info, PRs, etc
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->

N/A