### PR TITLE
[draft] process resources in batches to throttle concurrent API calls

### DIFF
--- a/changelogs/fragments/batching_implementation.yml
+++ b/changelogs/fragments/batching_implementation.yml
@@ -1,0 +1,17 @@
+major_changes:
+  - Implemented batch processing across multiple roles to throttle concurrent API calls and prevent overwhelming Gateway/Controller APIs on OpenShift deployments
+  - controller_credential_types - Added configurable batch processing with `controller_configuration_credential_types_async_concurrency` and `controller_configuration_credential_types_batch_delay` parameters
+  - controller_credentials - Added configurable batch processing with `controller_configuration_credentials_async_concurrency` and `controller_configuration_credentials_batch_delay` parameters
+  - controller_execution_environments - Added configurable batch processing with `controller_configuration_execution_environments_async_concurrency` and `controller_configuration_execution_environments_batch_delay` parameters
+  - controller_hosts - Added configurable batch processing with `controller_configuration_hosts_async_concurrency` and `controller_configuration_hosts_batch_delay` parameters
+  - controller_inventories - Added configurable batch processing with `controller_configuration_inventories_async_concurrency` and `controller_configuration_inventories_batch_delay` parameters
+  - controller_inventory_sources - Added configurable batch processing with `controller_configuration_inventory_sources_async_concurrency` and `controller_configuration_inventory_sources_batch_delay` parameters
+  - controller_job_templates - Added configurable batch processing with `controller_configuration_job_templates_async_concurrency` and `controller_configuration_job_templates_batch_delay` parameters
+  - controller_labels - Added configurable batch processing with `controller_configuration_labels_async_concurrency` and `controller_configuration_labels_batch_delay` parameters
+  - controller_notification_templates - Added configurable batch processing with `controller_configuration_notification_templates_async_concurrency` and `controller_configuration_notification_templates_batch_delay` parameters
+  - controller_projects - Added configurable batch processing with `controller_configuration_projects_async_concurrency` and `controller_configuration_projects_batch_delay` parameters
+  - controller_schedules - Added configurable batch processing with `controller_configuration_schedules_async_concurrency` and `controller_configuration_schedules_batch_delay` parameters
+  - gateway_organizations - Added configurable batch processing with `gateway_organizations_async_concurrency` and `gateway_organizations_batch_delay` parameters
+  - gateway_teams - Added configurable batch processing with `gateway_teams_async_concurrency` and `gateway_teams_batch_delay` parameters
+  - gateway_users - Added configurable batch processing with `gateway_users_async_concurrency` and `gateway_users_batch_delay` parameters
+  - Global defaults added - `aap_configuration_async_concurrency` (default 100) and `aap_configuration_batch_delay` (default 3 seconds) apply to all batched roles unless overridden

--- a/roles/controller_credential_types/defaults/main.yml
+++ b/roles/controller_credential_types/defaults/main.yml
@@ -4,6 +4,8 @@ controller_credential_types: []
 controller_configuration_credential_types_secure_logging: "{{ aap_configuration_secure_logging | default('false') }}"
 controller_configuration_credential_types_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 controller_configuration_credential_types_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
+controller_configuration_credential_types_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
+controller_configuration_credential_types_batch_delay: "{{ aap_configuration_batch_delay | default(3) }}"
 controller_configuration_credential_types_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_credential_types_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"

--- a/roles/controller_credential_types/tasks/main.yml
+++ b/roles/controller_credential_types/tasks/main.yml
@@ -4,59 +4,17 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ controller_configuration_credential_types_secure_logging }}"
   block:
-    - name: Managing Credential Types
-      ansible.controller.credential_type:
-        name: "{{ __controller_credential_type_item.name | mandatory }}"
-        new_name: "{{ __controller_credential_type_item.new_name | default(omit, true) }}"
-        description: "{{ __controller_credential_type_item.description | default(('' if controller_configuration_credential_types_enforce_defaults else omit), true) }}"
-        injectors: "{{ __controller_credential_type_item.injectors | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_credential_type_item.injectors is defined and __controller_credential_type_item.injectors) else ({} if controller_configuration_credential_types_enforce_defaults else omit) }}"
-        inputs: "{{ __controller_credential_type_item.inputs | default(({} if controller_configuration_credential_types_enforce_defaults else omit), true) }}"
-        kind: "{{ __controller_credential_type_item.kind | default('cloud') }}"
-        state: "{{ __controller_credential_type_item.state | default(platform_state | default('present')) }}"
-
-        # Role specific options
-        controller_username: "{{ aap_username | default(omit, true) }}"
-        controller_password: "{{ aap_password | default(omit, true) }}"
-        controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
-        request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
-        controller_host: "{{ aap_hostname | default(omit, true) }}"
-        validate_certs: "{{ aap_validate_certs | default(omit) }}"
-      loop: "{{ credential_types if credential_types is defined else controller_credential_types }}"
-      loop_control:
-        loop_var: __controller_credential_type_item
-        label: "{{ __operation.verb }} Credential Type {{ __controller_credential_type_item.name }}"
-        pause: "{{ controller_configuration_credential_types_loop_delay }}"
-      async: "{{ ansible_check_mode | ternary(0, 1000) }}"
-      poll: 0
-      register: __credentialtypes_job_async
-      changed_when: (__credentialtypes_job_async.changed if ansible_check_mode else false)
-      vars:
-        __operation: "{{ operation_translate[__controller_credential_type_item.state | default(platform_state) | default('present')] }}"
-
-    - name: Flag for errors (check mode only)
+    - name: Credential Types | Set batch size
       ansible.builtin.set_fact:
-        error_flag: true
-      when: ansible_check_mode and __credentialtypes_job_async.failed is defined and __credentialtypes_job_async.failed
+        __batch_size: "{{ controller_configuration_credential_types_async_concurrency | int }}"
 
-    - name: Managing Controller Credential Types | Wait for finish the credential types management
-      when:
-        - not ansible_check_mode
-        - __credentialtypes_job_async_result_item.ansible_job_id is defined
-      ansible.builtin.include_role:
-        name: infra.aap_configuration.collect_async_status
-      loop: "{{ __credentialtypes_job_async.results }}"
+    - name: Credential Types | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_credential_type_batch.yml
+      loop: "{{ range(0, (credential_types if credential_types is defined else controller_credential_types) | length, __batch_size | int) | list }}"
       loop_control:
-        loop_var: __credentialtypes_job_async_result_item
-        label: "{{ __operation.verb }} Controller Credential Type {{ __credentialtypes_job_async_result_item.__controller_credential_type_item.name }} | Wait for finish the credential type {{ __operation.action }}"
-      vars:
-        cas_secure_logging: "{{ controller_configuration_credential_types_secure_logging }}"
-        cas_async_delay: "{{ controller_configuration_credential_types_async_delay }}"
-        cas_async_retries: "{{ controller_configuration_credential_types_async_retries }}"
-        cas_job_async_results_item: "{{ __credentialtypes_job_async_result_item }}"
-        cas_register_subvar: controller_credential_types
-        cas_error_list_var_name: "controller_credential_types_errors"
-        __operation: "{{ operation_translate[__credentialtypes_job_async_result_item.__controller_credential_type_item.state | default(platform_state) | default('present')] }}"
-        cas_object_label: "{{ __operation.verb }} Controller Credential Type {{ __credentialtypes_job_async_result_item.__controller_credential_type_item.name }} | Wait for finish the credential type {{ __operation.action }}"
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ (((credential_types if credential_types is defined else controller_credential_types) | length - 1) / __batch_size | int) + 1 }}"
 
   always:
     - name: Cleanup async results files
@@ -66,7 +24,7 @@
       ansible.builtin.async_status:
         jid: "{{ __credentialtypes_job_async_result_item.ansible_job_id }}"
         mode: cleanup
-      loop: "{{ __credentialtypes_job_async.results }}"
+      loop: "{{ __credentialtypes_batch_async.results | default([]) }}"
       loop_control:
         loop_var: __credentialtypes_job_async_result_item
         label: "Cleaning up job results file: {{ __credentialtypes_job_async_result_item.results_file | default('Unknown') }}"

--- a/roles/controller_credential_types/tasks/process_credential_type_batch.yml
+++ b/roles/controller_credential_types/tasks/process_credential_type_batch.yml
@@ -1,0 +1,64 @@
+---
+- name: process_credential_type_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ (credential_types if credential_types is defined else controller_credential_types)[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_credential_type_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.controller.credential_type:
+    name: "{{ __controller_credential_type_item.name | mandatory }}"
+    new_name: "{{ __controller_credential_type_item.new_name | default(omit, true) }}"
+    description: "{{ __controller_credential_type_item.description | default(('' if controller_configuration_credential_types_enforce_defaults else omit), true) }}"
+    injectors: "{{ __controller_credential_type_item.injectors | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_credential_type_item.injectors is defined and __controller_credential_type_item.injectors) else ({} if controller_configuration_credential_types_enforce_defaults else omit) }}"
+    inputs: "{{ __controller_credential_type_item.inputs | default(({} if controller_configuration_credential_types_enforce_defaults else omit), true) }}"
+    kind: "{{ __controller_credential_type_item.kind | default('cloud') }}"
+    state: "{{ __controller_credential_type_item.state | default(platform_state | default('present')) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __controller_credential_type_item
+    label: "{{ __operation.verb }} Credential Type {{ __controller_credential_type_item.name }}"
+    pause: "{{ controller_configuration_credential_types_loop_delay }}"
+  async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+  poll: 0
+  register: __credentialtypes_batch_async
+  changed_when: (__credentialtypes_batch_async.changed if ansible_check_mode else false)
+  vars:
+    __operation: "{{ operation_translate[__controller_credential_type_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_credential_type_batch | Flag for errors (check mode only)
+  ansible.builtin.set_fact:
+    error_flag: true
+  when: ansible_check_mode and __credentialtypes_batch_async.failed is defined and __credentialtypes_batch_async.failed
+
+- name: process_credential_type_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __credentialtypes_batch_async.results }}"
+  loop_control:
+    loop_var: __credentialtypes_job_async_result_item
+    label: "{{ __operation.verb }} Controller Credential Type {{ __credentialtypes_job_async_result_item.__controller_credential_type_item.name }} | Wait for finish the credential type {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __credentialtypes_job_async_result_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ controller_configuration_credential_types_secure_logging }}"
+    cas_async_delay: "{{ controller_configuration_credential_types_async_delay }}"
+    cas_async_retries: "{{ controller_configuration_credential_types_async_retries }}"
+    cas_job_async_results_item: "{{ __credentialtypes_job_async_result_item }}"
+    cas_register_subvar: controller_credential_types
+    cas_error_list_var_name: "controller_credential_types_errors"
+    __operation: "{{ operation_translate[__credentialtypes_job_async_result_item.__controller_credential_type_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} Controller Credential Type {{ __credentialtypes_job_async_result_item.__controller_credential_type_item.name }} | Wait for finish the credential type {{ __operation.action }}"
+
+- name: process_credential_type_batch | Delay between batches
+  ansible.builtin.pause:
+    seconds: "{{ controller_configuration_credential_types_batch_delay }}"
+  when:
+    - not ansible_check_mode
+    - controller_configuration_credential_types_batch_delay | int > 0
+...

--- a/roles/controller_credentials/defaults/main.yml
+++ b/roles/controller_credentials/defaults/main.yml
@@ -5,6 +5,8 @@ controller_configuration_credentials_secure_logging: "{{ aap_configuration_secur
 controller_configuration_credentials_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 controller_configuration_credentials_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 controller_configuration_credentials_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+controller_configuration_credentials_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
+controller_configuration_credentials_batch_delay: "{{ aap_configuration_batch_delay | default(3) }}"
 aap_configuration_async_dir:
 controller_configuration_credentials_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 aap_configuration_apply_object_roles: true

--- a/roles/controller_credentials/tasks/main.yml
+++ b/roles/controller_credentials/tasks/main.yml
@@ -4,63 +4,17 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ controller_configuration_credentials_secure_logging }}"
   block:
-    - name: Managing Credentials
-      ansible.controller.credential:
-        name: "{{ __controller_credentials_item.name | mandatory }}"
-        new_name: "{{ __controller_credentials_item.new_name | default(omit, true) }}"
-        copy_from: "{{ __controller_credentials_item.copy_from | default(omit, true) }}"
-        description: "{{ __controller_credentials_item.description | default(('' if controller_configuration_credentials_enforce_defaults else omit), true) }}"
-        organization: "{{ __controller_credentials_item.organization.name | default(__controller_credentials_item.organization | default(omit, true)) }}"
-        credential_type: "{{ __controller_credentials_item.credential_type.name | default(__controller_credentials_item.credential_type | mandatory) }}"
-        inputs: "{{ __controller_credentials_item.inputs | default(({} if controller_configuration_credentials_enforce_defaults else omit), true) }}"
-        user: "{{ __controller_credentials_item.user.username | default(__controller_credentials_item.user | default(omit, true)) }}"
-        team: "{{ __controller_credentials_item.team.name | default(__controller_credentials_item.team | default(omit, true)) }}"
-        update_secrets: "{{ __controller_credentials_item.update_secrets | default(true if controller_configuration_credentials_enforce_defaults else omit) }}"
-        state: "{{ __controller_credentials_item.state | default(platform_state | default('present')) }}"
-
-        # Role specific options
-        controller_username: "{{ aap_username | default(omit, true) }}"
-        controller_password: "{{ aap_password | default(omit, true) }}"
-        controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
-        controller_host: "{{ aap_hostname | default(omit, true) }}"
-        request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
-        validate_certs: "{{ aap_validate_certs | default(omit) }}"
-      loop: "{{ credentials if credentials is defined else controller_credentials }}"
-      loop_control:
-        loop_var: __controller_credentials_item
-        label: "{{ __operation.verb }} Credential {{ __controller_credentials_item.name }}"
-        pause: "{{ controller_configuration_credentials_loop_delay }}"
-      async: "{{ ansible_check_mode | ternary(0, 1000) }}"
-      poll: 0
-      register: __credentials_job_async
-      changed_when: (__credentials_job_async.changed if ansible_check_mode else false)
-      vars:
-        __operation: "{{ operation_translate[__controller_credentials_item.state | default(platform_state) | default('present')] }}"
-
-    - name: Flag for errors (check mode only)
+    - name: Credentials | Set batch size
       ansible.builtin.set_fact:
-        error_flag: true
-      when: ansible_check_mode and __credentials_job_async.failed is defined and __credentials_job_async.failed
+        __batch_size: "{{ controller_configuration_credentials_async_concurrency | int }}"
 
-    - name: Managing Controller Credentials | Wait for finish the credential management
-      when:
-        - not ansible_check_mode
-        - __credentials_job_async_results_item.ansible_job_id is defined
-      ansible.builtin.include_role:
-        name: infra.aap_configuration.collect_async_status
-      loop: "{{ __credentials_job_async.results }}"
+    - name: Credentials | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_credential_batch.yml
+      loop: "{{ range(0, (credentials if credentials is defined else controller_credentials) | length, __batch_size | int) | list }}"
       loop_control:
-        loop_var: __credentials_job_async_results_item
-        label: "{{ __operation.verb }} Credential {{ __credentials_job_async_results_item.__controller_credentials_item.name }} | Wait for finish the credential {{ __operation.action }}"
-      vars:
-        cas_secure_logging: "{{ controller_configuration_credentials_secure_logging }}"
-        cas_async_delay: "{{ controller_configuration_credentials_async_delay }}"
-        cas_async_retries: "{{ controller_configuration_credentials_async_retries }}"
-        cas_job_async_results_item: "{{ __credentials_job_async_results_item }}"
-        cas_register_subvar: controller_credentials
-        cas_error_list_var_name: "controller_credentials_errors"
-        __operation: "{{ operation_translate[__credentials_job_async_results_item.__controller_credentials_item.state | default(platform_state) | default('present')] }}"
-        cas_object_label: "{{ __operation.verb }} Credential {{ __credentials_job_async_results_item.__controller_credentials_item.name }} | Wait for finish the credential {{ __operation.action }}"
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ (((credentials if credentials is defined else controller_credentials) | length - 1) / __batch_size | int) + 1 }}"
 
   always:
     - name: Cleanup async results files
@@ -70,7 +24,7 @@
       ansible.builtin.async_status:
         jid: "{{ __credentials_job_async_results_item.ansible_job_id }}"
         mode: cleanup
