### PR TITLE
docs(readme): standardize links and add Support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ collections:
 
 |                                      Collection Name                                                  |                      Purpose                      |
 |:-----------------------------------------------------------------------------------------------------:|:-------------------------------------------------:|
+| [AAP <= 2.4 Controller Configuration](https://github.com/redhat-cop/infra.controller_configuration) | Automation controller configuration       |
 | [AAP Configuration Extended](https://github.com/redhat-cop/aap_configuration_extended)                | Where other useful roles that don't fit here live |
 | [EE Utilities](https://github.com/redhat-cop/ee_utilities)                                            | Execution Environment creation utilities          |
 | [AAP installation Utilities](https://github.com/redhat-cop/aap_utilities)                             | Ansible Automation Platform Utilities             |
 | [AAP Configuration Template](https://github.com/redhat-cop/aap_configuration_template)                | Configuration Template for this suite             |
 | [Ansible Validated Gitlab Workflows](https://gitlab.com/redhat-cop/infra/ansible_validated_workflows) | Gitlab CI/CD Workflows for ansible content        |
-| [Ansible Validated Github Workflows](https://github.com/redhat-cop/infra.ansible_validated_workflows) | Github CI/CD Workflows for ansible content        |
+| [Ansible Validated GitHub Workflows](https://github.com/redhat-cop/infra.ansible_validated_workflows) | GitHub CI/CD Workflows for ansible content        |
 
 ## Included content
 
@@ -292,3 +293,7 @@ Please read and familiarize yourself with this document.
 GNU General Public License v3.0 or later.
 
 See [LICENSE](https://github.com/redhat-cop/infra.aap_configuration/blob/devel/LICENSE) to see the full text.
+
+## Support
+
+This collection is [Ansible Validated Content](https://access.redhat.com/articles/3166901). It is reviewed and tested by Red Hat but is not supported under a Red Hat SLA. For reporting issues and requesting improvements, file an issue at the [AAP Configuration repository](https://github.com/redhat-cop/infra.aap_configuration/issues). Community help is also available on the [Ansible Forum](https://forum.ansible.com/tag/infra-config-as-code).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ collections:
 
 |                                      Collection Name                                                  |                      Purpose                      |
 |:-----------------------------------------------------------------------------------------------------:|:-------------------------------------------------:|
-| [AAP <= 2.4 Controller Configuration](https://github.com/redhat-cop/infra.controller_configuration) | Automation controller configuration       |
+| [AAP <= 2.4 Controller Configuration](https://github.com/redhat-cop/infra.controller_configuration)   | Automation controller configuration               |
 | [AAP Configuration Extended](https://github.com/redhat-cop/aap_configuration_extended)                | Where other useful roles that don't fit here live |
 | [EE Utilities](https://github.com/redhat-cop/ee_utilities)                                            | Execution Environment creation utilities          |
 | [AAP installation Utilities](https://github.com/redhat-cop/aap_utilities)                             | Ansible Automation Platform Utilities             |

--- a/changelogs/fragments/certification-review-readme.yaml
+++ b/changelogs/fragments/certification-review-readme.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - README - Standardized collection links tables and added Support section for certification review.


### PR DESCRIPTION
## Summary
- Add missing "AAP <= 2.4 Controller Configuration" entry to the validated collections links table
- Standardize "Github" to "GitHub" casing in workflow links
- Add Support section clarifying this is Ansible Validated Content (not certified), directing users to the GitHub issue tracker and community forum

## Changes
- `README.md`: Updated "Links to other Validated Configuration Collections" table, added Support section
- `changelogs/fragments/certification-review-readme.yaml`: Changelog fragment

## Test plan
- [ ] Pre-commit checks pass
- [ ] Changelog fragment added in `changelogs/fragments/`
- [ ] README renders correctly on GitHub


Made with [Cursor](https://cursor.com)