### PR TITLE
[AUTO] Update changelog 4.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ infra.aap\_configuration Release Notes
 
 .. contents:: Topics
 
+v4.5.0
+======
+
+Minor Changes
+-------------
+
+- README - Standardized collection links tables and added Support section for certification review.
+
+Bugfixes
+--------
+
+- Tags used across filetree_read/object_diff (aap_configuration_extended) and dispatch (this collection) were inconsistent (e.g. eda_credentials vs credential, hub_namespaces vs namespaces, controller_credentials vs credentials).
+- eda_projects, eda_credentials, eda_credential_types, eda_decision_environments, eda_event_streams, eda_rulebook_activations, eda_users - Fixed roles to honor the global ``platform_state`` variable, making them consistent with other AAP configuration roles (https://github.com/redhat-cop/infra.aap_configuration/issues/1319).
+
 v4.4.0
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -349,4 +349,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 4.4.0
+version: 4.5.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1129,3 +1129,21 @@ releases:
     - trivial.yml
     - update_gateway_role_definitions_readme.yml
     release_date: '2026-04-15'
+  4.5.0:
+    changes:
+      bugfixes:
+      - Tags used across filetree_read/object_diff (aap_configuration_extended) and
+        dispatch (this collection) were inconsistent (e.g. eda_credentials vs credential,
+        hub_namespaces vs namespaces, controller_credentials vs credentials).
+      - eda_projects, eda_credentials, eda_credential_types, eda_decision_environments,
+        eda_event_streams, eda_rulebook_activations, eda_users - Fixed roles to honor
+        the global ``platform_state`` variable, making them consistent with other
+        AAP configuration roles (https://github.com/redhat-cop/infra.aap_configuration/issues/1319).
+      minor_changes:
+      - README - Standardized collection links tables and added Support section for
+        certification review.
+    fragments:
+    - 1348-fix-eda-platform-state.yml
+    - 1350.yaml
+    - certification-review-readme.yaml
+    release_date: '2026-05-15'

--- a/changelogs/fragments/1348-fix-eda-platform-state.yml
+++ b/changelogs/fragments/1348-fix-eda-platform-state.yml
@@ -1,6 +1,0 @@
-bugfixes:
-  - >-
-    eda_projects, eda_credentials, eda_credential_types, eda_decision_environments,
-    eda_event_streams, eda_rulebook_activations, eda_users - Fixed roles to honor the
-    global ``platform_state`` variable, making them consistent with other AAP
-    configuration roles (https://github.com/redhat-cop/infra.aap_configuration/issues/1319).

--- a/changelogs/fragments/1350.yaml
+++ b/changelogs/fragments/1350.yaml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - Tags used across filetree_read/object_diff (aap_configuration_extended) and dispatch (this collection) were inconsistent (e.g. eda_credentials vs credential, hub_namespaces vs namespaces, controller_credentials vs credentials).
-...

--- a/changelogs/fragments/certification-review-readme.yaml
+++ b/changelogs/fragments/certification-review-readme.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - README - Standardized collection links tables and added Support section for certification review.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: infra
 name: aap_configuration
-version: 4.4.0
+version: 4.5.0
 description: A collection of roles to manage Ansible Controller
 readme: README.md
 authors:


### PR DESCRIPTION
## What's Changed
* ci: improve release workflow reliability and pre-commit CI by @djdanielsson in https://github.com/redhat-cop/infra.aap_configuration/pull/1337
* [AUTO] Update changelog 4.4.0 by @djdanielsson in https://github.com/redhat-cop/infra.aap_configuration/pull/1338
* ci: fix release skip chain, add sanity, remove update_pre_commit by @djdanielsson in https://github.com/redhat-cop/infra.aap_configuration/pull/1339
* Fix: "controller_hosts" role ignores "enabled: false" and enables host unconditionally. by @nikhjain14 in https://github.com/redhat-cop/infra.aap_configuration/pull/1346
* docs(readme): standardize links and add Support section by @djdanielsson in https://github.com/redhat-cop/infra.aap_configuration/pull/1353
* fix(dispatch): add prefixed tags for alignment with extended collections (#1350) by @djdanielsson in https://github.com/redhat-cop/infra.aap_configuration/pull/1352
* Fix EDA roles to honor global platform_state variable. by @nikhjain14 in https://github.com/redhat-cop/infra.aap_configuration/pull/1348
* Bump https://github.com/DavidAnson/markdownlint-cli2 from v0.22.0 to 0.22.1 by @dependabot[bot] in https://github.com/redhat-cop/infra.aap_configuration/pull/1349

## New Contributors
* @nikhjain14 made their first contribution in https://github.com/redhat-cop/infra.aap_configuration/pull/1346

**Full Changelog**: https://github.com/redhat-cop/infra.aap_configuration/compare/4.4.0...4.5.0