### PR TITLE
fix(controller_license): fix subscription lookup routing and add service account support

### DIFF
--- a/changelogs/fragments/1214-controller-license-lookup.yml
+++ b/changelogs/fragments/1214-controller-license-lookup.yml
@@ -1,0 +1,18 @@
+bugfixes:
+  - >-
+    controller_license - Fixed subscription lookup routing so that ``use_lookup: true``
+    is considered when deciding whether to include the subscription tasks. Previously
+    the role silently did nothing when ``use_lookup`` was set without
+    ``redhat_subscription_username``/``redhat_subscription_password``
+    (https://github.com/redhat-cop/infra.aap_configuration/issues/1214).
+minor_changes:
+  - >-
+    controller_license - Added support for Red Hat service account authentication
+    via ``redhat_subscription_client_id`` and ``redhat_subscription_client_secret``
+    for subscription lookup. Added clear validation error when ``use_lookup`` is
+    enabled but no credentials are provided. Added missing ``use_lookup``,
+    ``filters``, ``list_num``, and ``state`` sub-options to argument specs.
+    Fixed typo in secure logging variable name in argument specs. Added
+    Limitations section to documentation
+    (https://github.com/redhat-cop/infra.aap_configuration/issues/1214).
+...

--- a/roles/controller_license/README.md
+++ b/roles/controller_license/README.md
@@ -4,7 +4,8 @@
 
 An Ansible Role to deploy a license on Ansible Controller.
 
-This will either accept a manifest file, or use redhat subscription account credentials to lookup available subscriptions and use them.
+This will either accept a manifest file, or use Red Hat account credentials to lookup available subscriptions and use them.
+Subscription lookup supports both username/password and service account (client_id/client_secret) authentication.
 
 ## Requirements
 
@@ -22,8 +23,10 @@ ansible-galaxy collection install -r tests/collections/requirements.yml to be in
 |`aap_token`|""|no|Controller Admin User's token on the Ansible Automation Platform Server. This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook. Either username / password or oauthtoken need to be specified.||
 |`aap_request_timeout`|`10`|no|Specify the timeout in seconds Ansible should use in requests to the Ansible Automation Platform host.||
 |`controller_license`|`see below`|yes|Data structure describing your license for controller, described below.||
-|`redhat_subscription_username`|""|no|Red Hat or Red Hat Satellite username to get available subscriptions. Used only for Subscription lookup implementation.||
-|`redhat_subscription_password`|""|no|Red Hat or Red Hat Satellite password to get available subscriptions. Used only for Subscription lookup implementation.||
+|`redhat_subscription_username`|""|no|Red Hat or Red Hat Satellite username to get available subscriptions. Used only for subscription lookup.||
+|`redhat_subscription_password`|""|no|Red Hat or Red Hat Satellite password to get available subscriptions. Used only for subscription lookup.||
+|`redhat_subscription_client_id`|""|no|Red Hat service account client ID to get available subscriptions. Used only for subscription lookup.||
+|`redhat_subscription_client_secret`|""|no|Red Hat service account client secret to get available subscriptions. Used only for subscription lookup.||
 
 ### Secure Logging Variables
 
@@ -62,12 +65,11 @@ The module and this role can use either a manifest file, or lookup the subscript
 
 |Variable Name|Default Value|Required|Type|Description|
 |:---:|:---:|:---:|:---:|:---:|
-|`filters`|"default values"|no|str|dict of filters to use to narrow the subscription. See example below for how to use this.|
-|`support_level`|"Self-Support"|no|str|DEPRECATED - changed to `manifest_file` (still works as an alias)|
-|`list_num`|0|no|int|List index of the subscription to use, if you want to override the default, it is recommended to use the filters to limit the pools found.|
-|`subscription_id`|""|no|str|Red Hat or Red Hat Satellite subscription_id to attach to.|
+|`use_lookup`|`false`|no|bool|Whether or not to lookup subscriptions. Requires either `redhat_subscription_username`/`redhat_subscription_password` or `redhat_subscription_client_id`/`redhat_subscription_client_secret` to be set.|
+|`filters`|`see below`|no|dict|Dict of filters to narrow the subscription lookup results. Defaults to `product_name: "Red Hat Ansible Automation Platform"` and `support_level: "Self-Support"`.|
+|`list_num`|0|no|int|List index of the subscription to use from lookup results. It is recommended to use filters to limit the results instead.|
+|`subscription_id`|""|no|str|Red Hat or Red Hat Satellite subscription_id to attach to. When provided, the subscription lookup is skipped.|
 |`force`|`false`|no|bool|By default, the license will only be applied if controller is currently unlicensed or trial licensed. When force=true, the license is always applied.|
-|`use_lookup`|`false`|no|bool|Whether or not to lookup subscriptions.|
 |`state`|`present`|no|str|Desired state of the resource.|
 
 ### Standard License Data Structure
@@ -120,7 +122,7 @@ controller_license:
     - {role: infra.aap_configuration.controller_license, when: controller_license is defined}
 ```
 
-### Standard Subscription lookup Role Usage
+### Subscription Lookup with Username/Password
 
 ```yaml
 ---
@@ -142,6 +144,35 @@ controller_license:
   roles:
     - {role: infra.aap_configuration.controller_license}
 ```
+
+### Subscription Lookup with Service Account
+
+```yaml
+---
+- name: Playbook to configure ansible controller post installation
+  hosts: localhost
+  connection: local
+  vars:
+    aap_validate_certs: false
+    aap_hostname: aap.example.com
+    aap_username: admin
+    aap_password: changeme
+    redhat_subscription_client_id: "c6bd7594-d776-46e5-8156-6d17af147479"
+    redhat_subscription_client_secret: "MO9QUvoOZ5fc5JQKXoTch1AsTLI7nFsZ"
+    controller_license:
+      use_lookup: true
+      filters:
+        product_name: "Red Hat Ansible Automation Platform"
+        support_level: "Standard"
+  roles:
+    - {role: infra.aap_configuration.controller_license}
+```
+
+## Limitations
+
+- The subscription lookup (`use_lookup: true`) requires Red Hat credentials to be provided as separate variables (`redhat_subscription_username`/`redhat_subscription_password` or `redhat_subscription_client_id`/`redhat_subscription_client_secret`), not inside the `controller_license` dict.
+- The `client_id`/`client_secret` service account parameters require `ansible.controller` collection version 4.6+ (or the equivalent `awx.awx` version that includes service account support in the `subscriptions` module).
+- The `filters` option performs client-side filtering on the subscription list returned by the Red Hat API. If no subscriptions match the filters, the role will fail when attempting to access the subscription at the index specified by `list_num`.
 
 ## License
 

--- a/roles/controller_license/defaults/main.yml
+++ b/roles/controller_license/defaults/main.yml
@@ -1,5 +1,13 @@
 ---
 controller_configuration_license_secure_logging: "{{ aap_configuration_secure_logging | default('false') }}"
+
+# Red Hat credential variables for subscription lookup
+# Either username/password or client_id/client_secret must be provided when use_lookup is true
+# redhat_subscription_username:
+# redhat_subscription_password:
+# redhat_subscription_client_id:
+# redhat_subscription_client_secret:
+
 _redhat_cop_license_filters:
   product_name: Red Hat Ansible Automation Platform
   support_level: Self-Support

--- a/roles/controller_license/meta/argument_specs.yml
+++ b/roles/controller_license/meta/argument_specs.yml
@@ -28,13 +28,35 @@ argument_specs:
             required: false
             type: str
             description: Red Hat or Red Hat Satellite subscription_id to attach to
+          use_lookup:
+            default: false
+            required: false
+            type: bool
+            description: Whether or not to lookup subscriptions using Red Hat credentials.
+          filters:
+            required: false
+            type: dict
+            description: Dict of filters to narrow the subscription lookup results.
+          list_num:
+            default: 0
+            required: false
+            type: int
+            description: List index of the subscription to use from lookup results.
           force:
             default: false
             required: false
             type: bool
             description: By default, the license manifest will only be applied if controller is currently unlicensed or trial licensed. When force=true, the license is always applied.
+          state:
+            default: present
+            required: false
+            type: str
+            choices:
+              - present
+              - absent
+            description: Desired state of the resource.
 
-      # Variables used for Liscense lookup
+      # Variables used for License lookup (username/password or client_id/client_secret)
       redhat_subscription_username:
         default: None
         required: false
@@ -45,9 +67,19 @@ argument_specs:
         required: false
         type: str
         description: Red Hat or Red Hat Satellite password to get available subscriptions.
+      redhat_subscription_client_id:
+        default: None
+        required: false
+        type: str
+        description: Red Hat service account client ID to get available subscriptions.
+      redhat_subscription_client_secret:
+        default: None
+        required: false
+        type: str
+        description: Red Hat service account client secret to get available subscriptions.
 
       # No_log variables
-      controller_configuration_labels_secure_logging:
+      controller_configuration_license_secure_logging:
         default: "{{ aap_configuration_secure_logging | default(false) }}"
         required: false
         type: bool

--- a/roles/controller_license/tasks/main.yml
+++ b/roles/controller_license/tasks/main.yml
@@ -9,5 +9,9 @@
 - name: Use subscription id or subscription lookup
   ansible.builtin.include_tasks: subscription.yml
   when:
-    - (redhat_subscription_username is defined and redhat_subscription_password is defined) or controller_license.subscription_id is defined
+    - >-
+      (redhat_subscription_username is defined and redhat_subscription_password is defined)
+      or (redhat_subscription_client_id is defined and redhat_subscription_client_secret is defined)
+      or controller_license.subscription_id is defined
+      or (controller_license.use_lookup | default(false))
 ...

--- a/roles/controller_license/tasks/subscription.yml
+++ b/roles/controller_license/tasks/subscription.yml
@@ -1,10 +1,26 @@
 ---
 # tasks file for license role - Subscription
 
+- name: subscription | Validate lookup credentials are provided
+  ansible.builtin.assert:
+    that:
+      - >-
+        (redhat_subscription_username is defined and redhat_subscription_password is defined)
+        or (redhat_subscription_client_id is defined and redhat_subscription_client_secret is defined)
+    fail_msg: >-
+      use_lookup is enabled but no Red Hat credentials were provided.
+      Set either redhat_subscription_username/redhat_subscription_password
+      or redhat_subscription_client_id/redhat_subscription_client_secret.
+  when:
+    - controller_license.use_lookup | default(false)
+    - controller_license.subscription_id is not defined
+
 - name: subscription | Get subscriptions with a filter
   ansible.controller.subscriptions:
-    username: "{{ redhat_subscription_username }}"
-    password: "{{ redhat_subscription_password }}"
+    username: "{{ redhat_subscription_username | default(omit) }}"
+    password: "{{ redhat_subscription_password | default(omit) }}"
+    client_id: "{{ redhat_subscription_client_id | default(omit) }}"
+    client_secret: "{{ redhat_subscription_client_secret | default(omit) }}"
     filters: "{{ controller_license.filters | default(_redhat_cop_license_filters) }}"
     # Role Standard Options
     controller_host: "{{ aap_hostname | default(omit, true) }}"
@@ -15,8 +31,8 @@
     validate_certs: "{{ aap_validate_certs | default(omit) }}"
   register: subscription
   when:
-    - "'use_lookup' in controller_license"
-    - controller_license.use_lookup
+    - controller_license.use_lookup | default(false)
+    - controller_license.subscription_id is not defined
 
 - name: subscription | Install the Controller license
   ansible.controller.license:


### PR DESCRIPTION
## Summary

- Fixed subscription lookup routing so that `use_lookup: true` actually triggers the subscription tasks. Previously the role silently did nothing when `use_lookup` was set without `redhat_subscription_username`/`redhat_subscription_password`.
- Added explicit validation that fails with a clear error message when `use_lookup` is enabled but no credentials are provided.
- Added support for Red Hat service account authentication via `redhat_subscription_client_id`/`redhat_subscription_client_secret` as an alternative to username/password.
- Added missing `use_lookup`, `filters`, `list_num`, and `state` sub-options to `argument_specs.yml`.
- Fixed `controller_configuration_labels_secure_logging` typo in argument specs (should be `controller_configuration_license_secure_logging`).
- Documented limitations and added a service account playbook example to the README.

Relates to #1214

## Test plan

- [ ] Verify role fails with a clear message when `use_lookup: true` is set but no Red Hat credentials are provided
- [ ] Verify subscription lookup works with `redhat_subscription_username`/`redhat_subscription_password`
- [ ] Verify subscription lookup works with `redhat_subscription_client_id`/`redhat_subscription_client_secret`
- [ ] Verify role still works with `subscription_id` provided directly (lookup should be skipped)
- [ ] Verify manifest flow is unaffected
- [ ] Verify `ansible-lint` passes on changed files


Made with [Cursor](https://cursor.com)