### PR TITLE
Fix - Setting state absent on workflow with nodes defined fails

### DIFF
--- a/changelogs/fragments/support-state-absent-on-fully-defined-workflows.yml
+++ b/changelogs/fragments/support-state-absent-on-fully-defined-workflows.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "Setting state: absent on a fully defined workflow with nodes defined will no longer throw an error."
+...

--- a/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml
+++ b/roles/controller_workflow_job_templates/tasks/add_workflows_schema.yml
@@ -45,6 +45,7 @@
         loop_var: __workflow_loop_node_item
         label: "{{ __workflow_loop_item.name }}/{{ __workflow_loop_node_item.identifier }}"
         pause: "{{ controller_configuration_workflow_job_templates_loop_delay }}"
+      when: "(__workflow_loop_item.state | default(platform_state | default('present'))) is match('present')"
       async: "{{ ansible_check_mode | ternary(0, 1000) }}"
       poll: 0
       register: __workflows_node_async


### PR DESCRIPTION
# What does this PR do?

I should be able to define a full workflow object including nodes and then be able to simply flip the state flag to absent to remove it. Currently, if I set the state flag to absent, the relevant workflow role will still try to update the nodes causing failures since the parent workflow simply does not exist.

This fix adds a conditional to the node update, making sure that state: present appears on the parent workflow before attempting to do a node update operation.

## How should this be tested?

On a new cluster the following playbook can be used to test the fix and replicate the error. 

```
- name: Testing state absent bug for workflows with nodes defined
  hosts: localhost
  connection: local
  become: false
  gather_facts: false
  vars:
    aap_hostname: <OMITTED>
    aap_username: <OMITTED>
    aap_password: <OMITTED>
    controller_workflows:
      - name: Testing
        state: absent
        organization: Default
        inventory: Demo Inventory
        simplified_workflow_nodes:
          - identifier: Test Node
            unified_job_template: Demo Job Template
            lookup_organization: Default
  roles:
    - infra.aap_configuration.dispatch
```

## Is there a relevant Issue open for this?

N/A

## Other Relevant info, PRs, etc

N/A
