### PR TITLE
Feature/support new_name and roles parameters in controller roles integration

### DIFF
--- a/changelogs/fragments/1376-support-new-name-in-controller-roles-integration.yaml
+++ b/changelogs/fragments/1376-support-new-name-in-controller-roles-integration.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - "Fix inline role assignments when ``new_name`` is specified on controller resources. Now uses the new name for role assignment."
+  - "Prevent inline role assignments from being applied to pre-existing objects when the resource creation/update fails during a ``new_name`` operation."
+...

--- a/roles/controller_credentials/tasks/main.yml
+++ b/roles/controller_credentials/tasks/main.yml
@@ -82,13 +82,14 @@
   vars:
     controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
     _item_list: "{{ credentials if credentials is defined else controller_credentials }}"
+    _failed_items: "{{ aap_configuration_role_errors['controller_credentials_errors'] | default([]) | map(attribute='name') | list }}"
     _controller_roles: |
       {% for _item in _item_list %}
-      {% if _item.roles is defined and (_item.state | default(platform_state | default('present'))) != 'absent' %}
+      {% if (_item.roles is defined) and ((_item.state | default(platform_state | default('present'))) != 'absent') and (_item.name not in _failed_items) %}
       {% for _role in _item.roles.keys() %}
       - role: "{{ _role }}"
         credentials:
-          - "{{ _item.name }}"
+          - "{{ _item.new_name | default(_item.name) }}"
         teams: "{{ _item.roles[_role].teams | default(omit) }}"
         users: "{{ _item.roles[_role].users | default(omit) }}"
       {% endfor %}

--- a/roles/controller_instance_groups/tasks/main.yml
+++ b/roles/controller_instance_groups/tasks/main.yml
@@ -85,13 +85,14 @@
   vars:
     controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
     _item_list: "{{ controller_instance_groups }}"
+    _failed_items: "{{ aap_configuration_role_errors['controller_instance_groups_errors'] | default([]) | map(attribute='name') | list }}"
     _controller_roles: |
       {% for _item in _item_list %}
-      {% if _item.roles is defined and (_item.state | default(platform_state | default('present'))) != 'absent' %}
+      {% if (_item.roles is defined) and ((_item.state | default(platform_state | default('present'))) != 'absent') and (_item.name not in _failed_items) %}
       {% for _role in _item.roles.keys() %}
       - role: "{{ _role }}"
         instance_groups:
-          - "{{ _item.name }}"
+          - "{{ _item.new_name | default(_item.name) }}"
         teams: "{{ _item.roles[_role].teams | default(omit) }}"
         users: "{{ _item.roles[_role].users | default(omit) }}"
       {% endfor %}

--- a/roles/controller_inventories/tasks/main.yml
+++ b/roles/controller_inventories/tasks/main.yml
@@ -84,15 +84,16 @@
   vars:
     controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
     _item_list: "{{ inventory if inventory is defined else controller_inventories }}"
+    _failed_items: "{{ aap_configuration_role_errors['controller_inventories_errors'] | default([]) | map(attribute='name') | list }}"
     _controller_roles: |
       {% for _item in _item_list %}
-      {% if _item.roles is defined and (_item.state | default(platform_state | default('present'))) != 'absent' %}
+      {% if (_item.roles is defined) and ((_item.state | default(platform_state | default('present'))) != 'absent') and (_item.name not in _failed_items) %}
       {% for _role in _item.roles.keys() %}
       - role: "{{ _role }}"
         inventories:
-          - "{{ _item.name }}"
-        teams: {{ _item.roles[_role].teams | default(omit) | to_json }}
-        users: {{ _item.roles[_role].users | default(omit) | to_json }}
+          - "{{ _item.new_name | default(_item.name) }}"
+        teams: {{ _item.roles[_role].teams | default(omit) }}
+        users: {{ _item.roles[_role].users | default(omit) }}
       {% endfor %}
       {% endif %}
       {% endfor %}

--- a/roles/controller_job_templates/tasks/main.yml
+++ b/roles/controller_job_templates/tasks/main.yml
@@ -126,15 +126,16 @@
   vars:
     controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
     _item_list: "{{ job_templates if job_templates is defined else controller_templates }}"
+    _failed_items: "{{ aap_configuration_role_errors['controller_job_templates_errors'] | default([]) | map(attribute='name') | list }}"
     _controller_roles: |
       {% for _item in _item_list %}
