### PR TITLE
chore: security audit remediations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,21 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: pre-commit
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+---
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/.github"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/issue-close-inactive.yml
+++ b/.github/workflows/issue-close-inactive.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: close-issues
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'close-issues'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-find-inactive.yml
+++ b/.github/workflows/issue-find-inactive.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check-inactive
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'check-inactive'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create comment
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         if: github.event.label.name == 'inactive'  # || github.event.label.name == 'need info'
         with:
           actions: 'create-comment'

--- a/.github/workflows/issue-remove-inactive.yml
+++ b/.github/workflows/issue-remove-inactive.yml
@@ -8,16 +8,17 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   remove-inactive:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
     steps:
       - name: remove inactive
         if: github.event.issue.state == 'open'
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'remove-labels'
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/office-hours-issue.yml
+++ b/.github/workflows/office-hours-issue.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: close-issues
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'close-issues'
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create issue
-        uses: actions-cool/issues-helper@v3
+        uses: actions-cool/issues-helper@200c78641dbf33838311e5a1e0c31bbdb92d7cf0 # v3
         with:
           actions: 'create-issue'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,8 +29,6 @@ jobs:
 
   pre-commit_and_sanity:
     needs: approve_run
-    environment:
-      name: pr-approval
     uses: "redhat-cop/ansible_collections_tooling/.github/workflows/pre_commit_workflow_crc.yml@main"
     with:
       collection_namespace: infra

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,6 +29,8 @@ jobs:
 
   pre-commit_and_sanity:
     needs: approve_run
+    environment:
+      name: pr-approval
     uses: "redhat-cop/ansible_collections_tooling/.github/workflows/pre_commit_workflow_crc.yml@main"
     with:
       collection_namespace: infra

--- a/.github/workflows/update_pre_commit.yml
+++ b/.github/workflows/update_pre_commit.yml
@@ -8,10 +8,11 @@ on:
   schedule:
     - cron: "0 5 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
-    permissions:
-      contents: read
     uses: "redhat-cop/ansible_collections_tooling/.github/workflows/update_precommit.yml@main"
     with:
       github_actor: ${{ github.actor }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.env
+*.pem
+*.key
 collections/*
 !collections/requirements.yml
 *.tar.gz


### PR DESCRIPTION
## Summary

- Pinned third-party GitHub Actions to immutable SHAs (CodeQL `actions/unpinned-tag`).
- Added Dependabot for pip and GitHub Actions.
- Set explicit workflow-level permissions where needed.
- Expanded `.gitignore` for common secret material.

## Details

**Repo:** `redhat-cop/infra.aap_configuration` | **Base branch:** `devel`

- **CodeQL alerts #10–15** (`actions/unpinned-tag`): Pinned `actions-cool/issues-helper@v3` to SHA `200c78641dbf33838311e5a1e0c31bbdb92d7cf0` in all issue automation workflows
- **`pull_request_target`** (`pre-commit.yml`): Added `environment: name: pr-approval` to `pre-commit_and_sanity` job
- **Dependabot**: Created `.github/dependabot.yml` for `pip` + `github-actions` (weekly)
- **Permissions**: Added workflow-level `permissions` to `update_pre_commit.yml`, `issue-remove-inactive.yml`
- **`.gitignore`**: Added `.env`, `*.pem`, `*.key`

Made with [Cursor](https://cursor.com)