### PR TITLE
add missing rename of controller_teams to aap_teams

### DIFF
--- a/docs/CONVERSION_GUIDE.md
+++ b/docs/CONVERSION_GUIDE.md
@@ -84,7 +84,7 @@ gateway_configuration vars:
 - gateway_services
 - gateway_role_user_assignments
 - gateway_routes
-- aap_teams
+- aap_teams <- controller_teams
 
 ah_configuration vars:
 


### PR DESCRIPTION
# What does this PR do?

There is a missing conversion mapping from controller_teams to aap_teams. The controller_teams was part of controller for 2.4, but the corresponding 2.5+ object is gateway's aap_teams

## How should this be tested?

No testing needed? Validate that this is the proper mapping.

## Is there a relevant Issue open for this?

No