### PR TITLE
Update required Ansible version to 2.16.0

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,3 @@
 ---
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"
 ...


### PR DESCRIPTION
# What does this PR do?

Update required Ansible version to 2.16.0 that are arbitrary for role based collections per Partner Engineering requirements. 
