### PR TITLE
fix(dispatch): run hub_collection after hub_collection_repository

### DIFF
--- a/changelogs/fragments/1361-hub-collection-dispatch-order.yml
+++ b/changelogs/fragments/1361-hub-collection-dispatch-order.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - dispatch - Run hub_collection after hub_collection_repository so collections referencing a repository distribution are created successfully (https://github.com/redhat-cop/infra.aap_configuration/issues/1361)
+...

--- a/roles/dispatch/README.md
+++ b/roles/dispatch/README.md
@@ -198,9 +198,6 @@ hub_configuration_dispatcher_roles:
   - role: hub_namespace
     var: hub_namespaces
     tags: namespaces
-  - role: hub_collection
-    var: hub_collections
-    tags: collections
   - role: hub_ee_registry
     var: hub_ee_registries
     tags: registries
@@ -231,6 +228,9 @@ hub_configuration_dispatcher_roles:
   - role: hub_collection_repository_sync
     var: hub_collection_repositories
     tags: collectionsrepsync
+  - role: hub_collection
+    var: hub_collections
+    tags: collections
 ```
 
 #### Controller Roles

--- a/roles/dispatch/defaults/main.yml
+++ b/roles/dispatch/defaults/main.yml
@@ -93,11 +93,6 @@ hub_configuration_dispatcher_roles:
     tags:
       - namespaces
       - hub_namespaces
-  - role: hub_collection
-    var: hub_collections
-    tags:
-      - collections
-      - hub_collections
   - role: hub_ee_registry
     var: hub_ee_registries
     tags:
@@ -143,6 +138,11 @@ hub_configuration_dispatcher_roles:
     tags:
       - collectionsrepsync
       - hub_collection_repository_sync
+  - role: hub_collection
+    var: hub_collections
+    tags:
+      - collections
+      - hub_collections
 
 hub_configuration_dispatcher_roles_publish:
   - role: hub_publish

--- a/roles/dispatch/meta/argument_specs.yml
+++ b/roles/dispatch/meta/argument_specs.yml
@@ -96,11 +96,6 @@ argument_specs:
             tags:
               - namespaces
               - hub_namespaces
-          - role: hub_collection
-            var: hub_collections
-            tags:
-              - collections
-              - hub_collections
           - role: hub_ee_registry
             var: hub_ee_registries
             tags:
@@ -149,6 +144,11 @@ argument_specs:
             tags:
               - collectionsrepsync
               - hub_collection_repository_sync
+          - role: hub_collection
+            var: hub_collections
+            tags:
+              - collections
+              - hub_collections
 
       controller_configuration_dispatcher_roles:
         default:


### PR DESCRIPTION
## Summary

- Fixes incorrect processing order in `hub_configuration_dispatcher_roles` where `hub_collection` ran before `hub_collection_repository`
- Collections that reference a repository distribution now succeed because the repository is created first

## Changes

- Move `hub_collection` to run after `hub_collection_repository` and `hub_collection_repository_sync` in `roles/dispatch/defaults/main.yml`
- Update matching documentation in `roles/dispatch/README.md` and `roles/dispatch/meta/argument_specs.yml`
- Add changelog fragment for the bugfix

## Test plan

- [ ] `ansible-lint` passes on changed files
- [ ] Run dispatch role with `hub_collection_repositories` and `hub_collections` where the collection references the repository (issue #1361 reproduction case)
- [ ] Verify collection upload succeeds without "Distribution does not exist" error

resolves #1361

Made with [Cursor](https://cursor.com)