-      loop: "{{ __credentials_job_async.results }}"
+      loop: "{{ __credentials_batch_async.results | default([]) }}"
       loop_control:
         loop_var: __credentials_job_async_results_item
         label: "Cleaning up job results file: {{ __credentials_job_async_results_item.results_file | default('Unknown') }}"

--- a/roles/controller_credentials/tasks/process_credential_batch.yml
+++ b/roles/controller_credentials/tasks/process_credential_batch.yml
@@ -1,0 +1,68 @@
+---
+- name: process_credential_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ (credentials if credentials is defined else controller_credentials)[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_credential_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.controller.credential:
+    name: "{{ __controller_credentials_item.name | mandatory }}"
+    new_name: "{{ __controller_credentials_item.new_name | default(omit, true) }}"
+    copy_from: "{{ __controller_credentials_item.copy_from | default(omit, true) }}"
+    description: "{{ __controller_credentials_item.description | default(('' if controller_configuration_credentials_enforce_defaults else omit), true) }}"
+    organization: "{{ __controller_credentials_item.organization.name | default(__controller_credentials_item.organization | default(omit, true)) }}"
+    credential_type: "{{ __controller_credentials_item.credential_type.name | default(__controller_credentials_item.credential_type | mandatory) }}"
+    inputs: "{{ __controller_credentials_item.inputs | default(({} if controller_configuration_credentials_enforce_defaults else omit), true) }}"
+    user: "{{ __controller_credentials_item.user.username | default(__controller_credentials_item.user | default(omit, true)) }}"
+    team: "{{ __controller_credentials_item.team.name | default(__controller_credentials_item.team | default(omit, true)) }}"
+    update_secrets: "{{ __controller_credentials_item.update_secrets | default(true if controller_configuration_credentials_enforce_defaults else omit) }}"
+    state: "{{ __controller_credentials_item.state | default(platform_state | default('present')) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __controller_credentials_item
+    label: "{{ __operation.verb }} Credential {{ __controller_credentials_item.name }}"
+    pause: "{{ controller_configuration_credentials_loop_delay }}"
+  async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+  poll: 0
+  register: __credentials_batch_async
+  changed_when: (__credentials_batch_async.changed if ansible_check_mode else false)
+  vars:
+    __operation: "{{ operation_translate[__controller_credentials_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_credential_batch | Flag for errors (check mode only)
+  ansible.builtin.set_fact:
+    error_flag: true
+  when: ansible_check_mode and __credentials_batch_async.failed is defined and __credentials_batch_async.failed
+
+- name: process_credential_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __credentials_batch_async.results }}"
+  loop_control:
+    loop_var: __credentials_job_async_results_item
+    label: "{{ __operation.verb }} Credential {{ __credentials_job_async_results_item.__controller_credentials_item.name }} | Wait for finish the credential {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __credentials_job_async_results_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ controller_configuration_credentials_secure_logging }}"
+    cas_async_delay: "{{ controller_configuration_credentials_async_delay }}"
+    cas_async_retries: "{{ controller_configuration_credentials_async_retries }}"
+    cas_job_async_results_item: "{{ __credentials_job_async_results_item }}"
+    cas_register_subvar: controller_credentials
+    cas_error_list_var_name: "controller_credentials_errors"
+    __operation: "{{ operation_translate[__credentials_job_async_results_item.__controller_credentials_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} Credential {{ __credentials_job_async_results_item.__controller_credentials_item.name }} | Wait for finish the credential {{ __operation.action }}"
+
+- name: process_credential_batch | Delay between batches
+  ansible.builtin.pause:
+    seconds: "{{ controller_configuration_credentials_batch_delay }}"
+  when:
+    - not ansible_check_mode
+    - controller_configuration_credentials_batch_delay | int > 0
+...

--- a/roles/controller_execution_environments/defaults/main.yml
+++ b/roles/controller_execution_environments/defaults/main.yml
@@ -4,6 +4,8 @@ controller_configuration_execution_environments_secure_logging: "{{ aap_configur
 controller_configuration_execution_environments_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 controller_configuration_execution_environments_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 controller_configuration_execution_environments_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+controller_configuration_execution_environments_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
+controller_configuration_execution_environments_batch_delay: "{{ aap_configuration_batch_delay | default(3) }}"
 aap_configuration_async_dir:
 controller_configuration_execution_environments_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/controller_execution_environments/tasks/main.yml
+++ b/roles/controller_execution_environments/tasks/main.yml
@@ -5,63 +5,18 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ controller_configuration_execution_environments_secure_logging }}"
   block:
-    - name: Managing Controller Execution Environments
-      ansible.controller.execution_environment:
-        name: "{{ __execution_environments_item.name | mandatory }}"
-        new_name: "{{ __execution_environments_item.new_name | default(omit, true) }}"
-        description: "{{ __execution_environments_item.description | default(('' if controller_configuration_execution_environments_enforce_defaults else omit), true) }}"
-        image: "{{ __execution_environments_item.image | mandatory }}"
-        organization: "{{ __execution_environments_item.organization.name | default(__execution_environments_item.organization | default(('' if controller_configuration_execution_environments_enforce_defaults else omit), true)) }}"
-        credential: "{{ __execution_environments_item.credential | default(('' if controller_configuration_execution_environments_enforce_defaults else omit), true) }}"
-        pull: "{{ __execution_environments_item.pull | default(('missing' if controller_configuration_execution_environments_enforce_defaults else omit), true) }}"
-        state: "{{ __execution_environments_item.state | default(platform_state | default('present')) }}"
-
-        # Role specific options
-        controller_username: "{{ aap_username | default(omit, true) }}"
-        controller_password: "{{ aap_password | default(omit, true) }}"
-        controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
-        request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
-        controller_host: "{{ aap_hostname | default(omit, true) }}"
-        validate_certs: "{{ aap_validate_certs | default(omit) }}"
-      loop: "{{ execution_environments if execution_environments is defined else controller_execution_environments }}"
-      loop_control:
-        loop_var: __execution_environments_item
-        label: "{{ __operation.verb }} Controller Execution Environment {{ __execution_environments_item.name }}"
-        pause: "{{ controller_configuration_execution_environments_loop_delay }}"
-      when: controller_execution_environments is defined
-      async: "{{ ansible_check_mode | ternary(0, 1000) }}"
-      poll: 0
-      register: __execution_environments_job_async
-      changed_when: (__execution_environments_job_async.changed if ansible_check_mode else false)
-      vars:
-        __operation: "{{ operation_translate[__execution_environments_item.state | default(platform_state) | default('present')] }}"
-        ansible_async_dir: "{{ aap_configuration_async_dir }}"
-
-    - name: Flag for errors (check mode only)
+    - name: Execution Environments | Set batch size
       ansible.builtin.set_fact:
-        error_flag: true
-      when: ansible_check_mode and __execution_environments_job_async.failed is defined and __execution_environments_job_async.failed
+        __batch_size: "{{ controller_configuration_execution_environments_async_concurrency | int }}"
 
-    - name: Managing Controller Execution Environments | Wait for finish the Controller Execution Environments management
-      when:
-        - not ansible_check_mode
-        - __execution_environments_job_async_results_item.ansible_job_id is defined
-      ansible.builtin.include_role:
-        name: infra.aap_configuration.collect_async_status
-      loop: "{{ __execution_environments_job_async.results }}"
+    - name: Execution Environments | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_ee_batch.yml
+      loop: "{{ range(0, (execution_environments if execution_environments is defined else controller_execution_environments) | length, __batch_size | int) | list }}"
       loop_control:
-        loop_var: __execution_environments_job_async_results_item
-        label: "{{ __operation.verb }} Controller Execution Environment {{ __execution_environments_job_async_results_item.__execution_environments_item.name }} | Wait
-          for finish the Controller Execution Environment {{ __operation.action }}"
-      vars:
-        cas_secure_logging: "{{ controller_configuration_execution_environments_secure_logging }}"
-        cas_async_delay: "{{ controller_configuration_execution_environments_async_delay }}"
-        cas_async_retries: "{{ controller_configuration_execution_environments_async_retries }}"
-        cas_job_async_results_item: "{{ __execution_environments_job_async_results_item }}"
-        cas_register_subvar: controller_execution_environments
-        cas_error_list_var_name: "controller_execution_environments_errors"
-        __operation: "{{ operation_translate[__execution_environments_job_async_results_item.__execution_environments_item.state | default(platform_state) | default('present')] }}"
-        cas_object_label: "{{ __operation.verb }} Controller Execution Environment {{ __execution_environments_job_async_results_item.__execution_environments_item.name }} | Wait for finish the Controller Execution Environment {{ __operation.action }}"
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ (((execution_environments if execution_environments is defined else controller_execution_environments) | length - 1) / __batch_size | int) + 1 }}"
+      when: controller_execution_environments is defined
 
   always:
     - name: Cleanup async results files
@@ -71,7 +26,7 @@
       ansible.builtin.async_status:
         jid: "{{ __execution_environments_job_async_results_item.ansible_job_id }}"
         mode: cleanup
-      loop: "{{ __execution_environments_job_async.results }}"
+      loop: "{{ __execution_environments_batch_async.results | default([]) }}"
       loop_control:
         loop_var: __execution_environments_job_async_results_item
         label: "Cleaning up job results file: {{ __execution_environments_job_async_results_item.results_file | default('Unknown') }}"

--- a/roles/controller_execution_environments/tasks/process_ee_batch.yml
+++ b/roles/controller_execution_environments/tasks/process_ee_batch.yml
@@ -1,0 +1,65 @@
+---
+- name: process_ee_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ (execution_environments if execution_environments is defined else controller_execution_environments)[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_ee_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.controller.execution_environment:
+    name: "{{ __execution_environments_item.name | mandatory }}"
+    new_name: "{{ __execution_environments_item.new_name | default(omit, true) }}"
+    description: "{{ __execution_environments_item.description | default(('' if controller_configuration_execution_environments_enforce_defaults else omit), true) }}"
+    image: "{{ __execution_environments_item.image | mandatory }}"
+    organization: "{{ __execution_environments_item.organization.name | default(__execution_environments_item.organization | default(('' if controller_configuration_execution_environments_enforce_defaults else omit), true)) }}"
+    credential: "{{ __execution_environments_item.credential | default(('' if controller_configuration_execution_environments_enforce_defaults else omit), true) }}"
+    pull: "{{ __execution_environments_item.pull | default(('missing' if controller_configuration_execution_environments_enforce_defaults else omit), true) }}"
+    state: "{{ __execution_environments_item.state | default(platform_state | default('present')) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __execution_environments_item
+    label: "{{ __operation.verb }} Controller Execution Environment {{ __execution_environments_item.name }}"
+    pause: "{{ controller_configuration_execution_environments_loop_delay }}"
+  async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+  poll: 0
+  register: __execution_environments_batch_async
+  changed_when: (__execution_environments_batch_async.changed if ansible_check_mode else false)
+  vars:
+    __operation: "{{ operation_translate[__execution_environments_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_ee_batch | Flag for errors (check mode only)
+  ansible.builtin.set_fact:
+    error_flag: true
+  when: ansible_check_mode and __execution_environments_batch_async.failed is defined and __execution_environments_batch_async.failed
+
+- name: process_ee_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __execution_environments_batch_async.results }}"
+  loop_control:
+    loop_var: __execution_environments_job_async_results_item
+    label: "{{ __operation.verb }} Controller Execution Environment {{ __execution_environments_job_async_results_item.__execution_environments_item.name }} | Wait for finish the Controller Execution Environment {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __execution_environments_job_async_results_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ controller_configuration_execution_environments_secure_logging }}"
+    cas_async_delay: "{{ controller_configuration_execution_environments_async_delay }}"
+    cas_async_retries: "{{ controller_configuration_execution_environments_async_retries }}"
+    cas_job_async_results_item: "{{ __execution_environments_job_async_results_item }}"
+    cas_register_subvar: controller_execution_environments
+    cas_error_list_var_name: "controller_execution_environments_errors"
+    __operation: "{{ operation_translate[__execution_environments_job_async_results_item.__execution_environments_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} Controller Execution Environment {{ __execution_environments_job_async_results_item.__execution_environments_item.name }} | Wait for finish the Controller Execution Environment {{ __operation.action }}"
+
+- name: process_ee_batch | Delay between batches
+  ansible.builtin.pause:
+    seconds: "{{ controller_configuration_execution_environments_batch_delay }}"
+  when:
+    - not ansible_check_mode
+    - controller_configuration_execution_environments_batch_delay | int > 0
+...

--- a/roles/controller_hosts/defaults/main.yml
+++ b/roles/controller_hosts/defaults/main.yml
@@ -5,6 +5,8 @@ controller_configuration_hosts_secure_logging: "{{ aap_configuration_secure_logg
 controller_configuration_hosts_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 controller_configuration_hosts_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 controller_configuration_hosts_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+controller_configuration_hosts_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
+controller_configuration_hosts_batch_delay: "{{ aap_configuration_batch_delay | default(3) }}"
 aap_configuration_async_dir:
 controller_configuration_host_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/controller_hosts/tasks/main.yml
+++ b/roles/controller_hosts/tasks/main.yml
@@ -4,7 +4,20 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ controller_configuration_hosts_secure_logging }}"
   block:
-    - name: Managing Controller Hosts
+    - name: Hosts | Set batch size
+      ansible.builtin.set_fact:
+        __batch_size: "{{ controller_configuration_hosts_async_concurrency | int }}"
+
+    - name: Hosts | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_host_batch.yml
+      loop: "{{ range(0, controller_hosts | length, __batch_size | int) | list }}"
+      loop_control:
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ ((controller_hosts | length - 1) / __batch_size | int) + 1 }}"
+
+    - name: Managing Controller Hosts (legacy)
+      when: false
       ansible.controller.host:
         name: "{{ __controller_host_item.name | mandatory }}"
         new_name: "{{ __controller_host_item.new_name | default(omit, true) }}"

--- a/roles/controller_hosts/tasks/process_host_batch.yml
+++ b/roles/controller_hosts/tasks/process_host_batch.yml
@@ -1,0 +1,64 @@
+---
+- name: process_host_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ controller_hosts[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_host_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.controller.host:
+    name: "{{ __controller_host_item.name | mandatory }}"
+    new_name: "{{ __controller_host_item.new_name | default(omit, true) }}"
+    description: "{{ __controller_host_item.description | default(('' if controller_configuration_host_enforce_defaults else omit), true) }}"
+    inventory: "{{ __controller_host_item.inventory | mandatory }}"
+    enabled: "{{ __controller_host_item.enabled | default((false if controller_configuration_host_enforce_defaults else omit), true) }}"
+    state: "{{ __controller_host_item.state | default(platform_state | default('present')) }}"
+    variables: "{{ __controller_host_item.variables | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_host_item.variables is defined and __controller_host_item.variables) else ({} if controller_configuration_host_enforce_defaults else omit) }}"
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __controller_host_item
+    label: "{{ __operation.verb }} Controller host {{ __controller_host_item.name }}"
+    pause: "{{ controller_configuration_hosts_loop_delay }}"
+  async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+  poll: 0
+  register: __host_batch_async
+  changed_when: (__host_batch_async.changed if ansible_check_mode else false)
+  vars:
+    __operation: "{{ operation_translate[__controller_host_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_host_batch | Flag for errors (check mode only)
+  ansible.builtin.set_fact:
+    error_flag: true
+  when: ansible_check_mode and __host_batch_async.failed is defined and __host_batch_async.failed
+
+- name: process_host_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __host_batch_async.results }}"
+  loop_control:
+    loop_var: __host_job_async_results_item
+    label: "{{ __operation.verb }} Controller Host {{ __host_job_async_results_item.__controller_host_item.name }} | Wait for finish the Hosts {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __host_job_async_results_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ controller_configuration_hosts_secure_logging }}"
+    cas_async_delay: "{{ controller_configuration_hosts_async_delay }}"
+    cas_async_retries: "{{ controller_configuration_hosts_async_retries }}"
+    cas_job_async_results_item: "{{ __host_job_async_results_item }}"
+    cas_register_subvar: controller_hosts
+    cas_error_list_var_name: "controller_hosts_errors"
+    __operation: "{{ operation_translate[__host_job_async_results_item.__controller_host_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} Controller Host {{ __host_job_async_results_item.__controller_host_item.name }} | Wait for finish the Hosts {{ __operation.action }}"
+
+- name: process_host_batch | Delay between batches
+  ansible.builtin.pause:
+    seconds: "{{ controller_configuration_hosts_batch_delay }}"
+  when:
+    - not ansible_check_mode
+    - controller_configuration_hosts_batch_delay | int > 0
+...

