### PR TITLE
AAP-73120: "controller_hosts" role ignores "enabled: false" and enables host unconditionally.

### DIFF
--- a/roles/controller_hosts/tasks/main.yml
+++ b/roles/controller_hosts/tasks/main.yml
@@ -10,7 +10,7 @@
         new_name: "{{ __controller_host_item.new_name | default(omit, true) }}"
         description: "{{ __controller_host_item.description | default(('' if controller_configuration_host_enforce_defaults else omit), true) }}"
         inventory: "{{ __controller_host_item.inventory | mandatory }}"
-        enabled: "{{ __controller_host_item.enabled | default((false if controller_configuration_host_enforce_defaults else omit), true) }}"
+        enabled: "{{ __controller_host_item.enabled | default((false if controller_configuration_host_enforce_defaults else omit)) }}"
         state: "{{ __controller_host_item.state | default(platform_state | default('present')) }}"
         variables: "{{ __controller_host_item.variables | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_host_item.variables is defined and __controller_host_item.variables) else ({} if controller_configuration_host_enforce_defaults else omit) }}"
 


### PR DESCRIPTION
## Summary
The `controller_hosts` role ignores the `enabled: false` parameter and always adds the host in an enabled state to the Controller inventory.

## Issue Type
- [x] Bug Report

## Problem
When defining a host with `enabled: false` in the `controller_hosts` variable list, the host is successfully created in the controller inventory but is always enabled, ignoring the explicitly set value.

Example configuration that triggers the bug:

~~~~~~~~~
controller_hosts:
  - name: "my-execution-node"
    description: "Execution node"
    inventory: "Demo Inventory"
    enabled: false
    variables:
      ansible_host: "192.168.1.10"
    state: present
~~~~~~~~~

**Expected behavior:**
Host `my-execution-node` should be added to `Demo Inventory` with enabled set to `false` (disabled state).

**Actual behavior:**
Host `my-execution-node` is added to `Demo Inventory` with enabled set to `true` regardless of the value passed.

## Solution
Changed `default(omit, true)` to `default(omit)` in the `enabled` parameter definition. Removing the second `true` argument ensures the filter only omits the parameter when it is truly **undefined/not set**, and correctly passes `false` to the module when `enabled: false` is explicitly specified by
the user.

## Related Issue
Fixes #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)