### PR TITLE
fix for code scanning alerts

### DIFF
--- a/.github/workflows/issue-close-inactive.yml
+++ b/.github/workflows/issue-close-inactive.yml
@@ -2,6 +2,10 @@
 # https://github.com/marketplace/actions/issues-helper
 name: Check and close inactive
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   schedule:
     - cron: "0 6 * * *"

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -6,6 +6,10 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   issue-labeled:
     runs-on: ubuntu-latest

--- a/.github/workflows/office-hours-issue.yml
+++ b/.github/workflows/office-hours-issue.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: "1 0 8 * *"
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-need-info:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,6 +3,8 @@
 # See .pre-commit-config.yaml for what hooks are executed
 name: pre-commit tests
 
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/release_auto.yml
+++ b/.github/workflows/release_auto.yml
@@ -8,6 +8,9 @@ on:
     - cron: "0 0 1,15 * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release Collection to galaxy/AH

--- a/.github/workflows/update_pre_commit.yml
+++ b/.github/workflows/update_pre_commit.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   pre-commit:
+    permissions:
+      contents: read
     uses: "redhat-cop/ansible_collections_tooling/.github/workflows/update_precommit.yml@main"
     with:
       github_actor: ${{ github.actor }}


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/infra.aap_configuration/security/code-scanning/9](https://github.com/redhat-cop/infra.aap_configuration/security/code-scanning/9)

In general, the fix is to declare explicit `permissions:` for the workflow or for each job, granting only what is required. Here, the jobs `check-need-info` and `create-issue` both interact only with issues through `actions-cool/issues-helper@v3`, so they minimally require `issues: write`. They do not need repository contents or other write scopes. We can add a `permissions:` block at the root (top level, next to `on:`) and set `contents: read` (safe default) and `issues: write`, or we can specify `permissions:` per job. The simplest, least intrusive change is to add a root‑level `permissions:` block that applies to both jobs.

Concretely, in `.github/workflows/office-hours-issue.yml`, after the `on:` block (after line 7) and before `jobs:` (line 9), add:

```yaml
permissions:
  contents: read
  issues: write
```

This explicitly restricts the GITHUB_TOKEN to read‑only access to repository contents while allowing write access only to issues, which is what the workflow needs. No imports or dependencies are required, and no existing logic changes; we are only constraining token scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
