### PR TITLE
Allow fork PR checkout in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,9 +28,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Use the PR merge ref so fork pull_request_target workflows can fetch PR
-          # code without allow-unsafe-pr-checkout (blocked by checkout v7+).
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Fork PRs need the head ref to lint PR changes. actions/checkout v7+ blocks
+          # this by default in pull_request_target workflows; opt in after review:
+          # https://gh.io/securely-using-pull_request_target
+          # Risk is gated by the requires-approval environment on approve_run.
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"

--- a/changelogs/fragments/fix-fork-pr-checkout.yml
+++ b/changelogs/fragments/fix-fork-pr-checkout.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Allow fork pull request checkout in pre-commit workflow via allow-unsafe-pr-checkout after maintainer approval gate.
+...


### PR DESCRIPTION
## Summary

- Revert the `refs/pull/<number>/merge` checkout workaround from #1406 (GitHub documents this ref as equally unsafe/blocked in `pull_request_target` workflows).
- Restore checkout of `github.event.pull_request.head.sha` and set `allow-unsafe-pr-checkout: true` on `actions/checkout` v7+, per [Securely using pull_request_target](https://gh.io/securely-using-pull_request_target).

This workflow intentionally runs checked-out PR code (pre-commit, ansible-lint, sanity) and needs `pull_request_target` plus secrets for certified Galaxy content. Fork PR CI is gated by the existing `requires-approval` environment on `approve_run` before the `pre-commit` job runs.

## Test plan

- [ ] Maintainer approves CI on a fork PR (e.g. #1404) and confirms checkout succeeds
- [ ] Pre-commit completes on the fork PR head ref
- [ ] `devel` push workflows still pass


Made with [Cursor](https://cursor.com)