--- a/roles/controller_inventories/defaults/main.yml
+++ b/roles/controller_inventories/defaults/main.yml
@@ -5,6 +5,8 @@ controller_configuration_inventories_secure_logging: "{{ aap_configuration_secur
 controller_configuration_inventories_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 controller_configuration_inventories_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 controller_configuration_inventories_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+controller_configuration_inventories_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
+controller_configuration_inventories_batch_delay: "{{ aap_configuration_batch_delay | default(3) }}"
 aap_configuration_async_dir:
 controller_configuration_inventories_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 aap_configuration_apply_object_roles: true

--- a/roles/controller_inventories/tasks/main.yml
+++ b/roles/controller_inventories/tasks/main.yml
@@ -4,7 +4,20 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ controller_configuration_inventories_secure_logging }}"
   block:
-    - name: Managing Inventories
+    - name: Inventories | Set batch size
+      ansible.builtin.set_fact:
+        __batch_size: "{{ controller_configuration_inventories_async_concurrency | int }}"
+
+    - name: Inventories | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_inventory_batch.yml
+      loop: "{{ range(0, (inventory if inventory is defined else controller_inventories) | length, __batch_size | int) | list }}"
+      loop_control:
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ (((inventory if inventory is defined else controller_inventories) | length - 1) / __batch_size | int) + 1 }}"
+
+    - name: Managing Inventories (legacy)
+      when: false
       ansible.controller.inventory:
         name: "{{ __controller_inventory_item.name | mandatory }}"
         new_name: "{{ __controller_inventory_item.new_name | default(omit, true) }}"

--- a/roles/controller_inventories/tasks/process_inventory_batch.yml
+++ b/roles/controller_inventories/tasks/process_inventory_batch.yml
@@ -1,0 +1,69 @@
+---
+- name: process_inventory_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ (inventory if inventory is defined else controller_inventories)[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_inventory_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.controller.inventory:
+    name: "{{ __controller_inventory_item.name | mandatory }}"
+    new_name: "{{ __controller_inventory_item.new_name | default(omit, true) }}"
+    copy_from: "{{ __controller_inventory_item.copy_from | default(omit, true) }}"
+    description: "{{ __controller_inventory_item.description | default(('' if controller_configuration_inventories_enforce_defaults else omit), true) }}"
+    organization: "{{ __controller_inventory_item.organization.name | default(__controller_inventory_item.organization) | mandatory }}"
+    instance_groups: "{{ __controller_inventory_item.instance_groups | default(([] if controller_configuration_inventories_enforce_defaults else omit), true) }}"
+    input_inventories: "{{ __controller_inventory_item.input_inventories | default(([] if controller_configuration_inventories_enforce_defaults else omit), true) }}"
+    variables: "{{ __controller_inventory_item.variables | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_inventory_item.variables is defined and __controller_inventory_item.variables) else ({} if controller_configuration_inventories_enforce_defaults else omit) }}"
+    kind: "{{ __controller_inventory_item.kind | default(('' if controller_configuration_inventories_enforce_defaults else omit), true) }}"
+    host_filter: "{{ __controller_inventory_item.host_filter | default(('' if controller_configuration_inventories_enforce_defaults else omit), true) }}"
+    prevent_instance_group_fallback: "{{ __controller_inventory_item.prevent_instance_group_fallback | default((false if controller_configuration_inventories_enforce_defaults else omit), true) }}"
+    state: "{{ __controller_inventory_item.state | default(platform_state | default('present')) }}"
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __controller_inventory_item
+    label: "{{ __operation.verb }} inventory {{ __controller_inventory_item.name }}"
+    pause: "{{ controller_configuration_inventories_loop_delay }}"
+  async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+  poll: 0
+  register: __inventories_batch_async
+  changed_when: (__inventories_batch_async.changed if ansible_check_mode else false)
+  vars:
+    __operation: "{{ operation_translate[__controller_inventory_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_inventory_batch | Flag for errors (check mode only)
+  ansible.builtin.set_fact:
+    error_flag: true
+  when: ansible_check_mode and __inventories_batch_async.failed is defined and __inventories_batch_async.failed
+
+- name: process_inventory_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __inventories_batch_async.results }}"
+  loop_control:
+    loop_var: __inventories_job_async_result_item
+    label: "{{ __operation.verb }} inventory {{ __inventories_job_async_result_item.__controller_inventory_item.name }} | Wait for finish the inventory {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __inventories_job_async_result_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ controller_configuration_inventories_secure_logging }}"
+    cas_async_delay: "{{ controller_configuration_inventories_async_delay }}"
+    cas_async_retries: "{{ controller_configuration_inventories_async_retries }}"
+    cas_job_async_results_item: "{{ __inventories_job_async_result_item }}"
+    cas_register_subvar: controller_inventories
+    cas_error_list_var_name: "controller_inventories_errors"
+    __operation: "{{ operation_translate[__inventories_job_async_result_item.__controller_inventory_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} inventory {{ __inventories_job_async_result_item.__controller_inventory_item.name }} | Wait for finish the inventory {{ __operation.action }}"
+
+- name: process_inventory_batch | Delay between batches
+  ansible.builtin.pause:
+    seconds: "{{ controller_configuration_inventories_batch_delay }}"
+  when:
+    - not ansible_check_mode
+    - controller_configuration_inventories_batch_delay | int > 0
+...

--- a/roles/controller_inventory_sources/defaults/main.yml
+++ b/roles/controller_inventory_sources/defaults/main.yml
@@ -3,6 +3,8 @@ controller_inventory_sources: []
 controller_configuration_inventory_sources_secure_logging: "{{ aap_configuration_secure_logging | default('false') }}"
 controller_configuration_inventory_sources_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 controller_configuration_inventory_sources_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
+controller_configuration_inventory_sources_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
+controller_configuration_inventory_sources_batch_delay: "{{ aap_configuration_batch_delay | default(3) }}"
 controller_configuration_inventory_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_inventory_sources_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"

--- a/roles/controller_inventory_sources/tasks/main.yml
+++ b/roles/controller_inventory_sources/tasks/main.yml
@@ -4,80 +4,17 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ controller_configuration_inventory_sources_secure_logging }}"
   block:
