### PR TITLE
fix: skip inline role assignments when object state is absent

### DIFF
--- a/changelogs/fragments/1377_skip_roles_on_absent.yml
+++ b/changelogs/fragments/1377_skip_roles_on_absent.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Skip inline role assignments when the parent object has state absent.
+...

--- a/roles/controller_credentials/tasks/main.yml
+++ b/roles/controller_credentials/tasks/main.yml
@@ -84,7 +84,7 @@
     _item_list: "{{ credentials if credentials is defined else controller_credentials }}"
     _controller_roles: |
       {% for _item in _item_list %}
-      {% if _item.roles is defined %}
+      {% if _item.roles is defined and (_item.state | default(platform_state | default('present'))) != 'absent' %}
       {% for _role in _item.roles.keys() %}
       - role: "{{ _role }}"
         credentials:

--- a/roles/controller_instance_groups/tasks/main.yml
+++ b/roles/controller_instance_groups/tasks/main.yml
@@ -87,7 +87,7 @@
     _item_list: "{{ controller_instance_groups }}"
     _controller_roles: |
       {% for _item in _item_list %}
-      {% if _item.roles is defined %}
+      {% if _item.roles is defined and (_item.state | default(platform_state | default('present'))) != 'absent' %}
       {% for _role in _item.roles.keys() %}
       - role: "{{ _role }}"
         instance_groups:

--- a/roles/controller_inventories/tasks/main.yml
+++ b/roles/controller_inventories/tasks/main.yml
@@ -86,7 +86,7 @@
     _item_list: "{{ inventory if inventory is defined else controller_inventories }}"
     _controller_roles: |
       {% for _item in _item_list %}
-      {% if _item.roles is defined %}
+      {% if _item.roles is defined and (_item.state | default(platform_state | default('present'))) != 'absent' %}
       {% for _role in _item.roles.keys() %}
       - role: "{{ _role }}"
         inventories:

--- a/roles/controller_job_templates/tasks/main.yml
+++ b/roles/controller_job_templates/tasks/main.yml
@@ -128,7 +128,7 @@
     _item_list: "{{ job_templates if job_templates is defined else controller_templates }}"
     _controller_roles: |
       {% for _item in _item_list %}
-      {% if _item.roles is defined %}
+      {% if _item.roles is defined and (_item.state | default(platform_state | default('present'))) != 'absent' %}
       {% for _role in _item.roles.keys() %}
       - role: "{{ _role }}"
         job_templates:

--- a/roles/controller_projects/tasks/main.yml
+++ b/roles/controller_projects/tasks/main.yml
@@ -101,7 +101,7 @@
     _item_list: "{{ projects if projects is defined else controller_projects }}"
     _controller_roles: |
       {% for _item in _item_list %}
-      {% if _item.roles is defined %}
+      {% if _item.roles is defined and (_item.state | default(platform_state | default('present'))) != 'absent' %}
       {% for _role in _item.roles.keys() %}
       - role: "{{ _role }}"
         projects:

--- a/roles/controller_workflow_job_templates/tasks/main.yml
+++ b/roles/controller_workflow_job_templates/tasks/main.yml
@@ -125,7 +125,7 @@
     _item_list: "{{ workflow_job_templates if workflow_job_templates is defined else controller_workflows }}"
     _controller_roles: |
       {% for _item in _item_list %}
-      {% if _item.roles is defined %}
+      {% if _item.roles is defined and (_item.state | default(platform_state | default('present'))) != 'absent' %}
       {% for _role in _item.roles.keys() %}
       - role: "{{ _role }}"
         workflows:


### PR DESCRIPTION
## Summary

Fixes #1377

- When an object has both `roles:` and `state: absent`, inline role assignments are now skipped instead of failing by trying to assign roles to a deleted object.
- Adds a state guard (`!= 'absent'`) to the Jinja2 template in all six affected controller roles: `controller_credentials`, `controller_projects`, `controller_job_templates`, `controller_inventories`, `controller_instance_groups`, and `controller_workflow_job_templates`.
- The state resolution (`_item.state | default(platform_state | default('present'))`) mirrors how state is already resolved in each role's module task.

## Test plan

- [ ] Define a credential (or other supported object) with both `roles:` and `state: absent`, verify the playbook no longer fails
- [ ] Define an object with `roles:` and `state: present` (or no state), verify roles are still applied as before
- [ ] Set `platform_state: absent` globally with objects that have `roles:` defined, verify roles are skipped for all of them


Made with [Cursor](https://cursor.com)