### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue-find-inactive.yml
+++ b/.github/workflows/issue-find-inactive.yml
@@ -1,6 +1,9 @@
 ---
 # https://github.com/marketplace/actions/issues-helper
 name: Check inactive
+permissions:
+  contents: read
+  issues: write
 
 on:
   schedule:

--- a/.github/workflows/issue-remove-inactive.yml
+++ b/.github/workflows/issue-remove-inactive.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   remove-inactive:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: remove inactive
         if: github.event.issue.state == 'open'


### PR DESCRIPTION
Potential fix for [https://github.com/redhat-cop/infra.aap_configuration/security/code-scanning/4](https://github.com/redhat-cop/infra.aap_configuration/security/code-scanning/4)

In general, the fix is to add an explicit `permissions` block to the workflow (at the root, applying to all jobs) or specifically to the `check-inactive` job. The block should grant only the scopes required by `actions-cool/issues-helper@v3` for the `check-inactive` action. Since this action needs to read and label/close/comment on issues, it typically requires `issues: write` and possibly `pull-requests: write` if it interacts with PRs; contents access can usually be read-only.

The single best minimal-change fix here is to define a root-level `permissions` block just below the `name:` (before `on:`) so it applies to all jobs. Based on the workflow’s intent (“Check inactive” issues) and its use of an issues helper, we grant `contents: read` (safe default), and `issues: write` to allow the action to update or comment on issues if needed. We do not alter existing steps or behavior; we only restrict the `GITHUB_TOKEN` to the least likely set of required permissions. Concretely, in `.github/workflows/issue-find-inactive.yml`, insert:

```yaml
permissions:
  contents: read
  issues: write
```

after line 3 (`name: Check inactive`). No imports or other code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
