### PR TITLE
Fix YAML parsing failure for inline object roles with lookup_organization

### DIFF
--- a/changelogs/fragments/1382-inline-object-roles-yaml-indentation.yml
+++ b/changelogs/fragments/1382-inline-object-roles-yaml-indentation.yml
@@ -1,3 +1,4 @@
 bugfixes:
   - Fix YAML parsing failure when applying inline object roles with lookup_organization.
+  - Fix inline object role assignments for credentials, projects, and instance groups by removing quotes around teams and users so they render as YAML lists, preventing failures on Ansible 2.20.
 ...

--- a/changelogs/fragments/1382-inline-object-roles-yaml-indentation.yml
+++ b/changelogs/fragments/1382-inline-object-roles-yaml-indentation.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix YAML parsing failure when applying inline object roles with lookup_organization.
+...

--- a/roles/controller_credentials/tasks/main.yml
+++ b/roles/controller_credentials/tasks/main.yml
@@ -91,8 +91,8 @@
         credentials:
           - "{{ _item.new_name | default(_item.name) }}"
         lookup_organization: {{ _item.organization.name | default(_item.organization) | default(omit) | to_json }}
-        teams: "{{ _item.roles[_role].teams | default(omit) }}"
-        users: "{{ _item.roles[_role].users | default(omit) }}"
+        teams: {{ _item.roles[_role].teams | default(omit) }}
+        users: {{ _item.roles[_role].users | default(omit) }}
       {% endfor %}
       {% endif %}
       {% endfor %}

--- a/roles/controller_credentials/tasks/main.yml
+++ b/roles/controller_credentials/tasks/main.yml
@@ -90,9 +90,7 @@
       - role: "{{ _role }}"
         credentials:
           - "{{ _item.new_name | default(_item.name) }}"
-        {% if _item.organization is defined %}
-        lookup_organization: "{{ _item.organization.name | default(_item.organization) }}"
-        {% endif %}
+        lookup_organization: {{ _item.organization.name | default(_item.organization) | default(omit) | to_json }}
         teams: "{{ _item.roles[_role].teams | default(omit) }}"
         users: "{{ _item.roles[_role].users | default(omit) }}"
       {% endfor %}

--- a/roles/controller_instance_groups/tasks/main.yml
+++ b/roles/controller_instance_groups/tasks/main.yml
@@ -93,8 +93,8 @@
       - role: "{{ _role }}"
         instance_groups:
           - "{{ _item.new_name | default(_item.name) }}"
-        teams: "{{ _item.roles[_role].teams | default(omit) }}"
-        users: "{{ _item.roles[_role].users | default(omit) }}"
+        teams: {{ _item.roles[_role].teams | default(omit) }}
+        users: {{ _item.roles[_role].users | default(omit) }}
       {% endfor %}
       {% endif %}
       {% endfor %}

--- a/roles/controller_inventories/tasks/main.yml
+++ b/roles/controller_inventories/tasks/main.yml
@@ -92,9 +92,7 @@
       - role: "{{ _role }}"
         inventories:
           - "{{ _item.new_name | default(_item.name) }}"
-        {% if _item.organization is defined %}
-        lookup_organization: "{{ _item.organization.name | default(_item.organization) }}"
-        {% endif %}
+        lookup_organization: {{ _item.organization.name | default(_item.organization) | default(omit) | to_json }}
         teams: {{ _item.roles[_role].teams | default(omit) }}
         users: {{ _item.roles[_role].users | default(omit) }}
       {% endfor %}

--- a/roles/controller_job_templates/tasks/main.yml
+++ b/roles/controller_job_templates/tasks/main.yml
@@ -134,9 +134,7 @@
       - role: "{{ _role }}"
         job_templates:
           - "{{ _item.new_name | default(_item.name) }}"
-        {% if _item.organization is defined %}
-        lookup_organization: "{{ _item.organization.name | default(_item.organization) }}"
-        {% endif %}
+        lookup_organization: {{ _item.organization.name | default(_item.organization) | default(omit) | to_json }}
         teams: {{ _item.roles[_role].teams | default(omit) }}
         users: {{ _item.roles[_role].users | default(omit) }}
       {% endfor %}

--- a/roles/controller_projects/tasks/main.yml
+++ b/roles/controller_projects/tasks/main.yml
@@ -108,8 +108,8 @@
         projects:
           - "{{ _item.new_name | default(_item.name) }}"
         lookup_organization: {{ _item.organization.name | default(_item.organization) | default(omit) | to_json }}
-        teams: "{{ _item.roles[_role].teams | default(omit) }}"
-        users: "{{ _item.roles[_role].users | default(omit) }}"
+        teams: {{ _item.roles[_role].teams | default(omit) }}
+        users: {{ _item.roles[_role].users | default(omit) }}
       {% endfor %}
       {% endif %}
       {% endfor %}

--- a/roles/controller_projects/tasks/main.yml
+++ b/roles/controller_projects/tasks/main.yml
@@ -107,9 +107,7 @@
       - role: "{{ _role }}"
         projects:
           - "{{ _item.new_name | default(_item.name) }}"
-        {% if _item.organization is defined %}
-        lookup_organization: "{{ _item.organization.name | default(_item.organization) }}"
-        {% endif %}
+        lookup_organization: {{ _item.organization.name | default(_item.organization) | default(omit) | to_json }}
         teams: "{{ _item.roles[_role].teams | default(omit) }}"
         users: "{{ _item.roles[_role].users | default(omit) }}"
       {% endfor %}

--- a/roles/controller_workflow_job_templates/tasks/main.yml
+++ b/roles/controller_workflow_job_templates/tasks/main.yml
@@ -131,9 +131,7 @@
       - role: "{{ _role }}"
         workflows:
           - "{{ _item.new_name | default(_item.name) }}"
-        {% if _item.organization is defined %}
-        lookup_organization: "{{ _item.organization.name | default(_item.organization) }}"
-        {% endif %}
+        lookup_organization: {{ _item.organization.name | default(_item.organization) | default(omit) | to_json }}
         teams: {{ _item.roles[_role].teams | default(omit) }}
         users: {{ _item.roles[_role].users | default(omit) }}
       {% endfor %}


### PR DESCRIPTION
## Summary

- Follow-up fix for [#1382](https://github.com/redhat-cop/infra.aap_configuration/issues/1382) / [#1388](https://github.com/redhat-cop/infra.aap_configuration/pull/1388).
- Replaces Jinja `{% if %}` block tags inside the inline `_controller_roles` YAML template with a single-line `default(omit) | to_json` expression for `lookup_organization`.
- The block tags mis-indented generated YAML keys, causing `from_yaml` to fail when parsing inline role definitions (e.g. on inventories with `organization` and `roles` set).

## Test plan

- [ ] Apply inline roles on an inventory with `organization` and `roles` defined (same config that failed after #1388)
- [ ] Verify `Add roles to inventories` completes without `from_yaml` parse errors
- [ ] Verify credentials without an `organization` field still work (no `lookup_organization` emitted)


Made with [Cursor](https://cursor.com)