### PR TITLE
Fix markdownlint failure in dispatch README

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -36,7 +36,11 @@ jobs:
           allow-unsafe-pr-checkout: true
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.x"
+          python-version: |
+            3.11
+            3.12
+            3.13
+            3.14
       - name: Run default pre-commit hooks
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         env:

--- a/changelogs/fragments/fix-dispatch-readme-markdown.yml
+++ b/changelogs/fragments/fix-dispatch-readme-markdown.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix markdownlint MD040 failure in dispatch README by adding a language to the fenced code block.
+...

--- a/changelogs/fragments/fix-dispatch-readme-markdown.yml
+++ b/changelogs/fragments/fix-dispatch-readme-markdown.yml
@@ -1,3 +1,4 @@
 bugfixes:
   - Fix markdownlint MD040 failure in dispatch README by adding a language to the fenced code block.
+  - Install Python 3.11 through 3.14 in pre-commit CI so ansible-test sanity tox environments can find required interpreters.
 ...

--- a/roles/dispatch/README.md
+++ b/roles/dispatch/README.md
@@ -371,7 +371,7 @@ For more information about roles, see each roles' README (also linked in the top
 In case an external playbook needs to read and process the wildcard variables like the `dispatch` role does,
 the following task shows how to make the `aap_configuration_all_vars` list variable available in the playbook:
 
-```
+```yaml
     - name: Read list of known AAP CaC wildcard variables
       ansible.builtin.include_role:
         name: infra.aap_configuration.dispatch


### PR DESCRIPTION
## Summary

- Fix `MD040/fenced-code-language` in `roles/dispatch/README.md` by adding a `yaml` language tag to the example task block.
- Install Python 3.11 through 3.14 in the pre-commit workflow so ansible-test sanity tox environments can find required interpreters (fixes sanity stage failures like [run 31221284621](https://github.com/redhat-cop/infra.aap_configuration/actions/runs/31221284621/job/93006249566)).

## Root cause (sanity)

`actions/setup-python` v7 with `python-version: "3.x"` only provisions the latest interpreter on the runner (3.14). Sanity tox envs for `py3.11` and `py3.13` then fail immediately with:

`could not find python interpreter matching any of the specs py3.11` / `py3.13`

## Test plan

- [ ] Pre-commit workflow passes (markdownlint + sanity)
- [ ] `devel` CI is green after merge