### PR TITLE
fix: ensure apply:tags is always a string for Ansible 2.13 compat

### DIFF
--- a/roles/dispatch/tasks/main.yml
+++ b/roles/dispatch/tasks/main.yml
@@ -8,7 +8,7 @@
   ansible.builtin.include_role:
     name: "{{ __role.role }}"
     apply:
-      tags: "{{ __role.tags }}"
+      tags: "{{ __role.tags if __role.tags is string else __role.tags | last }}"
   when: vars[__role.var] is defined
   tags: always
   loop: "{{ aap_configuration_dispatcher_roles }}"


### PR DESCRIPTION
Ansible 2.13.7 wraps any list returned by a Jinja2 template in apply:tags into another list, causing tag validation to fail with "the field 'tags' should be a list of str/int, but the item is a list".

Using a conditional ensures string tags pass through unchanged while list tags (e.g. ['inventories', 'projects']) fall back to their last (most specific) element as a single string.

Made-with: Cursor

# What does this PR do?

<!--- Brief explanation of the code or documentation change you've made -->

## How should this be tested?

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

## Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->

resolves #[number]

## Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