-      {% if _item.roles is defined and (_item.state | default(platform_state | default('present'))) != 'absent' %}
+      {% if (_item.roles is defined) and ((_item.state | default(platform_state | default('present'))) != 'absent') and (_item.name not in _failed_items) %}
       {% for _role in _item.roles.keys() %}
       - role: "{{ _role }}"
         job_templates:
-          - "{{ _item.name }}"
-        teams: {{ _item.roles[_role].teams | default(omit) | to_json }}
-        users: {{ _item.roles[_role].users | default(omit) | to_json }}
+          - "{{ _item.new_name | default(_item.name) }}"
+        teams: {{ _item.roles[_role].teams | default(omit) }}
+        users: {{ _item.roles[_role].users | default(omit) }}
       {% endfor %}
       {% endif %}
       {% endfor %}

--- a/roles/controller_projects/tasks/main.yml
+++ b/roles/controller_projects/tasks/main.yml
@@ -99,13 +99,14 @@
   vars:
     controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
     _item_list: "{{ projects if projects is defined else controller_projects }}"
+    _failed_items: "{{ aap_configuration_role_errors['controller_projects_errors'] | default([]) | map(attribute='name') | list }}"
     _controller_roles: |
       {% for _item in _item_list %}
-      {% if _item.roles is defined and (_item.state | default(platform_state | default('present'))) != 'absent' %}
+      {% if (_item.roles is defined) and ((_item.state | default(platform_state | default('present'))) != 'absent') and (_item.name not in _failed_items) %}
       {% for _role in _item.roles.keys() %}
       - role: "{{ _role }}"
         projects:
-          - "{{ _item.name }}"
+          - "{{ _item.new_name | default(_item.name) }}"
         teams: "{{ _item.roles[_role].teams | default(omit) }}"
         users: "{{ _item.roles[_role].users | default(omit) }}"
       {% endfor %}

--- a/roles/controller_workflow_job_templates/tasks/main.yml
+++ b/roles/controller_workflow_job_templates/tasks/main.yml
@@ -123,15 +123,16 @@
   vars:
     controller_roles: "{{ _controller_roles | from_yaml | default([], true) | list }}"
     _item_list: "{{ workflow_job_templates if workflow_job_templates is defined else controller_workflows }}"
+    _failed_items: "{{ aap_configuration_role_errors['controller_workflows_errors'] | default([]) | map(attribute='name') | list }}"
     _controller_roles: |
       {% for _item in _item_list %}
-      {% if _item.roles is defined and (_item.state | default(platform_state | default('present'))) != 'absent' %}
+      {% if (_item.roles is defined) and ((_item.state | default(platform_state | default('present'))) != 'absent') and (_item.name not in _failed_items) %}
       {% for _role in _item.roles.keys() %}
       - role: "{{ _role }}"
         workflows:
-          - "{{ _item.name }}"
-        teams: {{ _item.roles[_role].teams | default(omit) | to_json }}
-        users: {{ _item.roles[_role].users | default(omit) | to_json }}
+          - "{{ _item.new_name | default(_item.name) }}"
+        teams: {{ _item.roles[_role].teams | default(omit) }}
+        users: {{ _item.roles[_role].users | default(omit) }}
       {% endfor %}
       {% endif %}
       {% endfor %}


### PR DESCRIPTION
When new_name is utilized in conjunction with controller_roles, an error will be thrown indicating that the target for controller_roles does not exist. This is because the target object is renamed. Need to make sure that if there was already an object with the new_name and the preceding creation/update task fails, that controller_roles are not applied to the preexisting object leading to a potential security issue

# What does this PR do?

Adds support for using `new_name` attribute in conjunction with `roles` attribute across all 6 resource types that support both features.

**Primary Fix:**
When a resource is renamed using `new_name`, the roles integration now correctly references the new name instead of the old name, preventing "target does not exist" errors.

**Secondary Fix (Security):**
Added filtering to prevent roles from being assigned to wrong resources when creation fails but error collection mode (`aap_configuration_collect_logs: true`) is enabled.

**Changes:**
- Updated roles integration in 6 controller roles to use `{{ _item.new_name | default(_item.name) }}`
- Added `_failed_items` filtering to skip failed resources when assigning roles

## How should this be tested?

1. Create an object with roles and then attempt to rename it with new_name. This should no longer throw an error.
2. Create an object with new_name and then try to rename a second object with roles to match it. This should throw an error and the object with the target name should not have roles applied to it.