-    - name: Managing Inventory Sources
-      ansible.controller.inventory_source:
-        name: "{{ __controller_source_item.name | mandatory }}"
-        new_name: "{{ __controller_source_item.new_name | default(omit, true) }}"
-        description: "{{ __controller_source_item.description | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        inventory: "{{ __controller_source_item.inventory.name | default(__controller_source_item.inventory) | mandatory }}"
-        organization: "{{ __controller_source_item.inventory.organization.name | default(__controller_source_item.organization | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true)) }}"
-        source: "{{ __controller_source_item.source | default(('scm' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        source_path: "{{ __controller_source_item.source_path | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        source_vars: "{{ __controller_source_item.source_vars | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_source_item.source_vars is defined and __controller_source_item.source_vars) else ({} if controller_configuration_inventory_sources_enforce_defaults else omit) }}"
-        enabled_var: "{{ __controller_source_item.enabled_var | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        enabled_value: "{{ __controller_source_item.enabled_value | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        host_filter: "{{ __controller_source_item.host_filter | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        limit: "{{ __controller_source_item.limit | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        credential: "{{ __controller_source_item.credential | default(omit, true) }}"
-        execution_environment: "{{ __controller_source_item.execution_environment | default(omit, true) }}"
-        overwrite: "{{ __controller_source_item.overwrite | default((false if controller_configuration_inventory_sources_enforce_defaults else omit)) }}"
-        overwrite_vars: "{{ __controller_source_item.overwrite_vars | default((false if controller_configuration_inventory_sources_enforce_defaults else omit)) }}"
-        custom_virtualenv: "{{ __controller_source_item.custom_virtualenv | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        timeout: "{{ __controller_source_item.timeout | default(0, true) if __controller_source_item.timeout is defined or controller_configuration_inventory_sources_enforce_defaults else omit }}"
-        verbosity: "{{ __controller_source_item.verbosity | default((1 if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        update_on_launch: "{{ __controller_source_item.update_on_launch | default((false if controller_configuration_inventory_sources_enforce_defaults else omit)) }}"
-        update_cache_timeout: "{{ __controller_source_item.update_cache_timeout | default(0, true) if __controller_source_item.update_cache_timeout is defined or controller_configuration_inventory_sources_enforce_defaults else omit }}"
-        source_project: "{{ __controller_source_item.source_project.name | default(__controller_source_item.source_project | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true)) }}"
-        scm_branch: "{{ __controller_source_item.scm_branch | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        state: "{{ __controller_source_item.state | default(platform_state | default('present')) }}"
-        notification_templates_started: "{{ __controller_source_item.notification_templates_started | default((__controller_source_item.related.notification_templates_started | map(attribute='name') | list if __controller_source_item.related.notification_templates_started is defined)) | default(([] if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        notification_templates_success: "{{ __controller_source_item.notification_templates_success | default((__controller_source_item.related.notification_templates_success | map(attribute='name') | list if __controller_source_item.related.notification_templates_success is defined)) | default(([] if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-        notification_templates_error: "{{ __controller_source_item.notification_templates_error | default((__controller_source_item.related.notification_templates_error | map(attribute='name') | list if __controller_source_item.related.notification_templates_error is defined)) | default(([] if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-
-        # Role Standard Options
-        controller_host: "{{ aap_hostname | default(omit, true) }}"
-        controller_username: "{{ aap_username | default(omit, true) }}"
-        controller_password: "{{ aap_password | default(omit, true) }}"
-        controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
-        request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
-        validate_certs: "{{ aap_validate_certs | default(omit) }}"
-      loop: "{{ inventory_sources if inventory_sources is defined else controller_inventory_sources }}"
-      loop_control:
-        loop_var: __controller_source_item
-        label: "{{ __operation.verb }} an Inventory Source {{ __controller_source_item.name }}"
-        pause: "{{ controller_configuration_inventory_loop_delay }}"
-      async: "{{ ansible_check_mode | ternary(0, 1000) }}"
-      poll: 0
-      register: __inventory_source_job_async
-      changed_when: (__inventory_source_job_async.changed if ansible_check_mode else false)
-      when: (__controller_source_item.source | default(('scm' if controller_configuration_inventory_sources_enforce_defaults else omit), true)) != "constructed"
-      vars:
-        __operation: "{{ operation_translate[__controller_source_item.state | default(platform_state) | default('present')] }}"
-
-    - name: Flag for errors (check mode only)
+    - name: Inventory Sources | Set batch size
       ansible.builtin.set_fact:
-        error_flag: true
-      when: ansible_check_mode and __inventory_source_job_async.failed is defined and __inventory_source_job_async.failed
+        __batch_size: "{{ controller_configuration_inventory_sources_async_concurrency | int }}"
 
-    - name: Managing Inventory Sources | Wait for finish the Inventory Sources management
-      when:
-        - not ansible_check_mode
-        - __inventory_source_job_async_results_item.ansible_job_id is defined
-      ansible.builtin.include_role:
-        name: infra.aap_configuration.collect_async_status
-      loop: "{{ __inventory_source_job_async.results }}"
+    - name: Inventory Sources | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_inventory_source_batch.yml
+      loop: "{{ range(0, (inventory_sources if inventory_sources is defined else controller_inventory_sources) | length, __batch_size | int) | list }}"
       loop_control:
-        loop_var: __inventory_source_job_async_results_item
-        label: "{{ __operation.verb }} Inventory Source {{ __inventory_source_job_async_results_item.__controller_source_item.name }} | Wait for finish the Inventory Source {{ __operation.action }}"
-      vars:
-        cas_secure_logging: "{{ controller_configuration_inventory_sources_secure_logging }}"
-        cas_async_delay: "{{ controller_configuration_inventory_sources_async_delay }}"
-        cas_async_retries: "{{ controller_configuration_inventory_sources_async_retries }}"
-        cas_job_async_results_item: "{{ __inventory_source_job_async_results_item }}"
-        cas_register_subvar: controller_inventory_sources
-        cas_error_list_var_name: "controller_inventory_sources_errors"
-        __operation: "{{ operation_translate[__inventory_source_job_async_results_item.__controller_source_item.state | default(platform_state) | default('present')] }}"
-        cas_object_label: "{{ __operation.verb }} Inventory Source {{ __inventory_source_job_async_results_item.__controller_source_item.name }} | Wait for finish the Inventory Source {{ __operation.action }}"
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ (((inventory_sources if inventory_sources is defined else controller_inventory_sources) | length - 1) / __batch_size | int) + 1 }}"
 
   always:
     - name: Cleanup async results files
@@ -87,7 +24,7 @@
       ansible.builtin.async_status:
         jid: "{{ __inventory_source_job_async_results_item.ansible_job_id }}"
         mode: cleanup
-      loop: "{{ __inventory_source_job_async.results }}"
+      loop: "{{ __inventory_sources_batch_async.results | default([]) }}"
       loop_control:
         loop_var: __inventory_source_job_async_results_item
         label: "Cleaning up job results file: {{ __inventory_source_job_async_results_item.results_file | default('Unknown') }}"

--- a/roles/controller_inventory_sources/tasks/process_inventory_source_batch.yml
+++ b/roles/controller_inventory_sources/tasks/process_inventory_source_batch.yml
@@ -1,0 +1,85 @@
+---
+- name: process_inventory_source_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ (inventory_sources if inventory_sources is defined else controller_inventory_sources)[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_inventory_source_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.controller.inventory_source:
+    name: "{{ __controller_source_item.name | mandatory }}"
+    new_name: "{{ __controller_source_item.new_name | default(omit, true) }}"
+    description: "{{ __controller_source_item.description | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    inventory: "{{ __controller_source_item.inventory.name | default(__controller_source_item.inventory) | mandatory }}"
+    organization: "{{ __controller_source_item.inventory.organization.name | default(__controller_source_item.organization | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true)) }}"
+    source: "{{ __controller_source_item.source | default(('scm' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    source_path: "{{ __controller_source_item.source_path | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    source_vars: "{{ __controller_source_item.source_vars | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_source_item.source_vars is defined and __controller_source_item.source_vars) else ({} if controller_configuration_inventory_sources_enforce_defaults else omit) }}"
+    enabled_var: "{{ __controller_source_item.enabled_var | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    enabled_value: "{{ __controller_source_item.enabled_value | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    host_filter: "{{ __controller_source_item.host_filter | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    limit: "{{ __controller_source_item.limit | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    credential: "{{ __controller_source_item.credential | default(omit, true) }}"
+    execution_environment: "{{ __controller_source_item.execution_environment | default(omit, true) }}"
+    overwrite: "{{ __controller_source_item.overwrite | default((false if controller_configuration_inventory_sources_enforce_defaults else omit)) }}"
+    overwrite_vars: "{{ __controller_source_item.overwrite_vars | default((false if controller_configuration_inventory_sources_enforce_defaults else omit)) }}"
+    custom_virtualenv: "{{ __controller_source_item.custom_virtualenv | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    timeout: "{{ __controller_source_item.timeout | default(0, true) if __controller_source_item.timeout is defined or controller_configuration_inventory_sources_enforce_defaults else omit }}"
+    verbosity: "{{ __controller_source_item.verbosity | default((1 if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    update_on_launch: "{{ __controller_source_item.update_on_launch | default((false if controller_configuration_inventory_sources_enforce_defaults else omit)) }}"
+    update_cache_timeout: "{{ __controller_source_item.update_cache_timeout | default(0, true) if __controller_source_item.update_cache_timeout is defined or controller_configuration_inventory_sources_enforce_defaults else omit }}"
+    source_project: "{{ __controller_source_item.source_project.name | default(__controller_source_item.source_project | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true)) }}"
+    scm_branch: "{{ __controller_source_item.scm_branch | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    state: "{{ __controller_source_item.state | default(platform_state | default('present')) }}"
+    notification_templates_started: "{{ __controller_source_item.notification_templates_started | default((__controller_source_item.related.notification_templates_started | map(attribute='name') | list if __controller_source_item.related.notification_templates_started is defined)) | default(([] if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    notification_templates_success: "{{ __controller_source_item.notification_templates_success | default((__controller_source_item.related.notification_templates_success | map(attribute='name') | list if __controller_source_item.related.notification_templates_success is defined)) | default(([] if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    notification_templates_error: "{{ __controller_source_item.notification_templates_error | default((__controller_source_item.related.notification_templates_error | map(attribute='name') | list if __controller_source_item.related.notification_templates_error is defined)) | default(([] if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __controller_source_item
+    label: "{{ __operation.verb }} an Inventory Source {{ __controller_source_item.name }}"
+    pause: "{{ controller_configuration_inventory_loop_delay }}"
+  async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+  poll: 0
+  register: __inventory_sources_batch_async
+  changed_when: (__inventory_sources_batch_async.changed if ansible_check_mode else false)
+  when: (__controller_source_item.source | default(('scm' if controller_configuration_inventory_sources_enforce_defaults else omit), true)) != "constructed"
+  vars:
+    __operation: "{{ operation_translate[__controller_source_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_inventory_source_batch | Flag for errors (check mode only)
+  ansible.builtin.set_fact:
+    error_flag: true
+  when: ansible_check_mode and __inventory_sources_batch_async.failed is defined and __inventory_sources_batch_async.failed
+
+- name: process_inventory_source_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __inventory_sources_batch_async.results }}"
+  loop_control:
+    loop_var: __inventory_source_job_async_results_item
+    label: "{{ __operation.verb }} Inventory Source {{ __inventory_source_job_async_results_item.__controller_source_item.name }} | Wait for finish the Inventory Source {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __inventory_source_job_async_results_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ controller_configuration_inventory_sources_secure_logging }}"
+    cas_async_delay: "{{ controller_configuration_inventory_sources_async_delay }}"
+    cas_async_retries: "{{ controller_configuration_inventory_sources_async_retries }}"
+    cas_job_async_results_item: "{{ __inventory_source_job_async_results_item }}"
+    cas_register_subvar: controller_inventory_sources
+    cas_error_list_var_name: "controller_inventory_sources_errors"
+    __operation: "{{ operation_translate[__inventory_source_job_async_results_item.__controller_source_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} Inventory Source {{ __inventory_source_job_async_results_item.__controller_source_item.name }} | Wait for finish the Inventory Source {{ __operation.action }}"
+
+- name: process_inventory_source_batch | Delay between batches
+  ansible.builtin.pause:
+    seconds: "{{ controller_configuration_inventory_sources_batch_delay }}"
+  when:
+    - not ansible_check_mode
+    - controller_configuration_inventory_sources_batch_delay | int > 0
+...

--- a/roles/controller_job_templates/defaults/main.yml
+++ b/roles/controller_job_templates/defaults/main.yml
@@ -5,6 +5,8 @@ controller_configuration_job_templates_secure_logging: "{{ aap_configuration_sec
 controller_configuration_job_templates_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 controller_configuration_job_templates_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 controller_configuration_job_templates_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+controller_configuration_job_templates_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
+controller_configuration_job_templates_batch_delay: "{{ aap_configuration_batch_delay | default(3) }}"
 aap_configuration_async_dir:
 controller_configuration_job_templates_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 aap_configuration_apply_object_roles: true

--- a/roles/controller_job_templates/tasks/main.yml
+++ b/roles/controller_job_templates/tasks/main.yml
@@ -4,7 +4,20 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ controller_configuration_job_templates_secure_logging }}"
   block:
-    - name: Managing Controller Job Templates
+    - name: Job Templates | Set batch size
+      ansible.builtin.set_fact:
+        __batch_size: "{{ controller_configuration_job_templates_async_concurrency | int }}"
+
+    - name: Job Templates | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_jt_batch.yml
+      loop: "{{ range(0, (job_templates if job_templates is defined else controller_templates) | length, __batch_size | int) | list }}"
+      loop_control:
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ (((job_templates if job_templates is defined else controller_templates) | length - 1) / __batch_size | int) + 1 }}"
+
+    - name: Managing Controller Job Templates (legacy)
+      when: false
       ansible.controller.job_template:
         name: "{{ __controller_template_item.name | mandatory }}"
         new_name: "{{ __controller_template_item.new_name | default(omit, true) }}"

--- a/roles/controller_job_templates/tasks/process_jt_batch.yml
+++ b/roles/controller_job_templates/tasks/process_jt_batch.yml
@@ -1,0 +1,112 @@
+---
+- name: process_jt_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ (job_templates if job_templates is defined else controller_templates)[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_jt_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.controller.job_template:
+    name: "{{ __controller_template_item.name | mandatory }}"
+    new_name: "{{ __controller_template_item.new_name | default(omit, true) }}"
+    copy_from: "{{ __controller_template_item.copy_from | default(omit, true) }}"
+    description: "{{ __controller_template_item.description | default(('' if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    execution_environment: "{{ __controller_template_item.execution_environment.name | default(__controller_template_item.execution_environment | default(omit, true)) }}"
+    custom_virtualenv: "{{ __controller_template_item.custom_virtualenv | default(('' if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    job_type: "{{ __controller_template_item.job_type | default('run') }}"
+    inventory: "{{ __controller_template_item.inventory.name | default(__controller_template_item.inventory | default(omit, true)) }}"
+    organization: "{{ __controller_template_item.organization.name | default(__controller_template_item.organization | default(('' if controller_configuration_job_templates_enforce_defaults else omit), true)) }}"
+    project: "{{ __controller_template_item.project.name | default(__controller_template_item.project | default(omit, true)) }}"
+    playbook: "{{ __controller_template_item.playbook | default(omit, true) }}"
+    credentials: "{{ __controller_template_item.credentials | default(__controller_template_item.related.credentials | default([]) | map(attribute='name') | list) | default(omit, true) }}"
+    forks: "{{ __controller_template_item.forks | default(0, true) if __controller_template_item.forks is defined or controller_configuration_job_templates_enforce_defaults else omit }}"
+    limit: "{{ __controller_template_item.limit | default(('' if controller_configuration_job_templates_enforce_defaults else omit), false) }}"
+    verbosity: "{{ __controller_template_item.verbosity | default(0, true) if __controller_template_item.verbosity is defined or controller_configuration_job_templates_enforce_defaults else omit }}"
+    extra_vars: "{{ __controller_template_item.extra_vars | default(({} if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    job_tags: "{{ __controller_template_item.job_tags | default(('' if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    force_handlers: "{{ __controller_template_item.force_handlers | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    skip_tags: "{{ __controller_template_item.skip_tags | default(('' if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    start_at_task: "{{ __controller_template_item.start_at_task | default(('' if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    diff_mode: "{{ __controller_template_item.diff_mode | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    use_fact_cache: "{{ __controller_template_item.use_fact_cache | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    host_config_key: "{{ __controller_template_item.host_config_key | default(('' if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    ask_scm_branch_on_launch: "{{ __controller_template_item.ask_scm_branch_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_diff_mode_on_launch: "{{ __controller_template_item.ask_diff_mode_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_variables_on_launch: "{{ __controller_template_item.ask_variables_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_limit_on_launch: "{{ __controller_template_item.ask_limit_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_tags_on_launch: "{{ __controller_template_item.ask_tags | default(__controller_template_item.ask_tags_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit))) }}"
+    ask_skip_tags_on_launch: "{{ __controller_template_item.ask_skip_tags | default(__controller_template_item.ask_skip_tags_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit))) }}"
+    ask_job_type_on_launch: "{{ __controller_template_item.ask_job_type_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_verbosity_on_launch: "{{ __controller_template_item.ask_verbosity_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_inventory_on_launch: "{{ __controller_template_item.ask_inventory_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_credential_on_launch: "{{ __controller_template_item.ask_credential_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_execution_environment_on_launch: "{{ __controller_template_item.ask_execution_environment_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_forks_on_launch: "{{ __controller_template_item.ask_forks_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_instance_groups_on_launch: "{{ __controller_template_item.ask_instance_groups_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_job_slice_count_on_launch: "{{ __controller_template_item.ask_job_slice_count_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_labels_on_launch: "{{ __controller_template_item.ask_labels_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    ask_timeout_on_launch: "{{ __controller_template_item.ask_timeout_on_launch | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    prevent_instance_group_fallback: "{{ __controller_template_item.prevent_instance_group_fallback | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    survey_enabled: "{{ __controller_template_item.survey_enabled | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    survey_spec: "{{ __controller_template_item.related.survey_spec | default(__controller_template_item.survey_spec | default(__controller_template_item.survey | default(({} if controller_configuration_job_templates_enforce_defaults else omit), true))) }}"
+    become_enabled: "{{ __controller_template_item.become_enabled | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    allow_simultaneous: "{{ __controller_template_item.allow_simultaneous | default((false if controller_configuration_job_templates_enforce_defaults else omit)) }}"
+    timeout: "{{ __controller_template_item.timeout | default(0, true) if __controller_template_item.timeout is defined or controller_configuration_job_templates_enforce_defaults else omit }}"
+    instance_groups: "{{ __controller_template_item.instance_groups | default(([] if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    job_slice_count: "{{ __controller_template_item.job_slice_count | default((1 if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    webhook_service: "{{ __controller_template_item.webhook_service | default(('' if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    webhook_credential: "{{ __controller_template_item.webhook_credential | default(omit, true) }}"
+    scm_branch: "{{ __controller_template_item.scm_branch | default(('' if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    labels: "{{ __controller_template_item.labels | default((__controller_template_item.related.labels | map(attribute='name') | list if __controller_template_item.related.labels is defined)) | default(([] if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    state: "{{ __controller_template_item.state | default(platform_state | default('present')) }}"
+    notification_templates_started: "{{ __controller_template_item.notification_templates_started | default((__controller_template_item.related.notification_templates_started | map(attribute='name') | list if __controller_template_item.related.notification_templates_started is defined)) | default(([] if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    notification_templates_success: "{{ __controller_template_item.notification_templates_success | default((__controller_template_item.related.notification_templates_success | map(attribute='name') | list if __controller_template_item.related.notification_templates_success is defined)) | default(([] if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    notification_templates_error: "{{ __controller_template_item.notification_templates_error | default((__controller_template_item.related.notification_templates_error | map(attribute='name') | list if __controller_template_item.related.notification_templates_error is defined)) | default(([] if controller_configuration_job_templates_enforce_defaults else omit), true) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __controller_template_item
+    label: "{{ __operation.verb }} Controller Job Template {{ __controller_template_item.name }}"
+    pause: "{{ controller_configuration_job_templates_loop_delay }}"
+  async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+  poll: 0
+  register: __job_templates_batch_async
+  changed_when: (__job_templates_batch_async.changed if ansible_check_mode else false)
+  vars:
+    __operation: "{{ operation_translate[__controller_template_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_jt_batch | Flag for errors (check mode only)
+  ansible.builtin.set_fact:
+    error_flag: true
+  when: ansible_check_mode and __job_templates_batch_async.failed is defined and __job_templates_batch_async.failed
+
+- name: process_jt_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __job_templates_batch_async.results }}"
+  loop_control:
+    loop_var: __job_templates_job_async_results_item
+    label: "{{ __operation.verb }} Controller Job Template {{ __job_templates_job_async_results_item.__controller_template_item.name }} | Wait for finish the job template {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __job_templates_job_async_results_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ controller_configuration_job_templates_secure_logging }}"
+    cas_async_delay: "{{ controller_configuration_job_templates_async_delay }}"
+    cas_async_retries: "{{ controller_configuration_job_templates_async_retries }}"
+    cas_job_async_results_item: "{{ __job_templates_job_async_results_item }}"
+    cas_register_subvar: controller_templates
+    cas_error_list_var_name: "controller_job_templates_errors"
+    __operation: "{{ operation_translate[__job_templates_job_async_results_item.__controller_template_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} Controller Job Template {{ __job_templates_job_async_results_item.__controller_template_item.name }} | Wait for finish the job template {{ __operation.action }}"
+
+- name: process_jt_batch | Delay between batches
+  ansible.builtin.pause:
+    seconds: "{{ controller_configuration_job_templates_batch_delay }}"
+  when:
+    - not ansible_check_mode
+    - controller_configuration_job_templates_batch_delay | int > 0
+...

--- a/roles/controller_labels/defaults/main.yml
+++ b/roles/controller_labels/defaults/main.yml
@@ -3,6 +3,8 @@ controller_labels: []
 controller_configuration_labels_secure_logging: "{{ aap_configuration_secure_logging | default('false') }}"
 controller_configuration_labels_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 controller_configuration_labels_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
+controller_configuration_labels_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
+controller_configuration_labels_batch_delay: "{{ aap_configuration_batch_delay | default(3) }}"
 controller_configuration_labels_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 ...

--- a/roles/controller_labels/tasks/main.yml
+++ b/roles/controller_labels/tasks/main.yml
@@ -4,56 +4,17 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ controller_configuration_labels_secure_logging }}"
   block:
-    - name: Managing Controller Labels
-      ansible.controller.label:
-        name: "{{ __controller_label_item.name | mandatory }}"
-        new_name: "{{ __controller_label_item.new_name | default(omit, true) }}"
-        organization: "{{ __controller_label_item.organization | mandatory }}"
-        state: "{{ __controller_label_item.state | default(platform_state | default('present')) }}"
-
-        # Role Standard Options
-        controller_host: "{{ aap_hostname | default(omit, true) }}"
-        controller_username: "{{ aap_username | default(omit, true) }}"
-        controller_password: "{{ aap_password | default(omit, true) }}"
-        controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
-        request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
-        validate_certs: "{{ aap_validate_certs | default(omit) }}"
-      loop: "{{ controller_labels }}"
-      loop_control:
-        loop_var: __controller_label_item
-        label: "{{ __operation.verb }} the label {{ __controller_label_item.name }} to Controller"
-        pause: "{{ controller_configuration_labels_loop_delay }}"
-      async: "{{ ansible_check_mode | ternary(0, 1000) }}"
-      poll: 0
-      register: __controller_label_job_async
-      changed_when: (__controller_label_job_async.changed if ansible_check_mode else false)
-      vars:
-        __operation: "{{ operation_translate[__controller_label_item.state | default(platform_state) | default('present')] }}"
-
-    - name: Flag for errors (check mode only)
+    - name: Labels | Set batch size
       ansible.builtin.set_fact:
-        error_flag: true
-      when: ansible_check_mode and __controller_label_job_async.failed is defined and __controller_label_job_async.failed
+        __batch_size: "{{ controller_configuration_labels_async_concurrency | int }}"
 
-    - name: Managing Labels | Wait for finish the Labels management
-      when:
-        - not ansible_check_mode
-        - __controller_label_job_async_results_item.ansible_job_id is defined
-      ansible.builtin.include_role:
-        name: infra.aap_configuration.collect_async_status
-      loop: "{{ __controller_label_job_async.results }}"
+    - name: Labels | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_label_batch.yml
+      loop: "{{ range(0, controller_labels | length, __batch_size | int) | list }}"
       loop_control:
-        loop_var: __controller_label_job_async_results_item
-        label: "{{ __operation.verb }} Label {{ __controller_label_job_async_results_item.__controller_label_item.name }} | Wait for finish the Label {{ __operation.action }}"
-      vars:
-        cas_secure_logging: "{{ controller_configuration_labels_secure_logging }}"
-        cas_async_delay: "{{ controller_configuration_labels_async_delay }}"
-        cas_async_retries: "{{ controller_configuration_labels_async_retries }}"
-        cas_job_async_results_item: "{{ __controller_label_job_async_results_item }}"
-        cas_register_subvar: controller_labels
-        cas_error_list_var_name: "controller_labels_errors"
-        __operation: "{{ operation_translate[__controller_label_job_async_results_item.__controller_label_item.state | default(platform_state) | default('present')] }}"
-        cas_object_label: "{{ __operation.verb }} Label {{ __controller_label_job_async_results_item.__controller_label_item.name }} | Wait for finish the Label {{ __operation.action }}"
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ ((controller_labels | length - 1) / __batch_size | int) + 1 }}"
 
   always:
     - name: Cleanup async results files
@@ -63,7 +24,7 @@
       ansible.builtin.async_status:
         jid: "{{ __controller_label_job_async_results_item.ansible_job_id }}"
         mode: cleanup
-      loop: "{{ __controller_label_job_async.results }}"
+      loop: "{{ __labels_batch_async.results | default([]) }}"
       loop_control:
         loop_var: __controller_label_job_async_results_item
         label: "Cleaning up job results file: {{ __controller_label_job_async_results_item.results_file | default('Unknown') }}"

--- a/roles/controller_labels/tasks/process_label_batch.yml
+++ b/roles/controller_labels/tasks/process_label_batch.yml
@@ -1,0 +1,61 @@
+---
+- name: process_label_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ controller_labels[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_label_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.controller.label:
+    name: "{{ __controller_label_item.name | mandatory }}"
+    new_name: "{{ __controller_label_item.new_name | default(omit, true) }}"
+    organization: "{{ __controller_label_item.organization | mandatory }}"
+    state: "{{ __controller_label_item.state | default(platform_state | default('present')) }}"
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __controller_label_item
+    label: "{{ __operation.verb }} the label {{ __controller_label_item.name }} to Controller"
+    pause: "{{ controller_configuration_labels_loop_delay }}"
+  async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+  poll: 0
+  register: __labels_batch_async
+  changed_when: (__labels_batch_async.changed if ansible_check_mode else false)
+  vars:
+    __operation: "{{ operation_translate[__controller_label_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_label_batch | Flag for errors (check mode only)
+  ansible.builtin.set_fact:
+    error_flag: true
+  when: ansible_check_mode and __labels_batch_async.failed is defined and __labels_batch_async.failed
+
+- name: process_label_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __labels_batch_async.results }}"
+  loop_control:
+    loop_var: __controller_label_job_async_results_item
+    label: "{{ __operation.verb }} Label {{ __controller_label_job_async_results_item.__controller_label_item.name }} | Wait for finish the Label {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __controller_label_job_async_results_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ controller_configuration_labels_secure_logging }}"
+    cas_async_delay: "{{ controller_configuration_labels_async_delay }}"
+    cas_async_retries: "{{ controller_configuration_labels_async_retries }}"
+    cas_job_async_results_item: "{{ __controller_label_job_async_results_item }}"
+    cas_register_subvar: controller_labels
+    cas_error_list_var_name: "controller_labels_errors"
+    __operation: "{{ operation_translate[__controller_label_job_async_results_item.__controller_label_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} Label {{ __controller_label_job_async_results_item.__controller_label_item.name }} | Wait for finish the Label {{ __operation.action }}"
+
+- name: process_label_batch | Delay between batches
+  ansible.builtin.pause:
+    seconds: "{{ controller_configuration_labels_batch_delay }}"
+  when:
+    - not ansible_check_mode
+    - controller_configuration_labels_batch_delay | int > 0
+...

--- a/roles/controller_notification_templates/defaults/main.yml
+++ b/roles/controller_notification_templates/defaults/main.yml
@@ -5,6 +5,8 @@ controller_configuration_notifications_secure_logging: "{{ aap_configuration_sec
 controller_configuration_notifications_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 controller_configuration_notifications_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 controller_configuration_notifications_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+controller_configuration_notifications_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
+controller_configuration_notifications_batch_delay: "{{ aap_configuration_batch_delay | default(3) }}"
 aap_configuration_async_dir:
 controller_configuration_notifications_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 ...

--- a/roles/controller_notification_templates/tasks/main.yml
+++ b/roles/controller_notification_templates/tasks/main.yml
@@ -4,62 +4,17 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ controller_configuration_notifications_secure_logging }}"
   block:
-    - name: Managing Controller Notifications
-      ansible.controller.notification_template:
-        name: "{{ __controller_notification_item.name | mandatory }}"
-        new_name: "{{ __controller_notification_item.new_name | default(omit, true) }}"
-        copy_from: "{{ __controller_notification_item.copy_from | default(omit, true) }}"
-        description: "{{ __controller_notification_item.description | default(('' if controller_configuration_notifications_enforce_defaults else omit), true) }}"
-        organization: "{{ __controller_notification_item.organization.name | default(__controller_notification_item.organization) | default(omit, true) }}"
-        notification_type: "{{ __controller_notification_item.notification_type | default(omit, true) }}"
-        notification_configuration: "{{ __controller_notification_item.notification_configuration | default(({} if controller_configuration_notifications_enforce_defaults else omit), true) }}"
-        messages: "{{ __controller_notification_item.messages | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_notification_item.messages is defined and __controller_notification_item.messages) else ({} if controller_configuration_notifications_enforce_defaults else omit) }}"
-        state: "{{ __controller_notification_item.state | default(platform_state | default('present')) }}"
-
-        # Role Standard Options
-        controller_host: "{{ aap_hostname | default(omit, true) }}"
-        controller_username: "{{ aap_username | default(omit, true) }}"
-        controller_password: "{{ aap_password | default(omit, true) }}"
-        controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
-        request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
-        validate_certs: "{{ aap_validate_certs | default(omit) }}"
-      loop: "{{ notification_templates if notification_templates is defined else controller_notifications }}"
-      loop_control:
-        loop_var: __controller_notification_item
-        label: "{{ __operation.verb }} Controller notification {{ __controller_notification_item.name }}"
-        pause: "{{ controller_configuration_notifications_loop_delay }}"
-      async: "{{ ansible_check_mode | ternary(0, 1000) }}"
-      poll: 0
-      register: __controller_notification_job_async
-      changed_when: (__controller_notification_job_async.changed if ansible_check_mode else false)
-      vars:
-        __operation: "{{ operation_translate[__controller_notification_item.state | default(platform_state) | default('present')] }}"
-
-    - name: Flag for errors (check mode only)
+    - name: Notification Templates | Set batch size
       ansible.builtin.set_fact:
-        error_flag: true
-      when: ansible_check_mode and __controller_notification_job_async.failed is defined and __controller_notification_job_async.failed
+        __batch_size: "{{ controller_configuration_notifications_async_concurrency | int }}"
 
-    - name: Managing Notifications | Wait for finish the Notifications management
-      when:
-        - not ansible_check_mode
-        - __controller_notification_job_async_results_item.ansible_job_id is defined
-      ansible.builtin.include_role:
-        name: infra.aap_configuration.collect_async_status
-      loop: "{{ __controller_notification_job_async.results }}"
+    - name: Notification Templates | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_notification_batch.yml
+      loop: "{{ range(0, (notification_templates if notification_templates is defined else controller_notifications) | length, __batch_size | int) | list }}"
       loop_control:
-        loop_var: __controller_notification_job_async_results_item
-        label: "{{ __operation.verb }} notification {{ __controller_notification_job_async_results_item.__controller_notification_item.name }} | Wait for finish the notifications
-          {{ __operation.action }}"
-      vars:
-        cas_secure_logging: "{{ controller_configuration_notifications_secure_logging }}"
-        cas_async_delay: "{{ controller_configuration_notifications_async_delay }}"
-        cas_async_retries: "{{ controller_configuration_notifications_async_retries }}"
-        cas_job_async_results_item: "{{ __controller_notification_job_async_results_item }}"
-        cas_register_subvar: controller_notification_templates
-        cas_error_list_var_name: "controller_notification_templates_errors"
-        __operation: "{{ operation_translate[__controller_notification_job_async_results_item.__controller_notification_item.state | default(platform_state) | default('present')] }}"
-        cas_object_label: "{{ __operation.verb }} notification {{ __controller_notification_job_async_results_item.__controller_notification_item.name }} | Wait for finish the notifications {{ __operation.action }}"
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ (((notification_templates if notification_templates is defined else controller_notifications) | length - 1) / __batch_size | int) + 1 }}"
 
   always:
     - name: Cleanup async results files
@@ -69,7 +24,7 @@
       ansible.builtin.async_status:
         jid: "{{ __controller_notification_job_async_results_item.ansible_job_id }}"
         mode: cleanup
-      loop: "{{ __controller_notification_job_async.results }}"
+      loop: "{{ __notification_batch_async.results | default([]) }}"
       loop_control:
         loop_var: __controller_notification_job_async_results_item
         label: "Cleaning up job results file: {{ __controller_notification_job_async_results_item.results_file | default('Unknown') }}"

--- a/roles/controller_notification_templates/tasks/process_notification_batch.yml
+++ b/roles/controller_notification_templates/tasks/process_notification_batch.yml
@@ -1,0 +1,66 @@
+---
+- name: process_notification_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ (notification_templates if notification_templates is defined else controller_notifications)[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_notification_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.controller.notification_template:
+    name: "{{ __controller_notification_item.name | mandatory }}"
+    new_name: "{{ __controller_notification_item.new_name | default(omit, true) }}"
+    copy_from: "{{ __controller_notification_item.copy_from | default(omit, true) }}"
+    description: "{{ __controller_notification_item.description | default(('' if controller_configuration_notifications_enforce_defaults else omit), true) }}"
+    organization: "{{ __controller_notification_item.organization.name | default(__controller_notification_item.organization) | default(omit, true) }}"
+    notification_type: "{{ __controller_notification_item.notification_type | default(omit, true) }}"
+    notification_configuration: "{{ __controller_notification_item.notification_configuration | default(({} if controller_configuration_notifications_enforce_defaults else omit), true) }}"
+    messages: "{{ __controller_notification_item.messages | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_notification_item.messages is defined and __controller_notification_item.messages) else ({} if controller_configuration_notifications_enforce_defaults else omit) }}"
+    state: "{{ __controller_notification_item.state | default(platform_state | default('present')) }}"
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __controller_notification_item
+    label: "{{ __operation.verb }} Controller notification {{ __controller_notification_item.name }}"
+    pause: "{{ controller_configuration_notifications_loop_delay }}"
+  async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+  poll: 0
+  register: __notification_batch_async
+  changed_when: (__notification_batch_async.changed if ansible_check_mode else false)
+  vars:
+    __operation: "{{ operation_translate[__controller_notification_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_notification_batch | Flag for errors (check mode only)
+  ansible.builtin.set_fact:
+    error_flag: true
+  when: ansible_check_mode and __notification_batch_async.failed is defined and __notification_batch_async.failed
+
+- name: process_notification_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __notification_batch_async.results }}"
+  loop_control:
+    loop_var: __controller_notification_job_async_results_item
+    label: "{{ __operation.verb }} notification {{ __controller_notification_job_async_results_item.__controller_notification_item.name }} | Wait for finish the notifications {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __controller_notification_job_async_results_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ controller_configuration_notifications_secure_logging }}"
+    cas_async_delay: "{{ controller_configuration_notifications_async_delay }}"
+    cas_async_retries: "{{ controller_configuration_notifications_async_retries }}"
+    cas_job_async_results_item: "{{ __controller_notification_job_async_results_item }}"
+    cas_register_subvar: controller_notification_templates
+    cas_error_list_var_name: "controller_notification_templates_errors"
+    __operation: "{{ operation_translate[__controller_notification_job_async_results_item.__controller_notification_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} notification {{ __controller_notification_job_async_results_item.__controller_notification_item.name }} | Wait for finish the notifications {{ __operation.action }}"
+
+- name: process_notification_batch | Delay between batches
+  ansible.builtin.pause:
+    seconds: "{{ controller_configuration_notifications_batch_delay }}"
+  when:
+    - not ansible_check_mode
+    - controller_configuration_notifications_batch_delay | int > 0
+...

--- a/roles/controller_projects/defaults/main.yml
+++ b/roles/controller_projects/defaults/main.yml
@@ -2,9 +2,11 @@
 # list of dict describing Controller projects
 controller_projects: []
 controller_configuration_projects_secure_logging: "{{ aap_configuration_secure_logging | default('false') }}"
-controller_configuration_projects_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
-controller_configuration_projects_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
+controller_configuration_projects_async_retries: "{{ aap_configuration_async_retries | default(500) }}"
+controller_configuration_projects_async_delay: "{{ aap_configuration_async_delay | default(2) }}"
 controller_configuration_projects_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+controller_configuration_projects_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
+controller_configuration_projects_batch_delay: "{{ aap_configuration_batch_delay | default(3) }}"
 aap_configuration_async_dir:
 controller_configuration_projects_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 aap_configuration_apply_object_roles: true

--- a/roles/controller_projects/tasks/main.yml
+++ b/roles/controller_projects/tasks/main.yml
@@ -4,93 +4,30 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ controller_configuration_projects_secure_logging }}"
   block:
-    - name: Managing Projects
-      ansible.controller.project:
-        name: "{{ __controller_project_item.name | mandatory }}"
-        new_name: "{{ __controller_project_item.new_name | default(omit, true) }}"
-        copy_from: "{{ __controller_project_item.copy_from | default(omit, true) }}"
-        description: "{{ __controller_project_item.description | default(('' if controller_configuration_projects_enforce_defaults else omit), true) }}"
-        scm_type: "{{ __controller_project_item.scm_type | default('manual') }}"
-        scm_url: "{{ __controller_project_item.scm_url | default(('' if controller_configuration_projects_enforce_defaults else omit), true) }}"
-        default_environment: "{{ __controller_project_item.default_environment | default(omit, true) }}"
-        local_path: "{{ __controller_project_item.local_path | default(('' if controller_configuration_projects_enforce_defaults else omit), true) }}"
-        scm_branch: "{{ __controller_project_item.scm_branch | default(('' if controller_configuration_projects_enforce_defaults else omit)) }}"
-        scm_refspec: "{{ __controller_project_item.scm_refspec | default(('' if controller_configuration_projects_enforce_defaults else omit), true) }}"
-        credential: "{{ __controller_project_item.credential.name | default(__controller_project_item.credential | default(__controller_project_item.scm_credential | default(omit, true))) }}"
-        signature_validation_credential: "{{ __controller_project_item.signature_validation_credential.name | default(__controller_project_item.signature_validation_credential | default(omit, true)) }}"
-        scm_clean: "{{ __controller_project_item.scm_clean | default((false if controller_configuration_projects_enforce_defaults else omit)) }}"
-        scm_delete_on_update: "{{ __controller_project_item.scm_delete_on_update | default((false if controller_configuration_projects_enforce_defaults else omit)) }}"
-        scm_track_submodules: "{{ __controller_project_item.scm_track_submodules | default((false if controller_configuration_projects_enforce_defaults else omit)) }}"
-        scm_update_on_launch: "{{ __controller_project_item.scm_update_on_launch | default((false if controller_configuration_projects_enforce_defaults else omit)) }}"
-        scm_update_cache_timeout: "{{ __controller_project_item.scm_update_cache_timeout | default(0, true) if __controller_project_item.scm_update_cache_timeout is defined or controller_configuration_projects_enforce_defaults else omit }}"
-        allow_override: "{{ __controller_project_item.allow_override | default((false if controller_configuration_projects_enforce_defaults else omit)) }}"
-        timeout: "{{ __controller_project_item.job_timeout | default(__controller_project_item.timeout | default(0, true) if __controller_project_item.timeout is defined or __controller_project_item.job_timeout is defined or controller_configuration_projects_enforce_defaults else omit) }}"
-        custom_virtualenv: "{{ __controller_project_item.custom_virtualenv | default(('' if controller_configuration_projects_enforce_defaults else omit), true) }}"
-        organization: "{{ __controller_project_item.organization.name | default(__controller_project_item.organization | default(('' if controller_configuration_projects_enforce_defaults else omit))) }}"
-        state: "{{ __controller_project_item.state | default(platform_state | default('present')) }}"
-        wait: "{{ __controller_project_item.wait | default((true if controller_configuration_projects_enforce_defaults else omit)) }}"
-        update_project: "{{ __controller_project_item.update_project | default((false if controller_configuration_projects_enforce_defaults else omit)) }}"
-        interval: "{{ __controller_project_item.interval | default(controller_configuration_projects_async_delay) }}"
-        notification_templates_started: "{{ __controller_project_item.notification_templates_started | default((__controller_project_item.related.notification_templates_started | map(attribute='name') | list if __controller_project_item.related.notification_templates_started is defined)) | default(([] if controller_configuration_projects_enforce_defaults else omit), true) }}"
-        notification_templates_success: "{{ __controller_project_item.notification_templates_success | default((__controller_project_item.related.notification_templates_success | map(attribute='name') | list if __controller_project_item.related.notification_templates_success is defined)) | default(([] if controller_configuration_projects_enforce_defaults else omit), true) }}"
-        notification_templates_error: "{{ __controller_project_item.notification_templates_error | default((__controller_project_item.related.notification_templates_error | map(attribute='name') | list if __controller_project_item.related.notification_templates_error is defined)) | default(([] if controller_configuration_projects_enforce_defaults else omit), true) }}"
-
-        # Role Standard Options
-        controller_username: "{{ aap_username | default(omit, true) }}"
-        controller_password: "{{ aap_password | default(omit, true) }}"
-        controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
-        request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
-        controller_host: "{{ aap_hostname | default(omit, true) }}"
-        validate_certs: "{{ aap_validate_certs | default(omit) }}"
-      loop: "{{ projects if projects is defined else controller_projects }}"
-      loop_control:
-        loop_var: __controller_project_item
-        label: "{{ __operation.verb }} Project {{ __controller_project_item.name }}"
-        pause: "{{ controller_configuration_projects_loop_delay }}"
-      async: "{{ ansible_check_mode | ternary(0, 1000) }}"
-      poll: 0
-      register: __projects_job_async
-      changed_when: (__projects_job_async.changed if ansible_check_mode else false)
-      vars:
-        __operation: "{{ operation_translate[__controller_project_item.state | default(platform_state) | default('present')] }}"
-
-    - name: Flag for errors (check mode only)
+    - name: Projects | Set batch size
       ansible.builtin.set_fact:
-        error_flag: true
-      when: ansible_check_mode and __projects_job_async.failed is defined and __projects_job_async.failed
+        __batch_size: "{{ controller_configuration_projects_async_concurrency | int }}"
 
-    - name: Managing Projects | Wait for finish the projects management
-      when:
-        - not ansible_check_mode
-        - __projects_job_async_results_item.ansible_job_id is defined
-      ansible.builtin.include_role:
-        name: infra.aap_configuration.collect_async_status
-      loop: "{{ __projects_job_async.results }}"
+    - name: Projects | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_project_batch.yml
+      loop: "{{ range(0, (projects if projects is defined else controller_projects) | length, __batch_size | int) | list }}"
       loop_control:
-        loop_var: __projects_job_async_results_item
-        label: "{{ __operation.verb }} Project {{ __projects_job_async_results_item.__controller_project_item.name }} | Wait for finish the project {{ __operation.action }}"
-      vars:
-        cas_secure_logging: "{{ controller_configuration_projects_secure_logging }}"
-        cas_async_delay: "{{ controller_configuration_projects_async_delay }}"
-        cas_async_retries: "{{ controller_configuration_projects_async_retries }}"
-        cas_job_async_results_item: "{{ __projects_job_async_results_item }}"
-        cas_register_subvar: controller_projects
-        cas_error_list_var_name: "controller_projects_errors"
-        __operation: "{{ operation_translate[__projects_job_async_results_item.__controller_project_item.state | default(platform_state) | default('present')] }}"
-        cas_object_label: "{{ __operation.verb }} Project {{ __projects_job_async_results_item.__controller_project_item.name }} | Wait for finish the project {{ __operation.action }}"
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ (((projects if projects is defined else controller_projects) | length - 1) / __batch_size | int) + 1 }}"
 
   always:
     - name: Cleanup async results files
       when:
         - not ansible_check_mode
-        - __projects_job_async_results_item.ansible_job_id is defined
+        - __project_job_async_results_item.ansible_job_id is defined
       ansible.builtin.async_status:
-        jid: "{{ __projects_job_async_results_item.ansible_job_id }}"
+        jid: "{{ __project_job_async_results_item.ansible_job_id }}"
         mode: cleanup
-      loop: "{{ __projects_job_async.results }}"
+      loop: "{{ __projects_batch_async.results | default([]) }}"
       loop_control:
-        loop_var: __projects_job_async_results_item
-        label: "Cleaning up job results file: {{ __projects_job_async_results_item.results_file | default('Unknown') }}"
+        loop_var: __project_job_async_results_item
+        label: "Cleaning up job results file: {{ __project_job_async_results_item.results_file | default('Unknown') }}"
 
 - name: Add roles to projects
   ansible.builtin.include_role:

--- a/roles/controller_projects/tasks/process_project_batch.yml
+++ b/roles/controller_projects/tasks/process_project_batch.yml
@@ -1,0 +1,85 @@
+---
+- name: process_project_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ (projects if projects is defined else controller_projects)[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_project_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.controller.project:
+    name: "{{ __controller_project_item.name | mandatory }}"
+    new_name: "{{ __controller_project_item.new_name | default(omit, true) }}"
+    copy_from: "{{ __controller_project_item.copy_from | default(omit, true) }}"
+    description: "{{ __controller_project_item.description | default(('' if controller_configuration_projects_enforce_defaults else omit), true) }}"
+    scm_type: "{{ __controller_project_item.scm_type | default('manual') }}"
+    scm_url: "{{ __controller_project_item.scm_url | default(('' if controller_configuration_projects_enforce_defaults else omit), true) }}"
+    default_environment: "{{ __controller_project_item.default_environment | default(omit, true) }}"
+    local_path: "{{ __controller_project_item.local_path | default(('' if controller_configuration_projects_enforce_defaults else omit), true) }}"
+    scm_branch: "{{ __controller_project_item.scm_branch | default(('' if controller_configuration_projects_enforce_defaults else omit)) }}"
+    scm_refspec: "{{ __controller_project_item.scm_refspec | default(('' if controller_configuration_projects_enforce_defaults else omit), true) }}"
+    credential: "{{ __controller_project_item.credential.name | default(__controller_project_item.credential | default(__controller_project_item.scm_credential | default(omit, true))) }}"
+    signature_validation_credential: "{{ __controller_project_item.signature_validation_credential.name | default(__controller_project_item.signature_validation_credential | default(omit, true)) }}"
+    scm_clean: "{{ __controller_project_item.scm_clean | default((false if controller_configuration_projects_enforce_defaults else omit)) }}"
+    scm_delete_on_update: "{{ __controller_project_item.scm_delete_on_update | default((false if controller_configuration_projects_enforce_defaults else omit)) }}"
+    scm_track_submodules: "{{ __controller_project_item.scm_track_submodules | default((false if controller_configuration_projects_enforce_defaults else omit)) }}"
+    scm_update_on_launch: "{{ __controller_project_item.scm_update_on_launch | default((false if controller_configuration_projects_enforce_defaults else omit)) }}"
+    scm_update_cache_timeout: "{{ __controller_project_item.scm_update_cache_timeout | default(0, true) if __controller_project_item.scm_update_cache_timeout is defined or controller_configuration_projects_enforce_defaults else omit }}"
+    allow_override: "{{ __controller_project_item.allow_override | default((false if controller_configuration_projects_enforce_defaults else omit)) }}"
+    timeout: "{{ __controller_project_item.job_timeout | default(__controller_project_item.timeout | default(0, true) if __controller_project_item.timeout is defined or __controller_project_item.job_timeout is defined or controller_configuration_projects_enforce_defaults else omit) }}"
+    custom_virtualenv: "{{ __controller_project_item.custom_virtualenv | default(('' if controller_configuration_projects_enforce_defaults else omit), true) }}"
+    organization: "{{ __controller_project_item.organization.name | default(__controller_project_item.organization | default(('' if controller_configuration_projects_enforce_defaults else omit))) }}"
+    state: "{{ __controller_project_item.state | default(platform_state | default('present')) }}"
+    wait: "{{ __controller_project_item.wait | default((true if controller_configuration_projects_enforce_defaults else omit)) }}"
+    update_project: "{{ __controller_project_item.update_project | default((false if controller_configuration_projects_enforce_defaults else omit)) }}"
+    interval: "{{ __controller_project_item.interval | default(controller_configuration_projects_async_delay) }}"
+    notification_templates_started: "{{ __controller_project_item.notification_templates_started | default((__controller_project_item.related.notification_templates_started | map(attribute='name') | list if __controller_project_item.related.notification_templates_started is defined)) | default(([] if controller_configuration_projects_enforce_defaults else omit), true) }}"
+    notification_templates_success: "{{ __controller_project_item.notification_templates_success | default((__controller_project_item.related.notification_templates_success | map(attribute='name') | list if __controller_project_item.related.notification_templates_success is defined)) | default(([] if controller_configuration_projects_enforce_defaults else omit), true) }}"
+    notification_templates_error: "{{ __controller_project_item.notification_templates_error | default((__controller_project_item.related.notification_templates_error | map(attribute='name') | list if __controller_project_item.related.notification_templates_error is defined)) | default(([] if controller_configuration_projects_enforce_defaults else omit), true) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __controller_project_item
+    label: "{{ __operation.verb }} Project {{ __controller_project_item.name }}"
+    pause: "{{ controller_configuration_projects_loop_delay }}"
+  async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+  poll: 0
+  register: __projects_batch_async
+  changed_when: (__projects_batch_async.changed if ansible_check_mode else false)
+  vars:
+    __operation: "{{ operation_translate[__controller_project_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_project_batch | Flag for errors (check mode only)
+  ansible.builtin.set_fact:
+    error_flag: true
+  when: ansible_check_mode and __projects_batch_async.failed is defined and __projects_batch_async.failed
+
+- name: process_project_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __projects_batch_async.results }}"
+  loop_control:
+    loop_var: __projects_job_async_results_item
+    label: "{{ __operation.verb }} Project {{ __projects_job_async_results_item.__controller_project_item.name }} | Wait for finish the project {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __projects_job_async_results_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ controller_configuration_projects_secure_logging }}"
+    cas_async_delay: "{{ controller_configuration_projects_async_delay }}"
+    cas_async_retries: "{{ controller_configuration_projects_async_retries }}"
+    cas_job_async_results_item: "{{ __projects_job_async_results_item }}"
+    cas_register_subvar: controller_projects
+    cas_error_list_var_name: "controller_projects_errors"
+    __operation: "{{ operation_translate[__projects_job_async_results_item.__controller_project_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} Project {{ __projects_job_async_results_item.__controller_project_item.name }} | Wait for finish the project {{ __operation.action }}"
+
+- name: process_project_batch | Delay between batches
+  ansible.builtin.pause:
+    seconds: "{{ controller_configuration_projects_batch_delay }}"
+  when:
+    - not ansible_check_mode
+    - controller_configuration_projects_batch_delay | int > 0
+...

--- a/roles/controller_schedules/defaults/main.yml
+++ b/roles/controller_schedules/defaults/main.yml
@@ -4,6 +4,8 @@ controller_schedules: []
 controller_configuration_schedules_secure_logging: "{{ aap_configuration_secure_logging | default('false') }}"
 controller_configuration_schedules_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 controller_configuration_schedules_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
+controller_configuration_schedules_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
+controller_configuration_schedules_batch_delay: "{{ aap_configuration_batch_delay | default(3) }}"
 controller_configuration_schedules_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
 aap_configuration_async_dir:
 controller_configuration_schedules_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"

--- a/roles/controller_schedules/tasks/main.yml
+++ b/roles/controller_schedules/tasks/main.yml
@@ -4,77 +4,17 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ controller_configuration_schedules_secure_logging }}"
   block:
-    - name: Managing Controller Schedules
-      ansible.controller.schedule:
-        name: "{{ __controller_schedule_item.name | mandatory }}"
-        new_name: "{{ __controller_schedule_item.new_name | default(omit, true) }}"
-        description: "{{ __controller_schedule_item.description | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
-        rrule: "{{ __controller_schedule_item.rrule | default(omit, true) }}"
-        extra_data: "{{ __controller_schedule_item.extra_data | default(({} if controller_configuration_schedules_enforce_defaults else omit), true) }}"
-        inventory: "{{ __controller_schedule_item.inventory | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
-        credentials: "{{ __controller_schedule_item.credentials | default(omit, true) }}"
-        scm_branch: "{{ __controller_schedule_item.scm_branch | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
-        execution_environment: "{{ __controller_schedule_item.execution_environment.name | default(__controller_schedule_item.execution_environment | default(omit, true)) }}"
-        forks: "{{ __controller_schedule_item.forks | default(omit, true) }}"
-        instance_groups: "{{ __controller_schedule_item.instance_groups | default(omit, true) }}"
-        job_slice_count: "{{ __controller_schedule_item.job_slice_count | default((1 if controller_configuration_schedules_enforce_defaults else omit), true) }}"
-        labels: "{{ __controller_schedule_item.labels | default((__controller_schedule_item.related.labels | map(attribute='name') | list if __controller_schedule_item.related.labels is defined)) | default(([] if controller_configuration_schedules_enforce_defaults else omit), true) }}"
-        timeout: "{{ __controller_schedule_item.timeout | default(omit, true) }}"
-        job_type: "{{ __controller_schedule_item.job_type | default(omit, true) }}"
-        job_tags: "{{ __controller_schedule_item.job_tags | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
-        skip_tags: "{{ __controller_schedule_item.skip_tags | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
-        limit: "{{ __controller_schedule_item.limit | default(omit, true) }}"
-        diff_mode: "{{ __controller_schedule_item.diff_mode | default((false if controller_configuration_schedules_enforce_defaults else omit)) }}"
-        verbosity: "{{ __controller_schedule_item.verbosity | default(omit, true) }}"
-        organization: "{{ __controller_schedule_item.organization | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
-        unified_job_template: "{{ __controller_schedule_item.unified_job_template | default(omit, true) }}"
-        enabled: "{{ __controller_schedule_item.enabled | default((true if controller_configuration_schedules_enforce_defaults else omit)) }}"
-        state: "{{ __controller_schedule_item.state | default(platform_state | default('present')) }}"
-
-        # Role Standard Options
-        controller_username: "{{ aap_username | default(omit, true) }}"
-        controller_password: "{{ aap_password | default(omit, true) }}"
-        controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
-        request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
-        controller_host: "{{ aap_hostname | default(omit, true) }}"
-        validate_certs: "{{ aap_validate_certs | default(omit) }}"
-      loop: "{{ schedules if schedules is defined else controller_schedules }}"
-      loop_control:
-        loop_var: __controller_schedule_item
-        label: "{{ __operation.verb }} Controller Schedule {{ __controller_schedule_item.name }}"
-        pause: "{{ controller_configuration_schedules_loop_delay }}"
-      async: "{{ ansible_check_mode | ternary(0, 1000) }}"
-      poll: 0
-      register: __controller_schedule_job_async
-      changed_when: (__controller_schedule_job_async.changed if ansible_check_mode else false)
-      vars:
-        __operation: "{{ operation_translate[__controller_schedule_item.state | default(platform_state) | default('present')] }}"
-
-    - name: Flag for errors (check mode only)
+    - name: Schedules | Set batch size
       ansible.builtin.set_fact:
-        error_flag: true
-      when: ansible_check_mode and __controller_schedule_job_async.failed is defined and __controller_schedule_job_async.failed
+        __batch_size: "{{ controller_configuration_schedules_async_concurrency | int }}"
 
-    - name: Managing Schedules | Wait for finish the Schedules management
-      when:
-        - not ansible_check_mode
-        - __controller_schedule_job_async_results_item.ansible_job_id is defined
-      ansible.builtin.include_role:
-        name: infra.aap_configuration.collect_async_status
-      loop: "{{ __controller_schedule_job_async.results }}"
+    - name: Schedules | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_schedule_batch.yml
+      loop: "{{ range(0, (schedules if schedules is defined else controller_schedules) | length, __batch_size | int) | list }}"
       loop_control:
-        loop_var: __controller_schedule_job_async_results_item
-        label: "{{ __operation.verb }} Schedule {{ __controller_schedule_job_async_results_item.__controller_schedule_item.name }} | Wait for finish the Schedules {{
-          __operation.action }}"
-      vars:
-        cas_secure_logging: "{{ controller_configuration_schedules_secure_logging }}"
-        cas_async_delay: "{{ controller_configuration_schedules_async_delay }}"
-        cas_async_retries: "{{ controller_configuration_schedules_async_retries }}"
-        cas_job_async_results_item: "{{ __controller_schedule_job_async_results_item }}"
-        cas_register_subvar: controller_schedules
-        cas_error_list_var_name: "controller_schedules_errors"
-        __operation: "{{ operation_translate[__controller_schedule_job_async_results_item.__controller_schedule_item.state | default(platform_state) | default('present')] }}"
-        cas_object_label: "{{ __operation.verb }} Schedule {{ __controller_schedule_job_async_results_item.__controller_schedule_item.name }} | Wait for finish the Schedules {{ __operation.action }}"
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ (((schedules if schedules is defined else controller_schedules) | length - 1) / __batch_size | int) + 1 }}"
 
   always:
     - name: Cleanup async results files
@@ -84,7 +24,7 @@
       ansible.builtin.async_status:
         jid: "{{ __controller_schedule_job_async_results_item.ansible_job_id }}"
         mode: cleanup
-      loop: "{{ __controller_schedule_job_async.results }}"
+      loop: "{{ __schedules_batch_async.results | default([]) }}"
       loop_control:
         loop_var: __controller_schedule_job_async_results_item
         label: "Cleaning up job results file: {{ __controller_schedule_job_async_results_item.results_file | default('Unknown') }}"

--- a/roles/controller_schedules/tasks/process_schedule_batch.yml
+++ b/roles/controller_schedules/tasks/process_schedule_batch.yml
@@ -1,0 +1,81 @@
+---
+- name: process_schedule_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ (schedules if schedules is defined else controller_schedules)[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_schedule_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.controller.schedule:
+    name: "{{ __controller_schedule_item.name | mandatory }}"
+    new_name: "{{ __controller_schedule_item.new_name | default(omit, true) }}"
+    description: "{{ __controller_schedule_item.description | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
+    rrule: "{{ __controller_schedule_item.rrule | default(omit, true) }}"
+    extra_data: "{{ __controller_schedule_item.extra_data | default(({} if controller_configuration_schedules_enforce_defaults else omit), true) }}"
+    inventory: "{{ __controller_schedule_item.inventory | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
+    credentials: "{{ __controller_schedule_item.credentials | default(omit, true) }}"
+    scm_branch: "{{ __controller_schedule_item.scm_branch | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
+    execution_environment: "{{ __controller_schedule_item.execution_environment.name | default(__controller_schedule_item.execution_environment | default(omit, true)) }}"
+    forks: "{{ __controller_schedule_item.forks | default(omit, true) }}"
+    instance_groups: "{{ __controller_schedule_item.instance_groups | default(omit, true) }}"
+    job_slice_count: "{{ __controller_schedule_item.job_slice_count | default((1 if controller_configuration_schedules_enforce_defaults else omit), true) }}"
+    labels: "{{ __controller_schedule_item.labels | default((__controller_schedule_item.related.labels | map(attribute='name') | list if __controller_schedule_item.related.labels is defined)) | default(([] if controller_configuration_schedules_enforce_defaults else omit), true) }}"
+    timeout: "{{ __controller_schedule_item.timeout | default(omit, true) }}"
+    job_type: "{{ __controller_schedule_item.job_type | default(omit, true) }}"
+    job_tags: "{{ __controller_schedule_item.job_tags | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
+    skip_tags: "{{ __controller_schedule_item.skip_tags | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
+    limit: "{{ __controller_schedule_item.limit | default(omit, true) }}"
+    diff_mode: "{{ __controller_schedule_item.diff_mode | default((false if controller_configuration_schedules_enforce_defaults else omit)) }}"
+    verbosity: "{{ __controller_schedule_item.verbosity | default(omit, true) }}"
+    organization: "{{ __controller_schedule_item.organization | default(('' if controller_configuration_schedules_enforce_defaults else omit), true) }}"
+    unified_job_template: "{{ __controller_schedule_item.unified_job_template | default(omit, true) }}"
+    enabled: "{{ __controller_schedule_item.enabled | default((true if controller_configuration_schedules_enforce_defaults else omit)) }}"
+    state: "{{ __controller_schedule_item.state | default(platform_state | default('present')) }}"
+    controller_username: "{{ aap_username | default(omit, true) }}"
+    controller_password: "{{ aap_password | default(omit, true) }}"
+    controller_oauthtoken: "{{ aap_token | default(omit, true) }}"
+    request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    controller_host: "{{ aap_hostname | default(omit, true) }}"
+    validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __controller_schedule_item
+    label: "{{ __operation.verb }} Schedule {{ __controller_schedule_item.name }}"
+    pause: "{{ controller_configuration_schedules_loop_delay }}"
+  async: "{{ ansible_check_mode | ternary(0, 1000) }}"
+  poll: 0
+  register: __schedules_batch_async
+  changed_when: (__schedules_batch_async.changed if ansible_check_mode else false)
+  vars:
+    __operation: "{{ operation_translate[__controller_schedule_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_schedule_batch | Flag for errors (check mode only)
+  ansible.builtin.set_fact:
+    error_flag: true
+  when: ansible_check_mode and __schedules_batch_async.failed is defined and __schedules_batch_async.failed
+
+- name: process_schedule_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __schedules_batch_async.results }}"
+  loop_control:
+    loop_var: __controller_schedule_job_async_results_item
+    label: "{{ __operation.verb }} Schedule {{ __controller_schedule_job_async_results_item.__controller_schedule_item.name }} | Wait for finish the Schedules {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __controller_schedule_job_async_results_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ controller_configuration_schedules_secure_logging }}"
+    cas_async_delay: "{{ controller_configuration_schedules_async_delay }}"
+    cas_async_retries: "{{ controller_configuration_schedules_async_retries }}"
+    cas_job_async_results_item: "{{ __controller_schedule_job_async_results_item }}"
+    cas_register_subvar: controller_schedules
+    cas_error_list_var_name: "controller_schedules_errors"
+    __operation: "{{ operation_translate[__controller_schedule_job_async_results_item.__controller_schedule_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} Schedule {{ __controller_schedule_job_async_results_item.__controller_schedule_item.name }} | Wait for finish the Schedules {{ __operation.action }}"
+
+- name: process_schedule_batch | Delay between batches
+  ansible.builtin.pause:
+    seconds: "{{ controller_configuration_schedules_batch_delay }}"
+  when:
+    - not ansible_check_mode
+    - controller_configuration_schedules_batch_delay | int > 0
+...

--- a/roles/gateway_organizations/defaults/main.yml
+++ b/roles/gateway_organizations/defaults/main.yml
@@ -14,6 +14,9 @@ gateway_organizations_secure_logging: "{{ aap_configuration_secure_logging | def
 gateway_organizations_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 gateway_organizations_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_organizations_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+gateway_organizations_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
+# TODO: Auto-detect based on X-API-Product-Version header from /api endpoint once 2.7+ is released
+gateway_organizations_skip_controller_api: "{{ aap_configuration_skip_controller_org_api | default(true) }}"
 gateway_organizations_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 aap_configuration_async_dir:
 

--- a/roles/gateway_organizations/tasks/main.yml
+++ b/roles/gateway_organizations/tasks/main.yml
@@ -4,53 +4,20 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ gateway_organizations_secure_logging }}"
   block:
-    - name: Organizations | Configuration
-      ansible.platform.organization:
-        name: "{{ __gateway_organization_item.name | mandatory }}"
-        new_name: "{{ __gateway_organization_item.new_name | default(omit) }}"
-        description: "{{ __gateway_organization_item.description | default(omit) }}"
-        state: "{{ __gateway_organization_item.state | default(platform_state | default(omit, true)) }}"
+    - name: Organizations | Set batch size
+      ansible.builtin.set_fact:
+        __batch_size: "{{ gateway_organizations_async_concurrency | int }}"
 
-        # Role Standard Options
-        gateway_hostname: "{{ aap_hostname | default(omit, true) }}"
-        gateway_username: "{{ aap_username | default(omit, true) }}"
-        gateway_password: "{{ aap_password | default(omit, true) }}"
-        gateway_token: "{{ aap_token | default(omit, true) }}"
-        gateway_request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
-        gateway_validate_certs: "{{ aap_validate_certs | default(omit) }}"
-      loop: "{{ aap_organizations }}"
+    - name: Organizations | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_org_batch.yml
+      loop: "{{ range(0, aap_organizations | length, __batch_size | int) | list }}"
       loop_control:
-        loop_var: __gateway_organization_item
-        label: "{{ __operation.verb }} AAP Platform Organizations {{ __gateway_organization_item.name }}"
-        pause: "{{ gateway_organizations_loop_delay }}"
-      async: 1000
-      poll: 0
-      register: __gateway_organizations_job_async
-      changed_when: not __gateway_organizations_job_async.changed
-      vars:
-        __operation: "{{ operation_translate[__gateway_organization_item.state | default(platform_state) | default('present')] }}"
-
-    - name: Organizations | Wait for finish the configuration
-      ansible.builtin.include_role:
-        name: infra.aap_configuration.collect_async_status
-      loop: "{{ __gateway_organizations_job_async.results }}"
-      loop_control:
-        loop_var: __gateway_organizations_job_async_results_item
-        label: "{{ __operation.verb }} AAP Platform Organizations {{ __gateway_organizations_job_async_results_item.__gateway_organization_item.name }} | Wait for finish the Organizations {{ __operation.action }}"
-      when:
-        - not ansible_check_mode
-        - __gateway_organizations_job_async_results_item.ansible_job_id is defined
-      vars:
-        cas_secure_logging: "{{ gateway_organizations_secure_logging }}"
-        cas_async_delay: "{{ gateway_organizations_async_delay }}"
-        cas_async_retries: "{{ gateway_organizations_async_retries }}"
-        cas_job_async_results_item: "{{ __gateway_organizations_job_async_results_item }}"
-        cas_register_subvar: aap_organizations
-        cas_error_list_var_name: "aap_organizations_errors"
-        __operation: "{{ operation_translate[__gateway_organizations_job_async_results_item.__gateway_organization_item.state | default(platform_state) | default('present')] }}"
-        cas_object_label: "{{ __operation.verb }} AAP Platform Organizations {{ __gateway_organizations_job_async_results_item.__gateway_organization_item.name }} | Wait for finish the Organizations {{ __operation.action }}"
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ ((aap_organizations | length - 1) / __batch_size | int) + 1 }}"
 
     - name: Organizations | Controller Configuration
+      when: not gateway_organizations_skip_controller_api | bool
       ansible.controller.organization:
         name: "{{ __controller_organizations_item.name | mandatory }}"
         new_name: "{{ __controller_organizations_item.new_name | default(omit) }}"
@@ -95,6 +62,7 @@
 
     - name: Managing Controller Organizations | Wait for finish the Organizations management
       when:
+        - not gateway_organizations_skip_controller_api | bool
         - not ansible_check_mode
         - __organizations_job_async_results_item.ansible_job_id is defined
       ansible.builtin.include_role:

--- a/roles/gateway_organizations/tasks/process_org_batch.yml
+++ b/roles/gateway_organizations/tasks/process_org_batch.yml
@@ -1,0 +1,49 @@
+---
+- name: process_org_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ aap_organizations[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_org_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.platform.organization:
+    name: "{{ __gateway_organization_item.name | mandatory }}"
+    new_name: "{{ __gateway_organization_item.new_name | default(omit) }}"
+    description: "{{ __gateway_organization_item.description | default(omit) }}"
+    state: "{{ __gateway_organization_item.state | default(platform_state | default(omit, true)) }}"
+    gateway_hostname: "{{ aap_hostname | default(omit, true) }}"
+    gateway_username: "{{ aap_username | default(omit, true) }}"
+    gateway_password: "{{ aap_password | default(omit, true) }}"
+    gateway_token: "{{ aap_token | default(omit, true) }}"
+    gateway_request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    gateway_validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __gateway_organization_item
+    label: "{{ __operation.verb }} AAP Platform Organizations {{ __gateway_organization_item.name }}"
+    pause: "{{ gateway_organizations_loop_delay }}"
+  async: 1000
+  poll: 0
+  register: __gateway_organizations_batch_async
+  changed_when: not __gateway_organizations_batch_async.changed
+  vars:
+    __operation: "{{ operation_translate[__gateway_organization_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_org_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __gateway_organizations_batch_async.results }}"
+  loop_control:
+    loop_var: __gateway_organizations_job_async_results_item
+    label: "{{ __operation.verb }} AAP Platform Organizations {{ __gateway_organizations_job_async_results_item.__gateway_organization_item.name }} | Wait for finish the Organizations {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __gateway_organizations_job_async_results_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ gateway_organizations_secure_logging }}"
+    cas_async_delay: "{{ gateway_organizations_async_delay }}"
+    cas_async_retries: "{{ gateway_organizations_async_retries }}"
+    cas_job_async_results_item: "{{ __gateway_organizations_job_async_results_item }}"
+    cas_register_subvar: aap_organizations
+    cas_error_list_var_name: "aap_organizations_errors"
+    __operation: "{{ operation_translate[__gateway_organizations_job_async_results_item.__gateway_organization_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} AAP Platform Organizations {{ __gateway_organizations_job_async_results_item.__gateway_organization_item.name }} | Wait for finish the Organizations {{ __operation.action }}"
+...

--- a/roles/gateway_teams/defaults/main.yml
+++ b/roles/gateway_teams/defaults/main.yml
@@ -14,5 +14,6 @@ gateway_teams_secure_logging: "{{ aap_configuration_secure_logging | default('fa
 gateway_teams_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 gateway_teams_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_teams_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+gateway_teams_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
 aap_configuration_async_dir:
 ...

--- a/roles/gateway_teams/tasks/main.yml
+++ b/roles/gateway_teams/tasks/main.yml
@@ -4,64 +4,28 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ gateway_teams_secure_logging }}"
   block:
-    - name: Teams | Configuration
-      ansible.platform.team:
-        name: "{{ __gateway_teams_item.name | mandatory }}"
-        new_name: "{{ __gateway_teams_item.new_name | default(omit) }}"
-        description: "{{ __gateway_teams_item.description | default(omit) }}"
-        organization: "{{ __gateway_teams_item.organization | default(omit) }}"
-        new_organization: "{{ __gateway_teams_item.new_organization | default(omit) }}"
-        state: "{{ __gateway_teams_item.state | default(platform_state | default(omit, true)) }}"
+    - name: Teams | Set batch size
+      ansible.builtin.set_fact:
+        __batch_size: "{{ gateway_teams_async_concurrency | int }}"
 
-        # Role Standard Options
-        gateway_hostname: "{{ aap_hostname | default(omit, true) }}"
-        gateway_username: "{{ aap_username | default(omit, true) }}"
-        gateway_password: "{{ aap_password | default(omit, true) }}"
-        gateway_token: "{{ aap_token | default(omit, true) }}"
-        gateway_request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
-        gateway_validate_certs: "{{ aap_validate_certs | default(omit) }}"
-      loop: "{{ aap_teams }}"
+    - name: Teams | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_team_batch.yml
+      loop: "{{ range(0, aap_teams | length, __batch_size | int) | list }}"
       loop_control:
-        loop_var: __gateway_teams_item
-        label: "{{ __operation.verb }} the Gateway team {{ __gateway_teams_item.name }}"
-        pause: "{{ gateway_teams_loop_delay }}"
-      async: 1000
-      poll: 0
-      register: __gateway_teams_job_async
-      changed_when: not __gateway_teams_job_async.changed
-      vars:
-        __operation: "{{ operation_translate[__gateway_teams_item.state | default(platform_state) | default('present')] }}"
-
-    - name: Teams | Wait for finish the configuration
-      when:
-        - not ansible_check_mode
-        - __gateway_teams_job_async_results_item.ansible_job_id is defined
-      ansible.builtin.include_role:
-        name: infra.aap_configuration.collect_async_status
-      loop: "{{ __gateway_teams_job_async.results }}"
-      loop_control:
-        loop_var: __gateway_teams_job_async_results_item
-        label: "{{ __operation.verb }} Gateway team {{ __gateway_teams_job_async_results_item.__gateway_teams_item.name }} | Wait for finish the Gateway team {{ __operation.action }}"
-      vars:
-        cas_secure_logging: "{{ gateway_teams_secure_logging }}"
-        cas_async_delay: "{{ gateway_teams_async_delay }}"
-        cas_async_retries: "{{ gateway_teams_async_retries }}"
-        cas_job_async_results_item: "{{ __gateway_teams_job_async_results_item }}"
-        cas_register_subvar: gateway_teams
-        cas_error_list_var_name: "gateway_teams_errors"
-        __operation: "{{ operation_translate[__gateway_teams_job_async_results_item.__gateway_teams_item.state | default(platform_state) | default('present')] }}"
-        cas_object_label: "{{ __operation.verb }} Gateway team {{ __gateway_teams_job_async_results_item.__gateway_teams_item.name }} | Wait for finish the Gateway team {{ __operation.action }}"
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ ((aap_teams | length - 1) / __batch_size | int) + 1 }}"
 
   always:
     - name: Cleanup async results files
       when:
         - not ansible_check_mode
-        - __gateway_teams_job_async_results_item.ansible_job_id is defined
+        - __team_job_async_results_item.ansible_job_id is defined
       ansible.builtin.async_status:
-        jid: "{{ __gateway_teams_job_async_results_item.ansible_job_id }}"
+        jid: "{{ __team_job_async_results_item.ansible_job_id }}"
         mode: cleanup
-      loop: "{{ __gateway_teams_job_async.results }}"
+      loop: "{{ __gateway_teams_batch_async.results | default([]) }}"
       loop_control:
-        loop_var: __gateway_teams_job_async_results_item
-        label: "Cleaning up job results file: {{ __gateway_teams_job_async_results_item.results_file | default('Unknown') }}"
+        loop_var: __team_job_async_results_item
+        label: "Cleaning up job results file: {{ __team_job_async_results_item.results_file | default('Unknown') }}"
 ...

--- a/roles/gateway_teams/tasks/process_team_batch.yml
+++ b/roles/gateway_teams/tasks/process_team_batch.yml
@@ -1,0 +1,51 @@
+---
+- name: process_team_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ aap_teams[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_team_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.platform.team:
+    name: "{{ __gateway_teams_item.name | mandatory }}"
+    new_name: "{{ __gateway_teams_item.new_name | default(omit) }}"
+    description: "{{ __gateway_teams_item.description | default(omit) }}"
+    organization: "{{ __gateway_teams_item.organization | default(omit) }}"
+    new_organization: "{{ __gateway_teams_item.new_organization | default(omit) }}"
+    state: "{{ __gateway_teams_item.state | default(platform_state | default(omit, true)) }}"
+    gateway_hostname: "{{ aap_hostname | default(omit, true) }}"
+    gateway_username: "{{ aap_username | default(omit, true) }}"
+    gateway_password: "{{ aap_password | default(omit, true) }}"
+    gateway_token: "{{ aap_token | default(omit, true) }}"
+    gateway_request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    gateway_validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __gateway_teams_item
+    label: "{{ __operation.verb }} Gateway team {{ __gateway_teams_item.name }}"
+    pause: "{{ gateway_teams_loop_delay }}"
+  async: 1000
+  poll: 0
+  register: __gateway_teams_batch_async
+  changed_when: not __gateway_teams_batch_async.changed
+  vars:
+    __operation: "{{ operation_translate[__gateway_teams_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_team_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __gateway_teams_batch_async.results }}"
+  loop_control:
+    loop_var: __gateway_teams_job_async_results_item
+    label: "{{ __operation.verb }} Gateway team {{ __gateway_teams_job_async_results_item.__gateway_teams_item.name }} | Wait for finish the team {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __gateway_teams_job_async_results_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ gateway_teams_secure_logging }}"
+    cas_async_delay: "{{ gateway_teams_async_delay }}"
+    cas_async_retries: "{{ gateway_teams_async_retries }}"
+    cas_job_async_results_item: "{{ __gateway_teams_job_async_results_item }}"
+    cas_register_subvar: gateway_teams
+    cas_error_list_var_name: "gateway_teams_errors"
+    __operation: "{{ operation_translate[__gateway_teams_job_async_results_item.__gateway_teams_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} Gateway team {{ __gateway_teams_job_async_results_item.__gateway_teams_item.name }} | Wait for finish the team {{ __operation.action }}"
+...

--- a/roles/gateway_users/defaults/main.yml
+++ b/roles/gateway_users/defaults/main.yml
@@ -28,5 +28,6 @@ gateway_users_secure_logging: "{{ aap_configuration_secure_logging | default('fa
 gateway_users_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 gateway_users_async_delay: "{{ aap_configuration_async_delay | default(1) }}"
 gateway_users_loop_delay: "{{ aap_configuration_loop_delay | default(0) }}"
+gateway_users_async_concurrency: "{{ aap_configuration_async_concurrency | default(100) }}"
 aap_configuration_async_dir:
 ...

--- a/roles/gateway_users/tasks/main.yml
+++ b/roles/gateway_users/tasks/main.yml
@@ -4,71 +4,28 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ gateway_users_secure_logging }}"
   block:
-    - name: Users | Configuration
-      ansible.platform.user:
-        username: "{{ __gateway_user_accounts_item.username | mandatory }}"
-        # the 'true' in the second default leads to no password being set if the default password is empty
-        password: "{{ __gateway_user_accounts_item.password | default(users_default_password | default(omit, true)) }}"
-        email: "{{ __gateway_user_accounts_item.email | default(omit, true) }}"
-        first_name: "{{ __gateway_user_accounts_item.first_name | default(omit, true) }}"
-        last_name: "{{ __gateway_user_accounts_item.last_name | default(omit, true) }}"
-        is_superuser: "{{ __gateway_user_accounts_item.is_superuser | default(omit) }}"
-        is_platform_auditor: "{{ __gateway_user_accounts_item.is_platform_auditor | default(omit) }}"
-        update_secrets: "{{ __gateway_user_accounts_item.update_secrets | default(omit) }}"
-        organizations: "{{ __gateway_user_accounts_item.organizations | default(omit) }}"
-        authenticators: "{{ __gateway_user_accounts_item.authenticators | default(omit) }}"
-        authenticator_uid: "{{ __gateway_user_accounts_item.authenticator_uid | default(omit) }}"
-        state: "{{ __gateway_user_accounts_item.state | default(platform_state | default(omit, true)) }}"
+    - name: Users | Set batch size
+      ansible.builtin.set_fact:
+        __batch_size: "{{ gateway_users_async_concurrency | int }}"
 
-        # Role Standard Options
-        gateway_hostname: "{{ aap_hostname | default(omit, true) }}"
-        gateway_username: "{{ aap_username | default(omit, true) }}"
-        gateway_password: "{{ aap_password | default(omit, true) }}"
-        gateway_token: "{{ aap_token | default(omit, true) }}"
-        gateway_request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
-        gateway_validate_certs: "{{ aap_validate_certs | default(omit) }}"
-      loop: "{{ aap_user_accounts }}"
+    - name: Users | Process in batches
+      ansible.builtin.include_tasks:
+        file: process_user_batch.yml
+      loop: "{{ range(0, aap_user_accounts | length, __batch_size | int) | list }}"
       loop_control:
-        loop_var: __gateway_user_accounts_item
-        label: "{{ __operation.verb }} the Gateway user {{ __gateway_user_accounts_item.username }}"
-        pause: "{{ gateway_users_loop_delay }}"
-      async: 1000
-      poll: 0
-      register: __gateway_user_accounts_job_async
-      changed_when: not __gateway_user_accounts_job_async.changed
-      vars:
-        __operation: "{{ operation_translate[__gateway_user_accounts_item.state | default(platform_state) | default('present')] }}"
-
-    - name: Users | Wait for finish the configuration
-      when:
-        - not ansible_check_mode
-        - __gateway_user_accounts_job_async_results_item.ansible_job_id is defined
-      ansible.builtin.include_role:
-        name: infra.aap_configuration.collect_async_status
-      loop: "{{ __gateway_user_accounts_job_async.results }}"
-      loop_control:
-        loop_var: __gateway_user_accounts_job_async_results_item
-        label: "{{ __operation.verb }} Gateway user {{ __gateway_user_accounts_job_async_results_item.__gateway_user_accounts_item.username }} | Wait for finish the Gateway user {{ __operation.action }}"
-      vars:
-        cas_secure_logging: "{{ gateway_users_secure_logging }}"
-        cas_async_delay: "{{ gateway_users_async_delay }}"
-        cas_async_retries: "{{ gateway_users_async_retries }}"
-        cas_job_async_results_item: "{{ __gateway_user_accounts_job_async_results_item }}"
-        cas_register_subvar: gateway_users
-        cas_error_list_var_name: "gateway_users_errors"
-        __operation: "{{ operation_translate[__gateway_user_accounts_job_async_results_item.__gateway_user_accounts_item.state | default(platform_state) | default('present')] }}"
-        cas_object_label: "{{ __operation.verb }} Gateway user {{ __gateway_user_accounts_job_async_results_item.__gateway_user_accounts_item.username }} | Wait for finish the Gateway user {{ __operation.action }}"
+        loop_var: __batch_start_index
+        label: "Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }} of {{ ((aap_user_accounts | length - 1) / __batch_size | int) + 1 }}"
 
   always:
     - name: Cleanup async results files
       when:
         - not ansible_check_mode
-        - __gateway_user_accounts_job_async_results_item.ansible_job_id is defined
+        - __user_job_async_results_item.ansible_job_id is defined
       ansible.builtin.async_status:
-        jid: "{{ __gateway_user_accounts_job_async_results_item.ansible_job_id }}"
+        jid: "{{ __user_job_async_results_item.ansible_job_id }}"
         mode: cleanup
-      loop: "{{ __gateway_user_accounts_job_async.results }}"
+      loop: "{{ __gateway_users_batch_async.results | default([]) }}"
       loop_control:
-        loop_var: __gateway_user_accounts_job_async_results_item
-        label: "Cleaning up job results file: {{ __gateway_user_accounts_job_async_results_item.results_file | default('Unknown') }}"
+        loop_var: __user_job_async_results_item
+        label: "Cleaning up job results file: {{ __user_job_async_results_item.results_file | default('Unknown') }}"
 ...

--- a/roles/gateway_users/tasks/process_user_batch.yml
+++ b/roles/gateway_users/tasks/process_user_batch.yml
@@ -1,0 +1,57 @@
+---
+- name: process_user_batch | Get current batch
+  ansible.builtin.set_fact:
+    __current_batch: "{{ aap_user_accounts[__batch_start_index | int : __batch_start_index | int + __batch_size | int] }}"
+
+- name: process_user_batch | Configuration (Batch {{ (__batch_start_index | int / __batch_size | int) + 1 }})
+  ansible.platform.user:
+    username: "{{ __gateway_user_accounts_item.username | mandatory }}"
+    password: "{{ __gateway_user_accounts_item.password | default(users_default_password | default(omit, true)) }}"
+    email: "{{ __gateway_user_accounts_item.email | default(omit, true) }}"
+    first_name: "{{ __gateway_user_accounts_item.first_name | default(omit, true) }}"
+    last_name: "{{ __gateway_user_accounts_item.last_name | default(omit, true) }}"
+    is_superuser: "{{ __gateway_user_accounts_item.is_superuser | default(omit) }}"
+    is_platform_auditor: "{{ __gateway_user_accounts_item.is_platform_auditor | default(omit) }}"
+    update_secrets: "{{ __gateway_user_accounts_item.update_secrets | default(omit) }}"
+    organizations: "{{ __gateway_user_accounts_item.organizations | default(omit) }}"
+    authenticators: "{{ __gateway_user_accounts_item.authenticators | default(omit) }}"
+    authenticator_uid: "{{ __gateway_user_accounts_item.authenticator_uid | default(omit) }}"
+    state: "{{ __gateway_user_accounts_item.state | default(platform_state | default(omit, true)) }}"
+    gateway_hostname: "{{ aap_hostname | default(omit, true) }}"
+    gateway_username: "{{ aap_username | default(omit, true) }}"
+    gateway_password: "{{ aap_password | default(omit, true) }}"
+    gateway_token: "{{ aap_token | default(omit, true) }}"
+    gateway_request_timeout: "{{ aap_request_timeout | default(omit, true) }}"
+    gateway_validate_certs: "{{ aap_validate_certs | default(omit) }}"
+  loop: "{{ __current_batch }}"
+  loop_control:
+    loop_var: __gateway_user_accounts_item
+    label: "{{ __operation.verb }} Gateway user {{ __gateway_user_accounts_item.username }}"
+    pause: "{{ gateway_users_loop_delay }}"
+  async: 1000
+  poll: 0
+  register: __gateway_users_batch_async
+  changed_when: not __gateway_users_batch_async.changed
+  vars:
+    __operation: "{{ operation_translate[__gateway_user_accounts_item.state | default(platform_state) | default('present')] }}"
+
+- name: process_user_batch | Wait for batch to complete
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.collect_async_status
+  loop: "{{ __gateway_users_batch_async.results }}"
+  loop_control:
+    loop_var: __gateway_user_accounts_job_async_results_item
+    label: "{{ __operation.verb }} Gateway user {{ __gateway_user_accounts_job_async_results_item.__gateway_user_accounts_item.username }} | Wait for finish the user {{ __operation.action }}"
+  when:
+    - not ansible_check_mode
+    - __gateway_user_accounts_job_async_results_item.ansible_job_id is defined
+  vars:
+    cas_secure_logging: "{{ gateway_users_secure_logging }}"
+    cas_async_delay: "{{ gateway_users_async_delay }}"
+    cas_async_retries: "{{ gateway_users_async_retries }}"
+    cas_job_async_results_item: "{{ __gateway_user_accounts_job_async_results_item }}"
+    cas_register_subvar: gateway_users
+    cas_error_list_var_name: "gateway_users_errors"
+    __operation: "{{ operation_translate[__gateway_user_accounts_job_async_results_item.__gateway_user_accounts_item.state | default(platform_state) | default('present')] }}"
+    cas_object_label: "{{ __operation.verb }} Gateway user {{ __gateway_user_accounts_job_async_results_item.__gateway_user_accounts_item.username }} | Wait for finish the user {{ __operation.action }}"
+...


### PR DESCRIPTION
<!-- markdownlint-disable -->
# What does this PR do?

This PR implements **batch processing** for AAP resource creation/updates to throttle concurrent API calls and prevent overwhelming Gateway/Controller APIs, especially on OpenShift deployments.

**Problem**: Creating hundreds of resources (credentials, projects, inventories, etc.) in parallel causes:
- 502/503/504 Gateway errors as uwsgi workers are exhausted
- SSL handshake failures under high concurrency
- Request timeouts (OpenShift pods have stricter 10-15s defaults)

**Root cause on OpenShift**:
- Small pods with few uwsgi workers (2-4 vs 10+ on bare-metal)
- Limited uwsgi backlog (can't queue as many requests)
- Stricter resource limits and default timeouts
- Gateway/Controller pods can't handle 100+ parallel API calls

**Solution**: Process resources in configurable batches:
1. Process N resources in parallel (default: 100)
2. Wait for batch to complete
3. Delay between batches (default: 3 seconds)
4. Repeat for next batch

**Alternative approaches considered**:
- `controller_configuration_<role>_loop_delay`: Adds delay between **every** request. Works but slows things down significantly (100 resources × 1s delay = 100s sequential). Good for very small deployments or very limited API capacity.
- **Batching (this PR)**: Middle ground - maintains parallelism within batches while limiting concurrent load. Faster than loop_delay, safer than unlimited parallelism.

## Batched Roles

Implemented batching for 10 roles:
- Gateway: `gateway_organizations`, `gateway_teams`, `gateway_users`
- Controller: `controller_credentials`, `controller_execution_environments`, `controller_inventories`, `controller_hosts`, `controller_job_templates`, `controller_notification_templates`, `controller_projects`

**Still TODO**:
- `controller_schedules`
- `controller_workflow_job_templates`
- `controller_inventory_sources`
- `controller_credential_types`
- `controller_labels`

## Configuration Variables

```yaml
# Global defaults (apply to all batched roles)
aap_configuration_async_concurrency: 100  # batch size
aap_configuration_batch_delay: 3          # seconds between batches
aap_request_timeout: 30                   # increased from 10s default

# Per-role overrides (example)
controller_configuration_credentials_async_concurrency: 50
controller_configuration_credentials_batch_delay: 5
```

Each role follows this pattern:
- `<role>_async_concurrency`: Batch size for this role (defaults to `aap_configuration_async_concurrency`)
- `<role>_batch_delay`: Seconds to pause between batches (defaults to `aap_configuration_batch_delay`)
- `<role>_async_delay`: Seconds between polling for async task completion (existing, unchanged)
- `<role>_async_retries`: Max polling attempts (existing, unchanged)
- `<role>_loop_delay`: Seconds between **every** request (existing, alternative to batching)

# How should this be tested?

## Unit Testing (Manual)

1. **Install the collection**:
```bash
cd /path/to/infra.aap_configuration
ansible-galaxy collection build --force
ansible-galaxy collection install infra-aap_configuration-*.tar.gz --force
```

2. **Create test data** with varying scale:
```yaml
# vars/test_batching_small.yml
aap_configuration_async_concurrency: 10
aap_configuration_batch_delay: 2

gateway_organizations:
  - name: Batch-Test-Org-1
  - name: Batch-Test-Org-2
# ... repeat for 21 organizations

controller_credentials:
  - name: "Batch-Cred-{{ item }}"
    organization: Batch-Test-Org-1
    credential_type: Machine
    inputs: {username: "user{{ item }}", password: "pass{{ item }}"}
# ... repeat for 21 credentials
```

3. **Run the playbook**:
```bash
ansible-playbook -i localhost, -c local \
  -e "@vars/test_batching_small.yml" \
  -e "aap_hostname=https://your-gateway.example.com" \
  -e "aap_token=YOUR_TOKEN" \
  -e "aap_validate_certs=false" \
  playbooks/configure_aap.yml
```

4. **Verify behavior**:
- Watch for "Batch X of Y" labels in output
- Check logs for 3-second pauses between batches
- Verify no 502/503/504 errors
- Confirm all resources created successfully

# Other Relevant info, PRs, etc

## Future Work

**Upstream contributions** to consider:
1. **Retry logic in modules** (`ansible.controller`, `ansible.gateway`, `ansible.hub`, `ansible.eda`):
   - Detect 502/503/504 responses
   - Implement exponential backoff
   - Make retry behavior configurable
   - Don't fail immediately on transient errors

## Testing Notes

- Tested on AAP 2.7 (devel) OpenShift deployment