### PR TITLE
Fix token retrieval for organization creation in AAP 2.7

### DIFF
--- a/roles/gateway_organizations/tasks/main.yml
+++ b/roles/gateway_organizations/tasks/main.yml
@@ -50,6 +50,33 @@
         __operation: "{{ operation_translate[__gateway_organizations_job_async_results_item.__gateway_organization_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} AAP Platform Organizations {{ __gateway_organizations_job_async_results_item.__gateway_organization_item.name }} | Wait for finish the Organizations {{ __operation.action }}"
 
+    - name: Organizations | Fetch AAP token for Controller Configuration
+      ansible.platform.token:
+        description: "Temp token for gateway_organizations controller sync"
+        scope: "write"
+        state: present
+        aap_hostname: "{{ aap_hostname }}"
+        aap_username: "{{ aap_username }}"
+        aap_password: "{{ aap_password }}"
+        aap_validate_certs: "{{ aap_validate_certs | default(omit) }}"
+      register: __gateway_organizations_token
+      no_log: "{{ gateway_organizations_secure_logging }}"
+      run_once: true
+      when:
+        - aap_token is not defined
+        - aap_username is defined
+        - aap_password is defined
+
+    - name: Organizations | Set aap_token fact from fetched token
+      ansible.builtin.set_fact:
+        aap_token: "{{ __gateway_organizations_token.token }}"
+      no_log: "{{ gateway_organizations_secure_logging }}"
+      run_once: true
+      when:
+        - aap_token is not defined
+        - __gateway_organizations_token is not skipped
+        - __gateway_organizations_token.token is defined
+
     - name: Organizations | Controller Configuration
       ansible.controller.organization:
         name: "{{ __controller_organizations_item.name | mandatory }}"


### PR DESCRIPTION
## Summary
The `gateway_organizations` role fails with `HTTP Error 404: Not Found` during async status checks when creating organizations against AAP 2.7, even though the organization is successfully created.
                                                                                                                                                                                                                                             
## Issue Type                                                                                                                                                                                                                              
- [x] Bug Report                                                                                                                                                                                                                           
                                                                                                                                                                                                                                             
## Problem      
When using the `gateway_organizations` role without a pre-defined `aap_token`, the controller configuration task attempts to authenticate using only username/password. This causes the async status collection to fail with "Failed to get token: HTTP Error 404: Not Found" when checking job completion status in AAP 2.7.                                                                                                                                                         

## Expected behavior:                                                                                                                                                                                                                         
Organization should be created successfully without any 404 errors during async status checks.
                                                                                                                                                                                                                                             
## Actual behavior:
- Organization is created successfully in AAP
- Async status collection fails with: "Failed to get token: HTTP Error 404: Not Found"                                                                                                                                                     
- Playbook execution reports failure despite organization being present               
                                                                                                                                                                                                                                             
## Solution                                                                                                                                                                                                                                   
Added explicit token retrieval logic before the controller configuration task to ensure `controller_oauthtoken` receives a valid token value. When `aap_token` is not pre-defined but `aap_username` and `aap_password` are available, the role now fetches a temporary write-scoped token using the `ansible.platform.token` module and stores it in the `aap_token` fact. This ensures the controller configuration task always has proper authentication, preventing the 404 error during async job status checks in AAP 2.7. 
The implementation is backward compatible, only fetching a token when needed and allowing users to continue providing their own `aap_token` if preferred. Both new tasks respect the `gateway_organizations_secure_logging` setting and use `run_once: true` for efficiency.                                                                                                                                                         
                                                                                                                                                                                                                                             
## Related Issue                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
Fixes #1344                                                                                                                                                                                                                                
                  
## Testing                                                                                                                                                                                                                                    
Tested against AAP 2.7:                                                                                                                                                                               
                  
Before fix: ❌ Failed with "HTTP Error 404: Not Found"                                                                                                                                                                                     
After fix: ✅ Organization created successfully, no errors