### PR TITLE
Updating controller_hosts_groups documentaiton and arguments to match code

### DIFF
--- a/changelogs/fragments/1380-host-groups-documentation-and-argument-update.yml
+++ b/changelogs/fragments/1380-host-groups-documentation-and-argument-update.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - Updates documentation for host groups to use the variable names in the controller_host_groups role
+  - Updates argument_specs for host groups to use the variable names in the controller_host_groups role
+...

--- a/roles/controller_host_groups/README.md
+++ b/roles/controller_host_groups/README.md
@@ -44,11 +44,11 @@ Enabling this will enforce configuration without specifying every option in the 
 The following Variables complement each other.
 If Both variables are not set, secure logging defaults to false.
 The role defaults to false as normally the add groups task does not include sensitive information.
-controller_configuration_groups_secure_logging defaults to the value of aap_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.
+controller_configuration_group_secure_logging defaults to the value of aap_configuration_secure_logging if it is not explicitly called. This allows for secure logging to be toggled for the entire suite of configuration roles with a single variable, or for the user to selectively use it.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
-|`controller_configuration_groups_secure_logging`|`false`|no|Whether or not to include the sensitive Group role tasks in the log.  Set this value to `true` if you will be providing your sensitive values from elsewhere.|
+|`controller_configuration_group_secure_logging`|`false`|no|Whether or not to include the sensitive Group role tasks in the log.  Set this value to `true` if you will be providing your sensitive values from elsewhere.|
 |`aap_configuration_secure_logging`|`false`|no|This variable enables secure logging as well, but is shared across multiple roles, see above.|
 
 ### Asynchronous Retry Variables
@@ -61,9 +61,9 @@ This also speeds up the overall role.
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
 |`aap_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
-|`controller_configuration_groups_async_retries`|`{{ aap_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
+|`controller_configuration_group_async_retries`|`{{ aap_configuration_async_retries }}`|no|This variable sets the number of retries to attempt for the role.|
 |`aap_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
-|`controller_configuration_groups_async_delay`|`aap_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`controller_configuration_group_async_delay`|`aap_configuration_async_delay`|no|This sets the delay between retries for the role.|
 |`aap_configuration_loop_delay`|0|no|This sets the pause between each item in the loop for the roles globally. To help when API is getting overloaded.|
 |`controller_configuration_group_loop_delay`|`aap_configuration_loop_delay`|no|This sets the pause between each item in the loop for the role. To help when API is getting overloaded.|
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|

--- a/roles/controller_host_groups/meta/argument_specs.yml
+++ b/roles/controller_host_groups/meta/argument_specs.yml
@@ -55,7 +55,7 @@ argument_specs:
 #            description: Desired state of the resource.
 
       # Async variables
-      controller_configuration_groups_async_retries:
+      controller_configuration_group_async_retries:
         default: "{{ aap_configuration_async_retries | default(50) }}"
         required: false
         description: This variable sets the number of retries to attempt for the role.
@@ -63,7 +63,7 @@ argument_specs:
         default: 50
         required: false
         description: This variable sets number of retries across all roles as a default.
-      controller_configuration_groups_async_delay:
+      controller_configuration_group_async_delay:
         default: "{{ aap_configuration_async_delay | default(1) }}"
         required: false
         description: This variable sets delay between retries for the role.
@@ -77,7 +77,7 @@ argument_specs:
         description: Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
-      controller_configuration_groups_secure_logging:
+      controller_configuration_group_secure_logging:
         default: "{{ aap_configuration_secure_logging | default(false) }}"
         required: false
         type: bool


### PR DESCRIPTION
# What does this PR do?

Updates the Documentation on the controller_hosts_groups role to match whats in the code and updates the arguments_specs.yml in the same to match

## How should this be tested?

If applicable, using this module add hosts to groups amd make sure that the secure logging values are respected.  (shouldnt be any changes though as it was documentaiton changes. 

## Is there a relevant Issue open for this?

Not that I see. I jsut notices this and it looked like something that I could fix.

resolves #[number]

## Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
